### PR TITLE
Add Skills宝 discovery entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -202,6 +202,25 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "skillsbao-registry",
+      "source": "./skills/skillsbao-registry",
+      "skills": "./",
+      "description": "Search and install AI skills in Chinese across Claude Code, OpenCode, Cursor, and other agent tools",
+      "keywords": [
+        "skills",
+        "registry",
+        "discovery",
+        "search",
+        "install",
+        "claude-code",
+        "open-code",
+        "cursor",
+        "agents"
+      ],
+      "category": "discovery",
+      "version": "1.0.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Community collection of Apify agent skills for web scraping, data extraction, an
 | `apify-lead-generation` | Generate B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search using Apify Actors | [SKILL.md](skills/apify-lead-generation/SKILL.md) |
 | `apify-market-research` | Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor | [SKILL.md](skills/apify-market-research/SKILL.md) |
 | `apify-trend-analysis` | Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy | [SKILL.md](skills/apify-trend-analysis/SKILL.md) |
+| `skillsbao-registry` | Search and install AI skills in Chinese across Claude Code, OpenCode, Cursor, and other agent tools | [SKILL.md](skills/skillsbao-registry/SKILL.md) |
 <!-- END_SKILLS_TABLE -->
 
 ## Installation


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a Chinese search and installation directory for AI skills.

This adds a new skills table row and matching marketplace metadata entry so the repository stays internally consistent.