### PR TITLE
Remove mcpc dependency from all 8 marketing skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
         "youtube"
       ],
       "category": "data-extraction",
-      "version": "1.1.12"
+      "version": "1.1.13"
     },
     {
       "name": "apify-brand-reputation-monitoring",
@@ -53,7 +53,7 @@
         "tiktok"
       ],
       "category": "data-extraction",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "apify-competitor-intelligence",
@@ -75,7 +75,7 @@
         "tiktok"
       ],
       "category": "data-extraction",
-      "version": "1.1.2"
+      "version": "1.1.3"
     },
     {
       "name": "apify-market-research",
@@ -97,7 +97,7 @@
         "tripadvisor"
       ],
       "category": "data-extraction",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "apify-influencer-discovery",
@@ -117,7 +117,7 @@
         "tiktok"
       ],
       "category": "data-extraction",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "apify-trend-analysis",
@@ -138,7 +138,7 @@
         "tiktok"
       ],
       "category": "data-extraction",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "apify-content-analytics",
@@ -158,7 +158,7 @@
         "tiktok"
       ],
       "category": "data-extraction",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "apify-audience-analysis",
@@ -178,7 +178,7 @@
         "tiktok"
       ],
       "category": "data-extraction",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "apify-ecommerce",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Any AI tool that supports Markdown context can use the skills by pointing to:
 1. **Apify account** - [apify.com](https://apify.com)
 2. **API token** - get from [Apify Console](https://console.apify.com/account/integrations), add `APIFY_TOKEN=your_token` to `.env`
 3. **Node.js 20.6+**
-4. **[mcpc CLI](https://github.com/apify/mcp-cli)** - `npm install -g @apify/mcpc`
 
 ## Pricing
 

--- a/skills/apify-audience-analysis/SKILL.md
+++ b/skills/apify-audience-analysis/SKILL.md
@@ -12,7 +12,6 @@ Analyze and understand your audience using Apify Actors to extract follower demo
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Identify audience analysis type (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the analysis script
 - [ ] Step 5: Summarize findings
@@ -54,27 +53,31 @@ Select the appropriate Actor based on analysis needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `apify/facebook-followers-following-scraper`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -115,7 +118,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-audience-analysis/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-audience-analysis/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-audience-analysis-1.0.2';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-audience-analysis/reference/scripts/run_actor.js
+++ b/skills/apify-audience-analysis/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-audience-analysis-1.0.1';
+const USER_AGENT = 'apify-agent-skills/apify-audience-analysis-1.0.2';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-brand-reputation-monitoring/SKILL.md
+++ b/skills/apify-brand-reputation-monitoring/SKILL.md
@@ -12,7 +12,6 @@ Scrape reviews, ratings, and brand mentions from multiple platforms using Apify 
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Determine data source (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the monitoring script
 - [ ] Step 5: Summarize results
@@ -54,27 +53,31 @@ Select the appropriate Actor based on user needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `compass/crawler-google-places`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -115,7 +118,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-brand-reputation-monitoring/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-brand-reputation-monitoring/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-brand-reputation-monitoring-1.0.3';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-brand-reputation-monitoring/reference/scripts/run_actor.js
+++ b/skills/apify-brand-reputation-monitoring/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-brand-reputation-monitoring-1.1.1';
+const USER_AGENT = 'apify-agent-skills/apify-brand-reputation-monitoring-1.0.3';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-competitor-intelligence/SKILL.md
+++ b/skills/apify-competitor-intelligence/SKILL.md
@@ -12,7 +12,6 @@ Analyze competitors using Apify Actors to extract data from multiple platforms.
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Identify competitor analysis type (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the analysis script
 - [ ] Step 5: Summarize findings
@@ -64,27 +63,31 @@ Select the appropriate Actor based on analysis needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `compass/crawler-google-places`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -125,7 +128,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-competitor-intelligence/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-competitor-intelligence/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-competitor-intelligence-1.1.3';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-competitor-intelligence/reference/scripts/run_actor.js
+++ b/skills/apify-competitor-intelligence/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-competitor-intelligence-1.0.1';
+const USER_AGENT = 'apify-agent-skills/apify-competitor-intelligence-1.1.3';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-content-analytics/SKILL.md
+++ b/skills/apify-content-analytics/SKILL.md
@@ -12,7 +12,6 @@ Track and analyze content performance using Apify Actors to extract engagement m
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Identify content analytics type (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the analytics script
 - [ ] Step 5: Summarize findings
@@ -53,27 +52,31 @@ Select the appropriate Actor based on analytics needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `apify/instagram-post-scraper`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -114,7 +117,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-content-analytics/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-content-analytics/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-content-analytics-1.0.2';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-content-analytics/reference/scripts/run_actor.js
+++ b/skills/apify-content-analytics/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-content-analytics-1.0.0';
+const USER_AGENT = 'apify-agent-skills/apify-content-analytics-1.0.2';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-influencer-discovery/SKILL.md
+++ b/skills/apify-influencer-discovery/SKILL.md
@@ -12,7 +12,6 @@ Discover and analyze influencers across multiple platforms using Apify Actors.
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Determine discovery source (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the discovery script
 - [ ] Step 5: Summarize results
@@ -51,27 +50,31 @@ Select the appropriate Actor based on user needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `apify/instagram-profile-scraper`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -112,7 +115,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-influencer-discovery/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-influencer-discovery/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-influencer-discovery-1.0.2';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-influencer-discovery/reference/scripts/run_actor.js
+++ b/skills/apify-influencer-discovery/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-influencer-discovery-1.0.0';
+const USER_AGENT = 'apify-agent-skills/apify-influencer-discovery-1.0.2';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-lead-generation/SKILL.md
+++ b/skills/apify-lead-generation/SKILL.md
@@ -12,7 +12,6 @@ Scrape leads from multiple platforms using Apify Actors.
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Determine lead source (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the lead finder script
 - [ ] Step 5: Summarize results
@@ -53,27 +52,31 @@ Select the appropriate Actor based on user needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `compass/crawler-google-places`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -114,7 +117,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-lead-generation/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-lead-generation/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-lead-generation-1.1.13';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-lead-generation/reference/scripts/run_actor.js
+++ b/skills/apify-lead-generation/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-lead-generation-1.1.11';
+const USER_AGENT = 'apify-agent-skills/apify-lead-generation-1.1.13';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-market-research/SKILL.md
+++ b/skills/apify-market-research/SKILL.md
@@ -12,7 +12,6 @@ Conduct market research using Apify Actors to extract data from multiple platfor
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Identify market research type (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the analysis script
 - [ ] Step 5: Summarize findings
@@ -52,27 +51,31 @@ Select the appropriate Actor based on research needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `compass/crawler-google-places`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -113,7 +116,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-market-research/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-market-research/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-market-research-1.0.3';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-market-research/reference/scripts/run_actor.js
+++ b/skills/apify-market-research/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-market-research-1.0.0';
+const USER_AGENT = 'apify-agent-skills/apify-market-research-1.0.3';
 
 // Parse command-line arguments
 function parseCliArgs() {

--- a/skills/apify-trend-analysis/SKILL.md
+++ b/skills/apify-trend-analysis/SKILL.md
@@ -12,7 +12,6 @@ Discover and track emerging trends using Apify Actors to extract data from multi
 
 - `.env` file with `APIFY_TOKEN`
 - Node.js 20.6+ (for native `--env-file` support)
-- `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
 
@@ -21,7 +20,7 @@ Copy this checklist and track progress:
 ```
 Task Progress:
 - [ ] Step 1: Identify trend type (select Actor)
-- [ ] Step 2: Fetch Actor schema via mcpc
+- [ ] Step 2: Fetch Actor schema
 - [ ] Step 3: Ask user preferences (format, filename)
 - [ ] Step 4: Run the analysis script
 - [ ] Step 5: Summarize findings
@@ -55,27 +54,31 @@ Select the appropriate Actor based on research needs:
 
 ### Step 2: Fetch Actor Schema
 
-Fetch the Actor's input schema and details dynamically using mcpc:
+Fetch the Actor's input schema and details:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/fetch_actor_details.js --actor "ACTOR_ID"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `apify/google-trends-scraper`).
 
 This returns:
-- Actor description and README
-- Required and optional input parameters
-- Output fields (if available)
+- Actor info (title, description, URL, categories, stats, rating)
+- README summary
+- Input schema (required and optional parameters)
 
 ### Step 3: Ask User Preferences
 
-Before running, ask:
+**Skip this step** for simple lookups (e.g., "what's Nike's follower count?", "find me 5 coffee shops in Prague") — just use quick answer mode and move to Step 4.
+
+For larger scraping tasks, ask:
 1. **Output format**:
    - **Quick answer** - Display top few results in chat (no file saved)
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+
+**Cost safety**: Always set a sensible result limit in the Actor input (e.g., `maxResults`, `resultsLimit`, `maxCrawledPages`, or equivalent field from the input schema). Default to 100 results unless the user explicitly asks for more. Warn the user before running large scrapes (1000+ results) as they consume more Apify credits.
 
 ### Step 4: Run the Script
 
@@ -116,7 +119,6 @@ After completion, report:
 ## Error Handling
 
 `APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
-`mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output
 `Timeout` - Reduce input size or increase `--timeout`

--- a/skills/apify-trend-analysis/reference/scripts/fetch_actor_details.js
+++ b/skills/apify-trend-analysis/reference/scripts/fetch_actor_details.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Fetch Apify Actor details: README, input schema, and description.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch_actor_details.js --actor "apify/instagram-profile-scraper"
+ */
+
+import { parseArgs } from 'node:util';
+
+const USER_AGENT = 'apify-agent-skills/apify-trend-analysis-1.0.2';
+
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        console.log(`
+Fetch Apify Actor details (README, input schema, description)
+
+Usage:
+  node --env-file=.env scripts/fetch_actor_details.js --actor "ACTOR_ID"
+
+Options:
+  --actor, -a    Actor ID (e.g., apify/instagram-profile-scraper) [required]
+  --help, -h     Show this help message
+`);
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        process.exit(1);
+    }
+
+    return { actor: values.actor };
+}
+
+async function fetchActorInfo(token, actorId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_actor_info` },
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to fetch actor info (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    return (await response.json()).data;
+}
+
+async function fetchBuildDetails(token, actorId, buildId) {
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/builds/${buildId}?token=${encodeURIComponent(token)}`;
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/fetch_build` },
+    });
+
+    if (!response.ok) {
+        return null;
+    }
+
+    return (await response.json()).data;
+}
+
+async function main() {
+    const args = parseCliArgs();
+
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Add your token to .env: APIFY_TOKEN=your_token_here');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Step 1: Get actor info (includes readmeSummary, taggedBuilds)
+    const actorInfo = await fetchActorInfo(token, args.actor);
+
+    // Step 2: Get build details for input schema
+    const buildId = actorInfo.taggedBuilds?.latest?.buildId;
+    let inputSchema = null;
+
+    if (buildId) {
+        const build = await fetchBuildDetails(token, args.actor, buildId);
+        if (build) {
+            const schemaRaw = build.inputSchema;
+            if (schemaRaw) {
+                inputSchema = typeof schemaRaw === 'string' ? JSON.parse(schemaRaw) : schemaRaw;
+            }
+        }
+    }
+
+    // Compose output (matching mcpc fetch-actor-details structure)
+    const stats = actorInfo.stats || {};
+    const output = {
+        actorId: args.actor,
+        title: actorInfo.title || null,
+        url: `https://apify.com/${args.actor}`,
+        description: actorInfo.description || null,
+        categories: actorInfo.categories || [],
+        isDeprecated: actorInfo.isDeprecated || false,
+        stats: {
+            totalUsers: stats.totalUsers || 0,
+            monthlyUsers: stats.totalUsers30Days || 0,
+            bookmarks: stats.bookmarkCount || 0,
+        },
+        rating: {
+            average: stats.actorReviewRating || null,
+            count: stats.actorReviewCount || 0,
+        },
+        readmeSummary: actorInfo.readmeSummary || null,
+        inputSchema: inputSchema || null,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});

--- a/skills/apify-trend-analysis/reference/scripts/run_actor.js
+++ b/skills/apify-trend-analysis/reference/scripts/run_actor.js
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, statSync } from 'node:fs';
 
 // User-Agent for tracking skill usage in Apify analytics
-const USER_AGENT = 'apify-agent-skills/apify-trend-analysis-1.0.0';
+const USER_AGENT = 'apify-agent-skills/apify-trend-analysis-1.0.2';
 
 // Parse command-line arguments
 function parseCliArgs() {


### PR DESCRIPTION
## Summary
- Replace `mcpc` CLI calls with zero-dependency `fetch_actor_details.js` scripts that call the Apify REST API directly (`/v2/acts/` and `/v2/acts/builds/`)
- Remove `mcpc` from prerequisites in all 8 SKILL.md files and repo README
- Add skip-for-simple-lookups guidance and cost safety defaults to Step 3
- Bump skill versions in `marketplace.json` and USER_AGENT strings

## Affected skills (8)
| Skill | Version |
|-------|---------|
| apify-lead-generation | 1.1.12 → 1.1.13 |
| apify-brand-reputation-monitoring | 1.0.2 → 1.0.3 |
| apify-competitor-intelligence | 1.1.2 → 1.1.3 |
| apify-market-research | 1.0.2 → 1.0.3 |
| apify-influencer-discovery | 1.0.1 → 1.0.2 |
| apify-trend-analysis | 1.0.1 → 1.0.2 |
| apify-content-analytics | 1.0.1 → 1.0.2 |
| apify-audience-analysis | 1.0.1 → 1.0.2 |

`apify-ecommerce` is unchanged (it didn't use mcpc).

## Test plan
- [ ] Verify no `mcpc` references remain in SKILL.md files (`grep -r mcpc skills/*/SKILL.md`)
- [ ] Run `fetch_actor_details.js` from one skill to confirm it works
- [ ] Spot-check 2-3 SKILL.md files for correct formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)