### PR TITLE
fix: update README to match agent-skills format

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "awesome-apify-skills",
+  "version": "1.0.0",
+  "description": "Community collection of Apify agent skills for web scraping, data extraction, and automation",
+  "author": {
+    "name": "Apify",
+    "email": "support@apify.com"
+  },
+  "homepage": "https://github.com/apify/awesome-apify-skills",
+  "repository": "https://github.com/apify/awesome-apify-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "apify",
+    "scraping",
+    "automation",
+    "leads",
+    "data-extraction"
+  ]
+}

--- a/.github/workflows/generate-agents.yml
+++ b/.github/workflows/generate-agents.yml
@@ -1,0 +1,30 @@
+name: Check AGENTS.md and marketplace.json
+
+on:
+  pull_request:
+    paths:
+      - "scripts/AGENTS_TEMPLATE.md"
+      - "scripts/generate_agents.py"
+      - "**/SKILL.md"
+      - "agents/AGENTS.md"
+      - ".claude-plugin/marketplace.json"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Generate AGENTS.md and validate marketplace.json
+        run: uv run scripts/generate_agents.py
+
+      - name: Ensure AGENTS.md is up to date
+        run: |
+          git diff --quiet -- agents/AGENTS.md || {
+            echo "::error::agents/AGENTS.md is outdated. Run 'uv run scripts/generate_agents.py' and commit the changes."
+            exit 1
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
-node_modules/
 .env
-.env.*
-!.env.example
-*.log
 .DS_Store
+
+# DEVELOPMENT
+.vscode
+.claude
+context/
+CLAUDE.md
+PLAN.md
+PLAN-*.md
+.mcp.json
+scripts/hooks/
+.idea
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,85 +1,82 @@
 # Awesome Apify Skills
 
-Community collection of specialized [Apify](https://apify.com) agent skills for AI coding assistants like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Cursor](https://cursor.com).
+Community collection of Apify agent skills for web scraping, data extraction, and automation. Works with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants.
 
-Each skill provides domain-specific prompts and pre-configured Apify Actor workflows for common data extraction use cases.
+> For the official consolidated Apify plugins, see [apify/agent-skills](https://github.com/apify/agent-skills).
 
-> For the official consolidated Apify plugins, see [apify/marketplace](https://github.com/apify/marketplace).
+## Available skills
 
-## Skills
-
-| Skill | Description |
-|-------|-------------|
-| **apify-lead-generation** | Generate B2B/B2C leads from Google Maps, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search |
-| **apify-brand-reputation-monitoring** | Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, and social media |
-| **apify-competitor-intelligence** | Analyze competitor strategies, content, pricing, ads, and market positioning |
-| **apify-market-research** | Analyze market conditions, geographic opportunities, pricing, and consumer behavior |
-| **apify-influencer-discovery** | Find and evaluate influencers, verify authenticity, and track collaboration performance |
-| **apify-trend-analysis** | Discover and track emerging trends across Google Trends and social platforms |
-| **apify-content-analytics** | Track engagement metrics, measure campaign ROI, and analyze content performance |
-| **apify-audience-analysis** | Understand audience demographics, preferences, behavior patterns, and engagement quality |
-| **apify-ecommerce** | Scrape e-commerce data from Amazon, Walmart, eBay, IKEA, and 50+ marketplaces |
-
-## Prerequisites
-
-1. **Apify account** - Sign up at [apify.com](https://apify.com)
-2. **Apify API token** - Get yours at [console.apify.com/account/integrations](https://console.apify.com/account/integrations)
-3. **mcpc** - Install the Apify MCP connector:
-   ```bash
-   npm install -g @anthropic-ai/claude-code
-   npx @anthropic-ai/claude-code /install-marketplace https://github.com/anthropics/awesome-apify-skills
-   ```
-
-Set your API token:
-```bash
-export APIFY_TOKEN=your_token_here
-```
+<!-- BEGIN_SKILLS_TABLE -->
+| Name | Description | Documentation |
+|------|-------------|---------------|
+| `apify-audience-analysis` | Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok | [SKILL.md](skills/apify-audience-analysis/SKILL.md) |
+| `apify-brand-reputation-monitoring` | Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, Facebook, Instagram, YouTube, and TikTok | [SKILL.md](skills/apify-brand-reputation-monitoring/SKILL.md) |
+| `apify-competitor-intelligence` | Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok | [SKILL.md](skills/apify-competitor-intelligence/SKILL.md) |
+| `apify-content-analytics` | Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok | [SKILL.md](skills/apify-content-analytics/SKILL.md) |
+| `apify-ecommerce` | Scrape e-commerce data for pricing intelligence, customer sentiment, product research, quality analysis, and supply chain monitoring across Amazon, Walmart, eBay, IKEA, and 50+ marketplaces | [SKILL.md](skills/apify-ecommerce/SKILL.md) |
+| `apify-influencer-discovery` | Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok | [SKILL.md](skills/apify-influencer-discovery/SKILL.md) |
+| `apify-lead-generation` | Generate B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search using Apify Actors | [SKILL.md](skills/apify-lead-generation/SKILL.md) |
+| `apify-market-research` | Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor | [SKILL.md](skills/apify-market-research/SKILL.md) |
+| `apify-trend-analysis` | Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy | [SKILL.md](skills/apify-trend-analysis/SKILL.md) |
+<!-- END_SKILLS_TABLE -->
 
 ## Installation
 
 ### Claude Code
 
 ```bash
-claude /install-marketplace https://github.com/anthropics/awesome-apify-skills
+# Add the marketplace
+/plugin marketplace add apify/awesome-apify-skills
+
+# Install a skill
+/plugin install apify-lead-generation@awesome-apify-skills
 ```
 
-Then install individual skills:
+### Cursor / Windsurf
+
+Add to your project's `.cursor/settings.json` or use the same Claude Code plugin format.
+
+### Codex / Gemini CLI
+
+Point your agent to the `agents/AGENTS.md` file which contains skill descriptions and paths:
+
 ```bash
-claude /install apify-lead-generation
+# Gemini CLI uses gemini-extension.json automatically
+# For Codex, reference agents/AGENTS.md in your configuration
 ```
 
-### Cursor
+### Other AI tools
 
-Copy the desired skill directory from `skills/` into your project's `.cursor-plugin/skills/` directory.
+Any AI tool that supports Markdown context can use the skills by pointing to:
+- `agents/AGENTS.md` - auto-generated skill index
+- `skills/*/SKILL.md` - individual skill documentation
 
-## Structure
+## Prerequisites
 
-```
-skills/
-├── apify-lead-generation/
-│   ├── SKILL.md              # Skill instructions and Actor configurations
-│   └── reference/scripts/    # Helper scripts (run_actor.js, etc.)
-├── apify-brand-reputation-monitoring/
-├── apify-competitor-intelligence/
-├── apify-market-research/
-├── apify-influencer-discovery/
-├── apify-trend-analysis/
-├── apify-content-analytics/
-├── apify-audience-analysis/
-└── apify-ecommerce/
-```
+1. **Apify account** - [apify.com](https://apify.com)
+2. **API token** - get from [Apify Console](https://console.apify.com/account/integrations), add `APIFY_TOKEN=your_token` to `.env`
+3. **Node.js 20.6+**
+4. **[mcpc CLI](https://github.com/apify/mcp-cli)** - `npm install -g @apify/mcpc`
+
+## Pricing
+
+Apify Actors use pay-per-result pricing. Check individual Actor pricing on the [Apify platform](https://apify.com).
 
 ## Contributing
 
-Contributions are welcome! To add a new skill:
+1. Fork this repository.
+2. Create your skill in `skills/your-skill-name/`.
+3. Add `SKILL.md` with proper frontmatter:
+   ```yaml
+   ---
+   name: your-skill-name
+   description: What your skill does and when to use it
+   ---
+   ```
+4. Add entry to `.claude-plugin/marketplace.json`.
+5. Submit a pull request.
 
-1. Fork this repository
-2. Create a new skill directory under `skills/`
-3. Include a `SKILL.md` with Actor configurations and usage instructions
-4. Add helper scripts in `reference/scripts/`
-5. Update `marketplace.json` with the new skill entry
-6. Submit a pull request
+## Support
 
-## License
-
-ISC
+- [Apify Documentation](https://docs.apify.com)
+- [Apify Discord](https://discord.gg/jyEM2PRvMU)

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,0 +1,33 @@
+<skills>
+
+You have additional SKILLs documented in directories containing a "SKILL.md" file.
+
+These skills are:
+ - apify-audience-analysis -> "skills/apify-audience-analysis/SKILL.md"
+ - apify-brand-reputation-monitoring -> "skills/apify-brand-reputation-monitoring/SKILL.md"
+ - apify-competitor-intelligence -> "skills/apify-competitor-intelligence/SKILL.md"
+ - apify-content-analytics -> "skills/apify-content-analytics/SKILL.md"
+ - apify-ecommerce -> "skills/apify-ecommerce/SKILL.md"
+ - apify-influencer-discovery -> "skills/apify-influencer-discovery/SKILL.md"
+ - apify-lead-generation -> "skills/apify-lead-generation/SKILL.md"
+ - apify-market-research -> "skills/apify-market-research/SKILL.md"
+ - apify-trend-analysis -> "skills/apify-trend-analysis/SKILL.md"
+
+IMPORTANT: You MUST read the SKILL.md file whenever the description of the skills matches the user intent, or may help accomplish their task.
+
+<available_skills>
+
+apify-audience-analysis: `Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.`
+apify-brand-reputation-monitoring: `Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, Facebook, Instagram, YouTube, and TikTok. Use when user asks to monitor brand reputation, analyze reviews, track mentions, or gather customer feedback.`
+apify-competitor-intelligence: `Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.`
+apify-content-analytics: `Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.`
+apify-ecommerce: `Scrape e-commerce data for pricing intelligence, customer reviews, and seller discovery across Amazon, Walmart, eBay, IKEA, and 50+ marketplaces. Use when user asks to monitor prices, track competitors, analyze reviews, research products, or find sellers.`
+apify-influencer-discovery: `Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.`
+apify-lead-generation: `Generates B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search. Use when user asks to find leads, prospects, businesses, build lead lists, enrich contacts, or scrape profiles for sales outreach.`
+apify-market-research: `Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.`
+apify-trend-analysis: `Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.`
+</available_skills>
+
+Paths referenced within SKILL.md files are relative to that SKILL folder. For example `reference/workflows.md` refers to the workflows file inside the skill's reference folder.
+
+</skills>

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "awesome-apify-skills",
+  "description": "Provides access to Apify community skills for web scraping, data extraction, and automation.",
+  "version": "1.0.0",
+  "contextFileName": "agents/AGENTS.md"
+}

--- a/scripts/AGENTS_TEMPLATE.md
+++ b/scripts/AGENTS_TEMPLATE.md
@@ -1,0 +1,22 @@
+<skills>
+
+You have additional SKILLs documented in directories containing a "SKILL.md" file.
+
+These skills are:
+{{#skills}}
+ - {{name}} -> "{{path}}/SKILL.md"
+{{/skills}}
+
+IMPORTANT: You MUST read the SKILL.md file whenever the description of the skills matches the user intent, or may help accomplish their task.
+
+<available_skills>
+
+{{#skills}}
+{{name}}: `{{description}}`
+
+{{/skills}}
+</available_skills>
+
+Paths referenced within SKILL.md files are relative to that SKILL folder. For example `reference/workflows.md` refers to the workflows file inside the skill's reference folder.
+
+</skills>

--- a/scripts/generate_agents.py
+++ b/scripts/generate_agents.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Generate AGENTS.md from AGENTS_TEMPLATE.md and SKILL.md frontmatter.
+
+Also validates that marketplace.json is in sync with discovered skills,
+updates the skills table in README.md, and handles version bumping.
+
+Version bumping (conventional commits):
+  - BREAKING CHANGE: or feat!: → major bump (1.0.0 → 2.0.0)
+  - feat: → minor bump (1.0.0 → 1.1.0)
+  - fix:, docs:, chore:, etc. → patch bump (1.0.0 → 1.0.1)
+
+Usage:
+  uv run scripts/generate_agents.py                    # Just regenerate
+  uv run scripts/generate_agents.py --bump "feat: X"   # Bump based on commit msg
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_PATH = ROOT / "scripts" / "AGENTS_TEMPLATE.md"
+OUTPUT_PATH = ROOT / "agents" / "AGENTS.md"
+MARKETPLACE_PATH = ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_PATH = ROOT / ".claude-plugin" / "plugin.json"
+README_PATH = ROOT / "README.md"
+SKILLS_DIR = ROOT / "skills"
+
+# Markers for the auto-generated skills table in README
+README_TABLE_START = "<!-- BEGIN_SKILLS_TABLE -->"
+README_TABLE_END = "<!-- END_SKILLS_TABLE -->"
+
+
+def load_template() -> str:
+    return TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Parse a minimal YAML-ish frontmatter block without external deps."""
+    match = re.search(r"^---\s*\n(.*?)\n---\s*", text, re.DOTALL)
+    if not match:
+        return {}
+    data: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def collect_skills() -> list[dict[str, str]]:
+    skills: list[dict[str, str]] = []
+    for skill_md in ROOT.glob("skills/*/SKILL.md"):
+        meta = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        name = meta.get("name")
+        description = meta.get("description")
+        if not name or not description:
+            continue
+        skills.append(
+            {
+                "name": name,
+                "description": description,
+                "path": str(skill_md.parent.relative_to(ROOT)),
+            }
+        )
+    # Keep deterministic order for consistent output
+    return sorted(skills, key=lambda s: s["name"].lower())
+
+
+def render(template: str, skills: list[dict[str, str]]) -> str:
+    """Very small Mustache-like renderer that only supports a single skills loop."""
+    def repl(match: re.Match[str]) -> str:
+        block = match.group(1).strip("\n")
+        rendered_blocks = []
+        for skill in skills:
+            rendered = (
+                block.replace("{{name}}", skill["name"])
+                .replace("{{description}}", skill["description"])
+                .replace("{{path}}", skill["path"])
+            )
+            rendered_blocks.append(rendered)
+        return "\n".join(rendered_blocks)
+
+    # Render loop blocks
+    content = re.sub(r"{{#skills}}(.*?){{/skills}}", repl, template, flags=re.DOTALL)
+    return content
+
+
+def load_marketplace() -> dict:
+    """Load marketplace.json and return parsed structure."""
+    if not MARKETPLACE_PATH.exists():
+        raise FileNotFoundError(f"marketplace.json not found at {MARKETPLACE_PATH}")
+    return json.loads(MARKETPLACE_PATH.read_text(encoding="utf-8"))
+
+
+def generate_readme_table(skills: list[dict[str, str]]) -> str:
+    """Generate the skills table for README.md using marketplace.json names."""
+    marketplace = load_marketplace()
+    plugins = {p["source"]: p for p in marketplace.get("plugins", [])}
+
+    lines = [
+        "| Name | Description | Documentation |",
+        "|------|-------------|---------------|",
+    ]
+
+    for skill in skills:
+        source = f"./{skill['path']}"
+        plugin = plugins.get(source, {})
+        name = plugin.get("name", skill["name"])
+        description = plugin.get("description", skill["description"])
+        doc_link = f"[SKILL.md]({skill['path']}/SKILL.md)"
+        lines.append(f"| `{name}` | {description} | {doc_link} |")
+
+    return "\n".join(lines)
+
+
+def update_readme(skills: list[dict[str, str]]) -> bool:
+    """
+    Update the README.md skills table between markers.
+    Returns True if the file was updated, False if markers not found.
+    """
+    if not README_PATH.exists():
+        print(f"Warning: README.md not found at {README_PATH}", file=sys.stderr)
+        return False
+
+    content = README_PATH.read_text(encoding="utf-8")
+
+    start_idx = content.find(README_TABLE_START)
+    end_idx = content.find(README_TABLE_END)
+
+    if start_idx == -1 or end_idx == -1:
+        print(
+            f"Warning: README.md markers not found. Add {README_TABLE_START} and "
+            f"{README_TABLE_END} to enable table generation.",
+            file=sys.stderr,
+        )
+        return False
+
+    if end_idx < start_idx:
+        print("Warning: README.md markers are in wrong order.", file=sys.stderr)
+        return False
+
+    table = generate_readme_table(skills)
+    new_content = (
+        content[: start_idx + len(README_TABLE_START)]
+        + "\n"
+        + table
+        + "\n"
+        + content[end_idx:]
+    )
+
+    README_PATH.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def validate_marketplace(skills: list[dict[str, str]]) -> list[str]:
+    """
+    Validate marketplace.json against discovered skills.
+    Returns list of error messages (empty = passed).
+    """
+    errors: list[str] = []
+    marketplace = load_marketplace()
+    plugins = marketplace.get("plugins", [])
+
+    # Build lookups (normalize paths: skill uses "skills/x", marketplace uses "./skills/x")
+    skill_by_source = {f"./{s['path']}": s for s in skills}
+    plugin_by_source = {p["source"]: p for p in plugins}
+
+    # Check: every skill has a marketplace entry with matching name
+    for skill in skills:
+        expected_source = f"./{skill['path']}"
+        if expected_source not in plugin_by_source:
+            errors.append(
+                f"Skill '{skill['name']}' at '{skill['path']}' is missing from marketplace.json"
+            )
+        elif plugin_by_source[expected_source]["name"] != skill["name"]:
+            errors.append(
+                f"Name mismatch at '{expected_source}': "
+                f"SKILL.md='{skill['name']}', marketplace.json='{plugin_by_source[expected_source]['name']}'"
+            )
+
+    # Check: every marketplace plugin with skills has a corresponding skill
+    for plugin in plugins:
+        # Skip plugins that don't have skills (e.g., commands-only plugins)
+        if "skills" not in plugin:
+            continue
+        if plugin["source"] not in skill_by_source:
+            errors.append(
+                f"Marketplace plugin '{plugin['name']}' at '{plugin['source']}' has no SKILL.md"
+            )
+
+    return errors
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Parse semver string to tuple."""
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)", version)
+    if not match:
+        return (1, 0, 0)
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    """Format version tuple to string."""
+    return f"{version[0]}.{version[1]}.{version[2]}"
+
+
+def get_bump_type(commit_msg: str) -> str:
+    """
+    Determine version bump type from conventional commit message.
+    Returns: 'major', 'minor', 'patch', or 'none'
+    """
+    msg_lower = commit_msg.lower()
+
+    # Major: BREAKING CHANGE or ! after type
+    if "breaking change" in msg_lower or re.match(r"^\w+!:", commit_msg):
+        return "major"
+
+    # Minor: feat
+    if re.match(r"^feat(\(.+\))?:", commit_msg, re.IGNORECASE):
+        return "minor"
+
+    # Patch: fix, docs, chore, refactor, style, test, perf, ci, build
+    patch_types = ["fix", "docs", "chore", "refactor", "style", "test", "perf", "ci", "build"]
+    for t in patch_types:
+        if re.match(rf"^{t}(\(.+\))?:", commit_msg, re.IGNORECASE):
+            return "patch"
+
+    return "none"
+
+
+def bump_version(version: str, bump_type: str) -> str:
+    """Bump version based on type."""
+    major, minor, patch = parse_version(version)
+
+    if bump_type == "major":
+        return format_version((major + 1, 0, 0))
+    elif bump_type == "minor":
+        return format_version((major, minor + 1, 0))
+    elif bump_type == "patch":
+        return format_version((major, minor, patch + 1))
+    return version
+
+
+def update_user_agent_in_skill(skill_name: str, new_version: str) -> bool:
+    """
+    Update USER_AGENT version in skill's run_actor.py script.
+    Returns True if updated, False otherwise.
+    """
+    script_path = SKILLS_DIR / skill_name / "reference" / "scripts" / "run_actor.py"
+    if not script_path.exists():
+        return False
+
+    content = script_path.read_text(encoding="utf-8")
+
+    # Pattern: USER_AGENT = "apify-agent-skills/skill-name-X.Y.Z"
+    pattern = rf'(USER_AGENT\s*=\s*"apify-agent-skills/{re.escape(skill_name)}-)\d+\.\d+\.\d+"'
+    replacement = rf'\g<1>{new_version}"'
+
+    new_content, count = re.subn(pattern, replacement, content)
+
+    if count > 0:
+        script_path.write_text(new_content, encoding="utf-8")
+        print(f"Updated USER_AGENT in {script_path.relative_to(ROOT)}: {new_version}")
+        return True
+
+    return False
+
+
+def get_changed_skills() -> set[str]:
+    """Get list of skill names that have staged changes."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        changed_files = result.stdout.strip().split("\n") if result.stdout.strip() else []
+    except Exception:
+        return set()
+
+    changed_skills = set()
+    for f in changed_files:
+        # Match skills/skill-name/... pattern
+        match = re.match(r"skills/([^/]+)/", f)
+        if match:
+            changed_skills.add(match.group(1))
+
+    return changed_skills
+
+
+def update_versions(commit_msg: str) -> bool:
+    """
+    Update versions based on commit message and changed files.
+    Returns True if any version was bumped.
+    """
+    bump_type = get_bump_type(commit_msg)
+    if bump_type == "none":
+        print(f"No version bump needed for commit: {commit_msg[:50]}...")
+        return False
+
+    changed_skills = get_changed_skills()
+    bumped = False
+
+    # Load marketplace.json
+    marketplace = load_marketplace()
+
+    # Bump individual skill versions if they changed
+    for plugin in marketplace.get("plugins", []):
+        skill_name = plugin["source"].replace("./skills/", "")
+        if skill_name in changed_skills:
+            old_version = plugin.get("version", "1.0.0")
+            new_version = bump_version(old_version, bump_type)
+            if old_version != new_version:
+                plugin["version"] = new_version
+                print(f"Bumped {skill_name}: {old_version} → {new_version} ({bump_type})")
+                bumped = True
+                # Also update USER_AGENT in skill's run_actor.py
+                update_user_agent_in_skill(skill_name, new_version)
+
+    # Bump marketplace version if any skill changed
+    if changed_skills or bumped:
+        old_version = marketplace.get("metadata", {}).get("version", "1.0.0")
+        new_version = bump_version(old_version, bump_type)
+        if old_version != new_version:
+            if "metadata" not in marketplace:
+                marketplace["metadata"] = {}
+            marketplace["metadata"]["version"] = new_version
+            print(f"Bumped marketplace: {old_version} → {new_version} ({bump_type})")
+            bumped = True
+
+    # Save marketplace.json
+    if bumped:
+        MARKETPLACE_PATH.write_text(
+            json.dumps(marketplace, indent=2) + "\n",
+            encoding="utf-8"
+        )
+
+    # Also bump plugin.json version
+    if bumped and PLUGIN_PATH.exists():
+        plugin_data = json.loads(PLUGIN_PATH.read_text(encoding="utf-8"))
+        old_version = plugin_data.get("version", "1.0.0")
+        new_version = bump_version(old_version, bump_type)
+        if old_version != new_version:
+            plugin_data["version"] = new_version
+            PLUGIN_PATH.write_text(
+                json.dumps(plugin_data, indent=2) + "\n",
+                encoding="utf-8"
+            )
+            print(f"Bumped plugin.json: {old_version} → {new_version}")
+
+    return bumped
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate AGENTS.md and manage versions")
+    parser.add_argument(
+        "--bump",
+        metavar="COMMIT_MSG",
+        help="Bump versions based on conventional commit message"
+    )
+    args = parser.parse_args()
+
+    # Handle version bumping if requested
+    if args.bump:
+        update_versions(args.bump)
+
+    template = load_template()
+    skills = collect_skills()
+    output = render(template, skills)
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(output, encoding="utf-8")
+    print(f"Wrote {OUTPUT_PATH} with {len(skills)} skills.")
+
+    # Validate marketplace.json
+    errors = validate_marketplace(skills)
+    if errors:
+        print("\nMarketplace.json validation errors:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        sys.exit(1)
+    print("Marketplace.json validation passed.")
+
+    # Update README.md skills table
+    if update_readme(skills):
+        print(f"Updated {README_PATH} skills table.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Rewrite README to match the official agent-skills repo format
- Fix installation commands to use correct `/plugin marketplace add` and `/plugin install` syntax
- Remove output formats section
- Remove incorrect npx/claude CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)