### PR TITLE
refactor!: drop apify-CLI enforcement, adopt npx skills installer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Maintainer-owned files — require review from maintainers.
+# Contributors adding skills should only touch their own skills/apify-<name>/
+# directory and .claude-plugin/marketplace.json.
+
+# Generator scripts and template
+/scripts/                          @apify/awesome-skills-maintainers
+/skills/_template/                 @apify/awesome-skills-maintainers
+
+# Plugin identity
+/.claude-plugin/plugin.json        @apify/awesome-skills-maintainers
+
+# Documentation (regenerated for agents/AGENTS.md)
+/CONTRIBUTING.md                   @apify/awesome-skills-maintainers
+/README.md                         @apify/awesome-skills-maintainers
+/agents/AGENTS.md                  @apify/awesome-skills-maintainers
+
+# CI and repo infrastructure
+/.github/                          @apify/awesome-skills-maintainers
+/test/                             @apify/awesome-skills-maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Skill
+
+- **Name:** `apify-...`
+- **What it does:** (one sentence — see also the `description` in your SKILL.md frontmatter)
+- **Author:** (your name or handle)
+
+## Checklist
+
+- [ ] PR adds **one** skill in `skills/apify-<name>/` (no other file changes except `.claude-plugin/marketplace.json`)
+- [ ] `SKILL.md` frontmatter has `name` (matches folder, `apify-` prefix) and `description` (≤ 1024 chars)
+- [ ] Added entry to `.claude-plugin/marketplace.json`
+- [ ] Tested the skill end-to-end at least once
+
+## Notes
+
+<!-- Optional: design decisions, links to similar skills, anything reviewers should know -->

--- a/.github/workflows/generate-agents.yml
+++ b/.github/workflows/generate-agents.yml
@@ -1,30 +1,152 @@
-name: Check AGENTS.md and marketplace.json
+name: Validate skill PRs and regenerate AGENTS.md
 
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened]
     paths:
-      - "scripts/AGENTS_TEMPLATE.md"
-      - "scripts/generate_agents.py"
-      - "**/SKILL.md"
-      - "agents/AGENTS.md"
-      - ".claude-plugin/marketplace.json"
+      - "scripts/**"
+      - "skills/**"
+      - "agents/**"
+      - ".claude-plugin/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - ".github/**"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - "skills/**"
+      - ".claude-plugin/**"
 
 jobs:
-  validate:
+  validate-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Generate AGENTS.md and validate marketplace.json
+      - name: Detect maintainer override
+        id: override
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
+        run: |
+          if echo "$LABELS_JSON" | grep -q '"name": *"maintainer"'; then
+            echo "maintainer=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR has 'maintainer' label — file/scope checks will only warn."
+          else
+            echo "maintainer=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check PR scope (one skill per PR, no out-of-bounds files)
+        env:
+          IS_MAINTAINER: ${{ steps.override.outputs.maintainer }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          CHANGED=$(git diff --name-only --diff-filter=ACMRT "origin/$BASE_REF...HEAD")
+          if [ -z "$CHANGED" ]; then
+            echo "No file changes detected."
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED" | sed 's/^/  - /'
+          echo
+
+          SKILL_DIRS=$(echo "$CHANGED" | grep -oE '^skills/apify-[^/]+' | sort -u)
+          N_SKILLS=$(echo "$SKILL_DIRS" | grep -c . || true)
+
+          ALLOWED='^(skills/apify-[^/]+/|\.claude-plugin/marketplace\.json$)'
+          OUT_OF_BOUNDS=$(echo "$CHANGED" | grep -vE "$ALLOWED" || true)
+
+          FAIL=0
+
+          if [ "$N_SKILLS" -gt 1 ]; then
+            echo "::error::PR touches $N_SKILLS skills; one skill per PR."
+            echo "$SKILL_DIRS" | sed 's/^/  - /'
+            FAIL=1
+          fi
+
+          if [ -n "$OUT_OF_BOUNDS" ]; then
+            echo "::error::PR touches files outside 'skills/apify-<name>/' and '.claude-plugin/marketplace.json':"
+            echo "$OUT_OF_BOUNDS" | sed 's/^/  - /'
+            FAIL=1
+          fi
+
+          if [ "$FAIL" -eq 1 ]; then
+            if [ "$IS_MAINTAINER" = "true" ]; then
+              echo "::notice::Scope violations present, but 'maintainer' label is set — continuing."
+            else
+              echo
+              echo "To override, a maintainer can add the 'maintainer' label to this PR."
+              exit 1
+            fi
+          fi
+
+      - name: Check PR checklist
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          IS_MAINTAINER: ${{ steps.override.outputs.maintainer }}
+        run: |
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR description is empty — please fill in the template."
+            exit 1
+          fi
+
+          UNCHECKED=$(echo "$PR_BODY" | grep -nE '^- \[ \]' || true)
+          if [ -n "$UNCHECKED" ]; then
+            if [ "$IS_MAINTAINER" = "true" ]; then
+              echo "::notice::Unchecked boxes in PR description, but 'maintainer' label is set — continuing."
+            else
+              echo "::error::PR checklist has unchecked boxes — please complete them:"
+              echo "$UNCHECKED" | sed 's/^/  /'
+              exit 1
+            fi
+          fi
+
+      - name: Validate skills and marketplace sync
         run: uv run scripts/generate_agents.py
 
-      - name: Ensure AGENTS.md is up to date
+      - name: Detect manual edits to generated files
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git diff --quiet -- agents/AGENTS.md || {
-            echo "::error::agents/AGENTS.md is outdated. Run 'uv run scripts/generate_agents.py' and commit the changes."
-            exit 1
-          }
+          GENERATED='agents/AGENTS.md README.md'
+          if git diff --name-only "origin/$BASE_REF...HEAD" -- $GENERATED | grep -q .; then
+            echo "::notice::PR modifies generated files (agents/AGENTS.md or README.md) — they will be overwritten by the post-merge regenerate job."
+          fi
+
+  regenerate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Regenerate AGENTS.md and README skills table
+        run: uv run scripts/generate_agents.py
+
+      - name: Commit regenerated files
+        run: |
+          if git diff --quiet -- agents/AGENTS.md README.md; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add agents/AGENTS.md README.md
+          git commit -m 'chore: regenerate agents/AGENTS.md and README skills table [skip ci]'
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Add your Apify skill to this list in under a minute.
+
+## Setup (1 minute)
+
+1. **Fork** this repo
+2. **Copy** `skills/_template/` → `skills/apify-<your-name>/`
+3. **Edit** `skills/apify-<your-name>/SKILL.md`:
+   - `name: apify-<your-name>` (must match the folder name)
+   - `description: ...` (≤ 1024 chars; include trigger phrases a user would say)
+   - `author`, `author_url` (optional)
+   - Replace every `REPLACE` placeholder in the body
+4. **Add** one entry to `.claude-plugin/marketplace.json` (see existing entries)
+5. **Open a PR** — CI validates, a maintainer reviews and merges
+
+## Rules
+
+- **One skill per PR.** CI enforces this. Exception: maintainers can add a `maintainer` label.
+- **No unnecessary changes.** Edit only files inside your skill dir and `.claude-plugin/marketplace.json`. Don't touch `agents/AGENTS.md` or the skills table in `README.md` — both are regenerated automatically.
+- **Use Apify Actors only** — publicly available on the [Apify Store](https://apify.com/store).
+
+## Quality (recommended, not required)
+
+The `skills/_template/` shows the recommended structure with three optional pieces:
+
+- **Apify CLI pattern** with three standard flags (`--json`, `--user-agent`, `2>/dev/null`)
+- **`references/actor-index.md`** — full Actor routing table
+- **`references/gotchas.md`** — cost guardrails and error recovery
+
+For a polished reference implementation, see [apify/agent-skills ultimate-scraper](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/SKILL.md).
+
+## FAQ
+
+**Must I use the Apify CLI?**
+No. We recommend it for cross-tool compatibility, but anything works — the [Apify MCP connector](https://mcp.apify.com), an MCP client of your choice, or [mcpc](https://github.com/apify/mcpc). Cross-tool compatibility is your responsibility.
+
+**Where do generated files live?**
+`agents/AGENTS.md` and the skills table in `README.md`. CI regenerates both after merge — you don't commit them.
+
+**Can I test locally?**
+Yes. After editing, run `uv run scripts/generate_agents.py` to validate. To preview installation, use [`npx skills add <path-to-your-fork>`](https://github.com/vercel-labs/skills).

--- a/README.md
+++ b/README.md
@@ -1,81 +1,55 @@
 # Awesome Apify Skills
 
-Community collection of Apify agent skills for web scraping, data extraction, and automation. Works with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants.
+[![skills.sh](https://skills.sh/b/apify/awesome-skills)](https://skills.sh/apify/awesome-skills)
 
-> For the official consolidated Apify plugins, see [apify/agent-skills](https://github.com/apify/agent-skills).
+Community collection of [Apify](https://apify.com) agent skills for web scraping, data extraction, and automation.
+
+> Companion to [apify/agent-skills](https://github.com/apify/agent-skills), the home of official Apify-maintained skills. This repo collects community contributions that follow the same [agentskills.io](https://agentskills.io/specification) open standard.
+
+## What's a skill?
+
+A skill is a `SKILL.md` file with YAML frontmatter that teaches an AI agent how to do a specific task with [Apify Actors](https://apify.com/store) — which Actors to use, how to build inputs, how to handle errors.
+
+## Install
+
+```bash
+npx skills add apify/awesome-skills
+```
+
+Works with Claude Code, Codex, Cursor, Gemini CLI, Windsurf, OpenCode, and [50+ other agents](https://skills.sh). Pass `--list` to preview, `-s <name>` to install one specific skill.
 
 ## Available skills
 
 <!-- BEGIN_SKILLS_TABLE -->
-| Name | Description | Documentation |
-|------|-------------|---------------|
-| `apify-audience-analysis` | Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok | [SKILL.md](skills/apify-audience-analysis/SKILL.md) |
-| `apify-brand-reputation-monitoring` | Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, Facebook, Instagram, YouTube, and TikTok | [SKILL.md](skills/apify-brand-reputation-monitoring/SKILL.md) |
-| `apify-competitor-intelligence` | Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok | [SKILL.md](skills/apify-competitor-intelligence/SKILL.md) |
-| `apify-content-analytics` | Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok | [SKILL.md](skills/apify-content-analytics/SKILL.md) |
-| `apify-ecommerce` | Scrape e-commerce data for pricing intelligence, customer sentiment, product research, quality analysis, and supply chain monitoring across Amazon, Walmart, eBay, IKEA, and 50+ marketplaces | [SKILL.md](skills/apify-ecommerce/SKILL.md) |
-| `apify-influencer-discovery` | Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok | [SKILL.md](skills/apify-influencer-discovery/SKILL.md) |
-| `apify-lead-generation` | Generate B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search using Apify Actors | [SKILL.md](skills/apify-lead-generation/SKILL.md) |
-| `apify-market-research` | Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor | [SKILL.md](skills/apify-market-research/SKILL.md) |
-| `apify-trend-analysis` | Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy | [SKILL.md](skills/apify-trend-analysis/SKILL.md) |
+| Name | Description | Author |
+|------|-------------|--------|
+| [`apify-audience-analysis`](skills/apify-audience-analysis/SKILL.md) | Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok. | — |
+| [`apify-brand-reputation-monitoring`](skills/apify-brand-reputation-monitoring/SKILL.md) | Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, Facebook, Instagram, YouTube, and TikTok. Use when user asks to monitor brand reputation, analyze reviews, track mentions, or gather customer feedback. | — |
+| [`apify-competitor-intelligence`](skills/apify-competitor-intelligence/SKILL.md) | Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok. | — |
+| [`apify-content-analytics`](skills/apify-content-analytics/SKILL.md) | Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok. | — |
+| [`apify-ecommerce`](skills/apify-ecommerce/SKILL.md) | Scrape e-commerce data for pricing, reviews, bestsellers, and seller discovery across 30+ platforms including Amazon, Walmart, eBay, Shopify, WooCommerce, and more. Use when user asks about product prices, competitor analysis, store scraping, tech stack detection, food delivery, real estate, or marketplace intelligence. | — |
+| [`apify-influencer-discovery`](skills/apify-influencer-discovery/SKILL.md) | Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok. | — |
+| [`apify-lead-generation`](skills/apify-lead-generation/SKILL.md) | Generates B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search. Use when user asks to find leads, prospects, businesses, build lead lists, enrich contacts, or scrape profiles for sales outreach. | — |
+| [`apify-market-research`](skills/apify-market-research/SKILL.md) | Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor. | — |
+| [`apify-trend-analysis`](skills/apify-trend-analysis/SKILL.md) | Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy. | — |
 <!-- END_SKILLS_TABLE -->
 
-## Installation
+## Add your skill
 
-> For the official consolidated Apify plugins, see [apify/agent-skills](https://github.com/apify/agent-skills).
+See [CONTRIBUTING.md](CONTRIBUTING.md) — 1-minute setup.
 
-```bash
-# Add the marketplace
-/plugin marketplace add apify/awesome-skills
+## For AI agents
 
-# Install a skill
-/plugin install apify-lead-generation@awesome-skills
-```
-
-### Cursor / Windsurf
-
-Add to your project's `.cursor/settings.json` or use the same Claude Code plugin format.
-
-### Codex / Gemini CLI
-
-Point your agent to the `agents/AGENTS.md` file which contains skill descriptions and paths:
-
-```bash
-# Gemini CLI uses gemini-extension.json automatically
-# For Codex, reference agents/AGENTS.md in your configuration
-```
-
-### Other AI tools
-
-Any AI tool that supports Markdown context can use the skills by pointing to:
-- `agents/AGENTS.md` - auto-generated skill index
-- `skills/*/SKILL.md` - individual skill documentation
+See [agents/AGENTS.md](agents/AGENTS.md) — same content as this README plus the contributing guide, in a format optimised for autonomous agents.
 
 ## Prerequisites
 
-1. **Apify account** - [apify.com](https://apify.com)
-2. **API token** - get from [Apify Console](https://console.apify.com/account/integrations), add `APIFY_TOKEN=your_token` to `.env`
-3. **Node.js 20.6+**
-
-## Pricing
-
-Apify Actors use pay-per-result pricing. Check individual Actor pricing on the [Apify platform](https://apify.com).
-
-## Contributing
-
-1. Fork this repository.
-2. Create your skill in `skills/your-skill-name/`.
-3. Add `SKILL.md` with proper frontmatter:
-   ```yaml
-   ---
-   name: your-skill-name
-   description: What your skill does and when to use it
-   ---
-   ```
-4. Add entry to `.claude-plugin/marketplace.json`.
-5. Submit a pull request.
+- [Apify account](https://apify.com)
+- (Optional) [Apify CLI](https://docs.apify.com/cli): `npm install -g apify-cli`
+- Authentication: `apify login` or `APIFY_TOKEN` env var ([get a token](https://console.apify.com/settings/integrations))
 
 ## Support
 
 - [Apify Documentation](https://docs.apify.com)
 - [Apify Discord](https://discord.gg/jyEM2PRvMU)
+- [Agent Skills Specification](https://agentskills.io/specification)

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,33 +1,87 @@
 <skills>
 
-You have additional SKILLs documented in directories containing a "SKILL.md" file.
+# Awesome Apify Skills
 
-These skills are:
- - apify-audience-analysis -> "skills/apify-audience-analysis/SKILL.md"
- - apify-brand-reputation-monitoring -> "skills/apify-brand-reputation-monitoring/SKILL.md"
- - apify-competitor-intelligence -> "skills/apify-competitor-intelligence/SKILL.md"
- - apify-content-analytics -> "skills/apify-content-analytics/SKILL.md"
- - apify-ecommerce -> "skills/apify-ecommerce/SKILL.md"
- - apify-influencer-discovery -> "skills/apify-influencer-discovery/SKILL.md"
- - apify-lead-generation -> "skills/apify-lead-generation/SKILL.md"
- - apify-market-research -> "skills/apify-market-research/SKILL.md"
- - apify-trend-analysis -> "skills/apify-trend-analysis/SKILL.md"
+Community collection of Apify agent skills for web data extraction, scraping, and automation. Each skill is a `SKILL.md` file that teaches you how to accomplish a specific task using [Apify Actors](https://apify.com/store).
 
-IMPORTANT: You MUST read the SKILL.md file whenever the description of the skills matches the user intent, or may help accomplish their task.
+Companion to [apify/agent-skills](https://github.com/apify/agent-skills), the home of official Apify-maintained skills. Skills follow the [Agent Skills open standard](https://agentskills.io/specification).
+
+## Available skills
+
+Read a skill's SKILL.md before using it — that's where the full instructions live.
 
 <available_skills>
 
-apify-audience-analysis: `Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.`
-apify-brand-reputation-monitoring: `Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, Facebook, Instagram, YouTube, and TikTok. Use when user asks to monitor brand reputation, analyze reviews, track mentions, or gather customer feedback.`
-apify-competitor-intelligence: `Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.`
-apify-content-analytics: `Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.`
-apify-ecommerce: `Scrape e-commerce data for pricing, reviews, bestsellers, and seller discovery across 30+ platforms including Amazon, Walmart, eBay, Shopify, WooCommerce, and more. Use when user asks about product prices, competitor analysis, store scraping, tech stack detection, food delivery, real estate, or marketplace intelligence.`
-apify-influencer-discovery: `Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.`
-apify-lead-generation: `Generates B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search. Use when user asks to find leads, prospects, businesses, build lead lists, enrich contacts, or scrape profiles for sales outreach.`
-apify-market-research: `Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.`
-apify-trend-analysis: `Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.`
+- **apify-audience-analysis** → `skills/apify-audience-analysis/SKILL.md`: Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.
+- **apify-brand-reputation-monitoring** → `skills/apify-brand-reputation-monitoring/SKILL.md`: Track reviews, ratings, sentiment, and brand mentions across Google Maps, Booking.com, TripAdvisor, Facebook, Instagram, YouTube, and TikTok. Use when user asks to monitor brand reputation, analyze reviews, track mentions, or gather customer feedback.
+- **apify-competitor-intelligence** → `skills/apify-competitor-intelligence/SKILL.md`: Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.
+- **apify-content-analytics** → `skills/apify-content-analytics/SKILL.md`: Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.
+- **apify-ecommerce** → `skills/apify-ecommerce/SKILL.md`: Scrape e-commerce data for pricing, reviews, bestsellers, and seller discovery across 30+ platforms including Amazon, Walmart, eBay, Shopify, WooCommerce, and more. Use when user asks about product prices, competitor analysis, store scraping, tech stack detection, food delivery, real estate, or marketplace intelligence.
+- **apify-influencer-discovery** → `skills/apify-influencer-discovery/SKILL.md`: Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.
+- **apify-lead-generation** → `skills/apify-lead-generation/SKILL.md`: Generates B2B/B2C leads by scraping Google Maps, websites, Instagram, TikTok, Facebook, LinkedIn, YouTube, and Google Search. Use when user asks to find leads, prospects, businesses, build lead lists, enrich contacts, or scrape profiles for sales outreach.
+- **apify-market-research** → `skills/apify-market-research/SKILL.md`: Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.
+- **apify-trend-analysis** → `skills/apify-trend-analysis/SKILL.md`: Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.
+
 </available_skills>
 
-Paths referenced within SKILL.md files are relative to that SKILL folder. For example `reference/workflows.md` refers to the workflows file inside the skill's reference folder.
+Paths are relative to the repository root.
 
 </skills>
+
+---
+
+# How to add a new skill (for AI agents)
+
+A contributor asked you to add a new skill to this repo. Follow these steps.
+
+## Files to create
+
+1. **`skills/apify-<name>/SKILL.md`** — copy from `skills/_template/SKILL.md` and replace every `REPLACE` placeholder. Required frontmatter:
+   - `name: apify-<name>` (must match the folder name; kebab-case)
+   - `description: ...` (≤ 1024 characters; include trigger phrases the user would say)
+   - `author: ...` (optional)
+   - `author_url: https://...` (optional)
+2. **`skills/apify-<name>/references/actor-index.md`** and **`references/gotchas.md`** — copy the templates from `skills/_template/references/` and fill them in. Optional but recommended.
+
+## Marketplace entry
+
+Add one entry to `.claude-plugin/marketplace.json` in the `plugins` array:
+
+```json
+{
+  "name": "apify-<name>",
+  "source": "./skills/apify-<name>",
+  "skills": "./",
+  "description": "Brief description",
+  "keywords": ["apify", "..."],
+  "category": "data-extraction",
+  "version": "1.0.0"
+}
+```
+
+## Rules
+
+- **One skill per PR.** CI rejects PRs that touch multiple skills (unless a maintainer adds the `maintainer` label).
+- **No unnecessary changes.** Edit only files inside `skills/apify-<name>/` and `.claude-plugin/marketplace.json`.
+- **Do not edit** `agents/AGENTS.md` or the skills table in `README.md` — both are regenerated from frontmatter after merge.
+- **Use Apify Actors only** — they must be publicly available on the [Apify Store](https://apify.com/store).
+
+## Calling Actors — your choice
+
+This repo does not mandate any specific interface. Pick one of:
+
+- **Apify CLI** (`apify actors call ...`) — recommended for portability; see [`skills/_template/SKILL.md`](../skills/_template/SKILL.md) for the three flags to include on every call.
+- **Apify MCP connector** at <https://mcp.apify.com>.
+- **MCP client** of your choice (e.g. [mcpc](https://github.com/apify/mcpc)).
+
+Whichever you pick, cross-tool compatibility is your responsibility.
+
+## Validation
+
+Run locally before opening the PR:
+
+```bash
+uv run scripts/generate_agents.py
+```
+
+This checks marketplace ↔ SKILL.md sync, validates `name`/`description`/`author_url` formats, and regenerates `agents/AGENTS.md` + the README skills table. CI runs the same script on the PR.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,0 @@
-{
-  "name": "awesome-skills",
-  "description": "Provides access to Apify community skills for web scraping, data extraction, and automation.",
-  "version": "1.0.0",
-  "contextFileName": "agents/AGENTS.md"
-}

--- a/scripts/AGENTS_TEMPLATE.md
+++ b/scripts/AGENTS_TEMPLATE.md
@@ -1,22 +1,81 @@
 <skills>
 
-You have additional SKILLs documented in directories containing a "SKILL.md" file.
+# Awesome Apify Skills
 
-These skills are:
-{{#skills}}
- - {{name}} -> "{{path}}/SKILL.md"
-{{/skills}}
+Community collection of Apify agent skills for web data extraction, scraping, and automation. Each skill is a `SKILL.md` file that teaches you how to accomplish a specific task using [Apify Actors](https://apify.com/store).
 
-IMPORTANT: You MUST read the SKILL.md file whenever the description of the skills matches the user intent, or may help accomplish their task.
+Companion to [apify/agent-skills](https://github.com/apify/agent-skills), the home of official Apify-maintained skills. Skills follow the [Agent Skills open standard](https://agentskills.io/specification).
+
+## Available skills
+
+Read a skill's SKILL.md before using it — that's where the full instructions live.
 
 <available_skills>
 
 {{#skills}}
-{{name}}: `{{description}}`
-
+- **{{name}}**{{attribution}} → `{{path}}/SKILL.md`: {{description}}
 {{/skills}}
+
 </available_skills>
 
-Paths referenced within SKILL.md files are relative to that SKILL folder. For example `reference/workflows.md` refers to the workflows file inside the skill's reference folder.
+Paths are relative to the repository root.
 
 </skills>
+
+---
+
+# How to add a new skill (for AI agents)
+
+A contributor asked you to add a new skill to this repo. Follow these steps.
+
+## Files to create
+
+1. **`skills/apify-<name>/SKILL.md`** — copy from `skills/_template/SKILL.md` and replace every `REPLACE` placeholder. Required frontmatter:
+   - `name: apify-<name>` (must match the folder name; kebab-case)
+   - `description: ...` (≤ 1024 characters; include trigger phrases the user would say)
+   - `author: ...` (optional)
+   - `author_url: https://...` (optional)
+2. **`skills/apify-<name>/references/actor-index.md`** and **`references/gotchas.md`** — copy the templates from `skills/_template/references/` and fill them in. Optional but recommended.
+
+## Marketplace entry
+
+Add one entry to `.claude-plugin/marketplace.json` in the `plugins` array:
+
+```json
+{
+  "name": "apify-<name>",
+  "source": "./skills/apify-<name>",
+  "skills": "./",
+  "description": "Brief description",
+  "keywords": ["apify", "..."],
+  "category": "data-extraction",
+  "version": "1.0.0"
+}
+```
+
+## Rules
+
+- **One skill per PR.** CI rejects PRs that touch multiple skills (unless a maintainer adds the `maintainer` label).
+- **No unnecessary changes.** Edit only files inside `skills/apify-<name>/` and `.claude-plugin/marketplace.json`.
+- **Do not edit** `agents/AGENTS.md` or the skills table in `README.md` — both are regenerated from frontmatter after merge.
+- **Use Apify Actors only** — they must be publicly available on the [Apify Store](https://apify.com/store).
+
+## Calling Actors — your choice
+
+This repo does not mandate any specific interface. Pick one of:
+
+- **Apify CLI** (`apify actors call ...`) — recommended for portability; see [`skills/_template/SKILL.md`](../skills/_template/SKILL.md) for the three flags to include on every call.
+- **Apify MCP connector** at <https://mcp.apify.com>.
+- **MCP client** of your choice (e.g. [mcpc](https://github.com/apify/mcpc)).
+
+Whichever you pick, cross-tool compatibility is your responsibility.
+
+## Validation
+
+Run locally before opening the PR:
+
+```bash
+uv run scripts/generate_agents.py
+```
+
+This checks marketplace ↔ SKILL.md sync, validates `name`/`description`/`author_url` formats, and regenerates `agents/AGENTS.md` + the README skills table. CI runs the same script on the PR.

--- a/scripts/generate_agents.py
+++ b/scripts/generate_agents.py
@@ -3,27 +3,25 @@
 # requires-python = ">=3.10"
 # dependencies = []
 # ///
-"""Generate AGENTS.md from AGENTS_TEMPLATE.md and SKILL.md frontmatter.
+"""Generate agents/AGENTS.md and the README skills table from SKILL.md frontmatter.
 
-Also validates that marketplace.json is in sync with discovered skills,
-updates the skills table in README.md, and handles version bumping.
+Also validates that .claude-plugin/marketplace.json is in sync with discovered
+skills. Fails (exit 1) on hard errors; prints nothing for healthy skills.
 
-Version bumping (conventional commits):
-  - BREAKING CHANGE: or feat!: → major bump (1.0.0 → 2.0.0)
-  - feat: → minor bump (1.0.0 → 1.1.0)
-  - fix:, docs:, chore:, etc. → patch bump (1.0.0 → 1.0.1)
+Frontmatter fields:
+  - name         (required) — must match folder name, kebab-case, apify- prefix
+  - description  (required) — max 1024 chars per agentskills.io spec
+  - author       (optional) — free string
+  - author_url   (optional) — must be a valid http(s) URL if present
 
 Usage:
-  uv run scripts/generate_agents.py                    # Just regenerate
-  uv run scripts/generate_agents.py --bump "feat: X"   # Bump based on commit msg
+  uv run scripts/generate_agents.py
 """
 
 from __future__ import annotations
 
-import argparse
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -32,123 +30,146 @@ ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_PATH = ROOT / "scripts" / "AGENTS_TEMPLATE.md"
 OUTPUT_PATH = ROOT / "agents" / "AGENTS.md"
 MARKETPLACE_PATH = ROOT / ".claude-plugin" / "marketplace.json"
-PLUGIN_PATH = ROOT / ".claude-plugin" / "plugin.json"
 README_PATH = ROOT / "README.md"
 SKILLS_DIR = ROOT / "skills"
 
-# Markers for the auto-generated skills table in README
 README_TABLE_START = "<!-- BEGIN_SKILLS_TABLE -->"
 README_TABLE_END = "<!-- END_SKILLS_TABLE -->"
 
+DESCRIPTION_MAX_CHARS = 1024
+NAME_PATTERN = re.compile(r"^apify-[a-z0-9]+(-[a-z0-9]+)*$")
+URL_PATTERN = re.compile(r"^https?://[^\s]+$")
 
-def load_template() -> str:
-    return TEMPLATE_PATH.read_text(encoding="utf-8")
+# Skill directories that exist for tooling/templates, not for discovery.
+EXCLUDED_DIRS = {"_template"}
 
 
 def parse_frontmatter(text: str) -> dict[str, str]:
-    """Parse a minimal YAML-ish frontmatter block without external deps."""
+    """Parse a minimal YAML-ish frontmatter block without external deps.
+
+    Supports:
+      - Single-line scalars:        key: value
+      - Folded scalars over lines:  key: >- ... (joined with single spaces)
+    """
     match = re.search(r"^---\s*\n(.*?)\n---\s*", text, re.DOTALL)
     if not match:
         return {}
+
     data: dict[str, str] = {}
-    for line in match.group(1).splitlines():
+    lines = match.group(1).splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         if ":" not in line:
+            i += 1
             continue
-        key, value = line.split(":", 1)
-        data[key.strip()] = value.strip()
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+
+        if value in {">-", ">", "|", "|-"}:
+            # Folded/block scalar — collect indented continuation lines
+            parts: list[str] = []
+            i += 1
+            while i < len(lines) and (lines[i].startswith((" ", "\t")) or lines[i] == ""):
+                stripped = lines[i].strip()
+                if stripped:
+                    parts.append(stripped)
+                i += 1
+            data[key] = " ".join(parts)
+            continue
+
+        data[key] = value
+        i += 1
     return data
 
 
 def collect_skills() -> list[dict[str, str]]:
+    """Discover all SKILL.md files under skills/ (excluding _template, etc.)."""
     skills: list[dict[str, str]] = []
-    for skill_md in ROOT.glob("skills/*/SKILL.md"):
-        meta = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
-        name = meta.get("name")
-        description = meta.get("description")
-        if not name or not description:
+    for skill_md in SKILLS_DIR.glob("*/SKILL.md"):
+        folder = skill_md.parent.name
+        if folder in EXCLUDED_DIRS:
             continue
+        meta = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
         skills.append(
             {
-                "name": name,
-                "description": description,
+                "folder": folder,
+                "name": meta.get("name", ""),
+                "description": meta.get("description", ""),
+                "author": meta.get("author", ""),
+                "author_url": meta.get("author_url", ""),
                 "path": str(skill_md.parent.relative_to(ROOT)),
             }
         )
-    # Keep deterministic order for consistent output
     return sorted(skills, key=lambda s: s["name"].lower())
 
 
-def render(template: str, skills: list[dict[str, str]]) -> str:
-    """Very small Mustache-like renderer that only supports a single skills loop."""
+def render_template(template: str, skills: list[dict[str, str]]) -> str:
+    """Tiny Mustache-like renderer for the {{#skills}}...{{/skills}} loop."""
+
     def repl(match: re.Match[str]) -> str:
         block = match.group(1).strip("\n")
-        rendered_blocks = []
+        rendered_blocks: list[str] = []
         for skill in skills:
+            attribution = ""
+            if skill["author"] and skill["author_url"]:
+                attribution = f" by [{skill['author']}]({skill['author_url']})"
+            elif skill["author"]:
+                attribution = f" by {skill['author']}"
             rendered = (
                 block.replace("{{name}}", skill["name"])
                 .replace("{{description}}", skill["description"])
                 .replace("{{path}}", skill["path"])
+                .replace("{{attribution}}", attribution)
             )
             rendered_blocks.append(rendered)
         return "\n".join(rendered_blocks)
 
-    # Render loop blocks
-    content = re.sub(r"{{#skills}}(.*?){{/skills}}", repl, template, flags=re.DOTALL)
-    return content
+    return re.sub(r"{{#skills}}(.*?){{/skills}}", repl, template, flags=re.DOTALL)
 
 
 def load_marketplace() -> dict:
-    """Load marketplace.json and return parsed structure."""
     if not MARKETPLACE_PATH.exists():
         raise FileNotFoundError(f"marketplace.json not found at {MARKETPLACE_PATH}")
     return json.loads(MARKETPLACE_PATH.read_text(encoding="utf-8"))
 
 
 def generate_readme_table(skills: list[dict[str, str]]) -> str:
-    """Generate the skills table for README.md using marketplace.json names."""
-    marketplace = load_marketplace()
-    plugins = {p["source"]: p for p in marketplace.get("plugins", [])}
-
+    """Render the README skills table with an Author column."""
     lines = [
-        "| Name | Description | Documentation |",
-        "|------|-------------|---------------|",
+        "| Name | Description | Author |",
+        "|------|-------------|--------|",
     ]
-
     for skill in skills:
-        source = f"./{skill['path']}"
-        plugin = plugins.get(source, {})
-        name = plugin.get("name", skill["name"])
-        description = plugin.get("description", skill["description"])
-        doc_link = f"[SKILL.md]({skill['path']}/SKILL.md)"
-        lines.append(f"| `{name}` | {description} | {doc_link} |")
-
+        name = skill["name"]
+        description = skill["description"]
+        doc_link = f"[`{name}`]({skill['path']}/SKILL.md)"
+        if skill["author"] and skill["author_url"]:
+            author_cell = f"[{skill['author']}]({skill['author_url']})"
+        elif skill["author"]:
+            author_cell = skill["author"]
+        else:
+            author_cell = "—"
+        lines.append(f"| {doc_link} | {description} | {author_cell} |")
     return "\n".join(lines)
 
 
 def update_readme(skills: list[dict[str, str]]) -> bool:
-    """
-    Update the README.md skills table between markers.
-    Returns True if the file was updated, False if markers not found.
-    """
     if not README_PATH.exists():
         print(f"Warning: README.md not found at {README_PATH}", file=sys.stderr)
         return False
 
     content = README_PATH.read_text(encoding="utf-8")
-
     start_idx = content.find(README_TABLE_START)
     end_idx = content.find(README_TABLE_END)
 
-    if start_idx == -1 or end_idx == -1:
+    if start_idx == -1 or end_idx == -1 or end_idx < start_idx:
         print(
-            f"Warning: README.md markers not found. Add {README_TABLE_START} and "
-            f"{README_TABLE_END} to enable table generation.",
+            f"Warning: README.md markers {README_TABLE_START}/{README_TABLE_END} "
+            "missing or out of order — skills table not regenerated.",
             file=sys.stderr,
         )
-        return False
-
-    if end_idx < start_idx:
-        print("Warning: README.md markers are in wrong order.", file=sys.stderr)
         return False
 
     table = generate_readme_table(skills)
@@ -159,244 +180,108 @@ def update_readme(skills: list[dict[str, str]]) -> bool:
         + "\n"
         + content[end_idx:]
     )
-
+    if new_content == content:
+        return False
     README_PATH.write_text(new_content, encoding="utf-8")
     return True
 
 
-def validate_marketplace(skills: list[dict[str, str]]) -> list[str]:
-    """
-    Validate marketplace.json against discovered skills.
-    Returns list of error messages (empty = passed).
-    """
+def validate_skills(skills: list[dict[str, str]]) -> list[str]:
+    """Hard validation. Returns list of error messages (empty = OK)."""
     errors: list[str] = []
-    marketplace = load_marketplace()
-    plugins = marketplace.get("plugins", [])
-
-    # Build lookups (normalize paths: skill uses "skills/x", marketplace uses "./skills/x")
-    skill_by_source = {f"./{s['path']}": s for s in skills}
-    plugin_by_source = {p["source"]: p for p in plugins}
-
-    # Check: every skill has a marketplace entry with matching name
     for skill in skills:
-        expected_source = f"./{skill['path']}"
-        if expected_source not in plugin_by_source:
+        folder = skill["folder"]
+        name = skill["name"]
+        description = skill["description"]
+
+        if not name:
+            errors.append(f"skills/{folder}/SKILL.md: missing 'name' in frontmatter")
+            continue
+        if not description:
+            errors.append(f"skills/{folder}/SKILL.md: missing 'description' in frontmatter")
+
+        if not NAME_PATTERN.match(name):
             errors.append(
-                f"Skill '{skill['name']}' at '{skill['path']}' is missing from marketplace.json"
+                f"skills/{folder}/SKILL.md: name '{name}' must be kebab-case "
+                "with 'apify-' prefix (lowercase letters, digits, hyphens)"
             )
-        elif plugin_by_source[expected_source]["name"] != skill["name"]:
+        if name != f"apify-{folder.removeprefix('apify-')}":
+            # Folder name and `name` must match exactly.
+            if name != folder:
+                errors.append(
+                    f"skills/{folder}/SKILL.md: name '{name}' does not match "
+                    f"folder name '{folder}' (they must be identical)"
+                )
+
+        if len(description) > DESCRIPTION_MAX_CHARS:
             errors.append(
-                f"Name mismatch at '{expected_source}': "
-                f"SKILL.md='{skill['name']}', marketplace.json='{plugin_by_source[expected_source]['name']}'"
+                f"skills/{folder}/SKILL.md: description is {len(description)} chars "
+                f"(max {DESCRIPTION_MAX_CHARS} per agentskills.io spec)"
             )
 
-    # Check: every marketplace plugin with skills has a corresponding skill
-    for plugin in plugins:
-        # Skip plugins that don't have skills (e.g., commands-only plugins)
-        if "skills" not in plugin:
-            continue
-        if plugin["source"] not in skill_by_source:
+        author_url = skill["author_url"]
+        if author_url and not URL_PATTERN.match(author_url):
             errors.append(
-                f"Marketplace plugin '{plugin['name']}' at '{plugin['source']}' has no SKILL.md"
+                f"skills/{folder}/SKILL.md: author_url '{author_url}' is not a valid http(s) URL"
             )
 
     return errors
 
 
-def parse_version(version: str) -> tuple[int, int, int]:
-    """Parse semver string to tuple."""
-    match = re.match(r"(\d+)\.(\d+)\.(\d+)", version)
-    if not match:
-        return (1, 0, 0)
-    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
-
-
-def format_version(version: tuple[int, int, int]) -> str:
-    """Format version tuple to string."""
-    return f"{version[0]}.{version[1]}.{version[2]}"
-
-
-def get_bump_type(commit_msg: str) -> str:
-    """
-    Determine version bump type from conventional commit message.
-    Returns: 'major', 'minor', 'patch', or 'none'
-    """
-    msg_lower = commit_msg.lower()
-
-    # Major: BREAKING CHANGE or ! after type
-    if "breaking change" in msg_lower or re.match(r"^\w+!:", commit_msg):
-        return "major"
-
-    # Minor: feat
-    if re.match(r"^feat(\(.+\))?:", commit_msg, re.IGNORECASE):
-        return "minor"
-
-    # Patch: fix, docs, chore, refactor, style, test, perf, ci, build
-    patch_types = ["fix", "docs", "chore", "refactor", "style", "test", "perf", "ci", "build"]
-    for t in patch_types:
-        if re.match(rf"^{t}(\(.+\))?:", commit_msg, re.IGNORECASE):
-            return "patch"
-
-    return "none"
-
-
-def bump_version(version: str, bump_type: str) -> str:
-    """Bump version based on type."""
-    major, minor, patch = parse_version(version)
-
-    if bump_type == "major":
-        return format_version((major + 1, 0, 0))
-    elif bump_type == "minor":
-        return format_version((major, minor + 1, 0))
-    elif bump_type == "patch":
-        return format_version((major, minor, patch + 1))
-    return version
-
-
-def update_user_agent_in_skill(skill_name: str, new_version: str) -> bool:
-    """
-    Update USER_AGENT version in skill's run_actor.py script.
-    Returns True if updated, False otherwise.
-    """
-    script_path = SKILLS_DIR / skill_name / "reference" / "scripts" / "run_actor.py"
-    if not script_path.exists():
-        return False
-
-    content = script_path.read_text(encoding="utf-8")
-
-    # Pattern: USER_AGENT = "apify-agent-skills/skill-name-X.Y.Z"
-    pattern = rf'(USER_AGENT\s*=\s*"apify-agent-skills/{re.escape(skill_name)}-)\d+\.\d+\.\d+"'
-    replacement = rf'\g<1>{new_version}"'
-
-    new_content, count = re.subn(pattern, replacement, content)
-
-    if count > 0:
-        script_path.write_text(new_content, encoding="utf-8")
-        print(f"Updated USER_AGENT in {script_path.relative_to(ROOT)}: {new_version}")
-        return True
-
-    return False
-
-
-def get_changed_skills() -> set[str]:
-    """Get list of skill names that have staged changes."""
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
-            capture_output=True,
-            text=True,
-            cwd=ROOT,
-        )
-        changed_files = result.stdout.strip().split("\n") if result.stdout.strip() else []
-    except Exception:
-        return set()
-
-    changed_skills = set()
-    for f in changed_files:
-        # Match skills/skill-name/... pattern
-        match = re.match(r"skills/([^/]+)/", f)
-        if match:
-            changed_skills.add(match.group(1))
-
-    return changed_skills
-
-
-def update_versions(commit_msg: str) -> bool:
-    """
-    Update versions based on commit message and changed files.
-    Returns True if any version was bumped.
-    """
-    bump_type = get_bump_type(commit_msg)
-    if bump_type == "none":
-        print(f"No version bump needed for commit: {commit_msg[:50]}...")
-        return False
-
-    changed_skills = get_changed_skills()
-    bumped = False
-
-    # Load marketplace.json
+def validate_marketplace_sync(skills: list[dict[str, str]]) -> list[str]:
+    errors: list[str] = []
     marketplace = load_marketplace()
+    plugins = marketplace.get("plugins", [])
 
-    # Bump individual skill versions if they changed
-    for plugin in marketplace.get("plugins", []):
-        skill_name = plugin["source"].replace("./skills/", "")
-        if skill_name in changed_skills:
-            old_version = plugin.get("version", "1.0.0")
-            new_version = bump_version(old_version, bump_type)
-            if old_version != new_version:
-                plugin["version"] = new_version
-                print(f"Bumped {skill_name}: {old_version} → {new_version} ({bump_type})")
-                bumped = True
-                # Also update USER_AGENT in skill's run_actor.py
-                update_user_agent_in_skill(skill_name, new_version)
+    skill_by_source = {f"./{s['path']}": s for s in skills}
+    plugin_by_source = {p["source"]: p for p in plugins}
 
-    # Bump marketplace version if any skill changed
-    if changed_skills or bumped:
-        old_version = marketplace.get("metadata", {}).get("version", "1.0.0")
-        new_version = bump_version(old_version, bump_type)
-        if old_version != new_version:
-            if "metadata" not in marketplace:
-                marketplace["metadata"] = {}
-            marketplace["metadata"]["version"] = new_version
-            print(f"Bumped marketplace: {old_version} → {new_version} ({bump_type})")
-            bumped = True
-
-    # Save marketplace.json
-    if bumped:
-        MARKETPLACE_PATH.write_text(
-            json.dumps(marketplace, indent=2) + "\n",
-            encoding="utf-8"
-        )
-
-    # Also bump plugin.json version
-    if bumped and PLUGIN_PATH.exists():
-        plugin_data = json.loads(PLUGIN_PATH.read_text(encoding="utf-8"))
-        old_version = plugin_data.get("version", "1.0.0")
-        new_version = bump_version(old_version, bump_type)
-        if old_version != new_version:
-            plugin_data["version"] = new_version
-            PLUGIN_PATH.write_text(
-                json.dumps(plugin_data, indent=2) + "\n",
-                encoding="utf-8"
+    for skill in skills:
+        expected_source = f"./{skill['path']}"
+        if expected_source not in plugin_by_source:
+            errors.append(
+                f"Skill '{skill['name']}' at '{skill['path']}' is missing "
+                "from .claude-plugin/marketplace.json"
             )
-            print(f"Bumped plugin.json: {old_version} → {new_version}")
+        elif plugin_by_source[expected_source]["name"] != skill["name"]:
+            errors.append(
+                f"Name mismatch at '{expected_source}': "
+                f"SKILL.md='{skill['name']}', "
+                f"marketplace.json='{plugin_by_source[expected_source]['name']}'"
+            )
 
-    return bumped
+    for plugin in plugins:
+        if "skills" not in plugin:
+            continue
+        if plugin["source"] not in skill_by_source:
+            errors.append(
+                f"Marketplace plugin '{plugin['name']}' at '{plugin['source']}' "
+                "has no SKILL.md"
+            )
+
+    return errors
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate AGENTS.md and manage versions")
-    parser.add_argument(
-        "--bump",
-        metavar="COMMIT_MSG",
-        help="Bump versions based on conventional commit message"
-    )
-    args = parser.parse_args()
-
-    # Handle version bumping if requested
-    if args.bump:
-        update_versions(args.bump)
-
-    template = load_template()
+def main() -> int:
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
     skills = collect_skills()
-    output = render(template, skills)
-    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_PATH.write_text(output, encoding="utf-8")
-    print(f"Wrote {OUTPUT_PATH} with {len(skills)} skills.")
 
-    # Validate marketplace.json
-    errors = validate_marketplace(skills)
+    errors = validate_skills(skills) + validate_marketplace_sync(skills)
     if errors:
-        print("\nMarketplace.json validation errors:", file=sys.stderr)
-        for error in errors:
-            print(f"  - {error}", file=sys.stderr)
-        sys.exit(1)
-    print("Marketplace.json validation passed.")
+        print("Validation failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
 
-    # Update README.md skills table
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(render_template(template, skills), encoding="utf-8")
+    print(f"Wrote {OUTPUT_PATH.relative_to(ROOT)} ({len(skills)} skills).")
+
     if update_readme(skills):
-        print(f"Updated {README_PATH} skills table.")
+        print(f"Updated {README_PATH.relative_to(ROOT)} skills table.")
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/_template/SKILL.md
+++ b/skills/_template/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: apify-REPLACE-skill-name
+description: >-
+  REPLACE: One or two sentences describing what the skill does, including
+  trigger phrases a user would say (e.g. "scrape Amazon reviews", "find
+  leads on LinkedIn"). Max 1024 characters per agentskills.io spec.
+author: REPLACE Your Name
+author_url: https://github.com/REPLACE-your-handle
+---
+
+# REPLACE: Skill Title
+
+REPLACE: One-line summary of what this skill helps the agent accomplish.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## Workflow
+
+1. REPLACE: Understand the user's goal, pick the right Actor(s).
+2. REPLACE: Fetch the Actor's input schema, build a valid input.
+3. REPLACE: Run the Actor, confirm with user if estimated cost is significant.
+4. REPLACE: Deliver results (count, format, link to dataset/console).
+
+For a worked 4-step workflow, see [apify/agent-skills ultimate-scraper](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/SKILL.md).
+
+## Actor routing
+
+| User need | Actor ID | Tier | Best for |
+|-----------|----------|------|----------|
+| REPLACE | `apify/REPLACE-actor` | apify | REPLACE |
+| REPLACE | `community/REPLACE-actor` | community | REPLACE |
+
+`Tier` = `apify` (Apify-maintained, prefer) or `community` (third-party).
+
+## Calling Actors — choose your interface
+
+Skills in this repo can call Actors via any of these interfaces. Pick the one
+that fits your runtime; cross-tool compatibility is your responsibility.
+
+### Option A: Apify CLI (recommended for portability)
+
+Works in any shell-capable agent. Three flags on every call:
+
+    apify actors call "ACTOR_ID" -i 'JSON_INPUT' \
+      --json \
+      --user-agent apify-agent-skills/REPLACE-skill-name \
+      2>/dev/null
+
+| Flag | Why |
+|------|-----|
+| `--json` | Stable machine-readable output |
+| `--user-agent` | Apify telemetry attribution |
+| `2>/dev/null` | Suppress progress messages that break JSON |
+
+Other useful commands:
+
+    # Search Actors
+    apify actors search "KEYWORDS" --json --limit 10 2>/dev/null
+
+    # Fetch Actor schema
+    apify actors info "ACTOR_ID" --input --json 2>/dev/null
+
+    # Fetch results
+    apify datasets get-items DATASET_ID --format json
+
+For the canonical command set with all flags, see [apify/agent-skills ultimate-scraper](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/SKILL.md).
+
+### Option B: Apify MCP connector
+
+Hosted MCP server at <https://mcp.apify.com>. Documented at
+<https://docs.apify.com/platform/integrations/mcp>.
+
+### Option C: MCP client of your choice (e.g. `mcpc`)
+
+Standalone CLI client. See <https://github.com/apify/mcpc>.
+
+## Troubleshooting
+
+- REPLACE: common error 1 → fix
+- REPLACE: common error 2 → fix
+- For detailed cost guardrails and recovery, see [references/gotchas.md](references/gotchas.md).

--- a/skills/_template/references/actor-index.md
+++ b/skills/_template/references/actor-index.md
@@ -1,0 +1,17 @@
+# Actor index — REPLACE skill name
+
+Comprehensive Actor routing table. The agent reads this after `SKILL.md` to
+pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| REPLACE | REPLACE | `apify/REPLACE` | apify | REPLACE pricing model, key flags |
+| REPLACE | REPLACE | `community/REPLACE` | community | REPLACE |
+
+## How to extend
+
+1. Search for candidates: `apify actors search "KEYWORDS" --json --limit 20 2>/dev/null`
+2. Fetch input schema: `apify actors info "ACTOR_ID" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it.
+
+For a polished example covering 130+ Actors across 15+ platforms, see [apify/agent-skills ultimate-scraper actor-index](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/references/actor-index.md).

--- a/skills/_template/references/gotchas.md
+++ b/skills/_template/references/gotchas.md
@@ -1,0 +1,39 @@
+# Gotchas — REPLACE skill name
+
+Cost guardrails, error recovery, and common pitfalls. The agent reads this
+on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+Apify Actors use one of three pricing models. Before running, check the
+model via `apify actors info "ACTOR_ID" --json 2>/dev/null` (look at
+`pricingInfo`).
+
+| Model | What to watch for |
+|-------|-------------------|
+| `FREE` | No cost — safe to run. |
+| `PAY_PER_EVENT` | Cost scales with results. Estimate before running. |
+| `FLAT_PRICE_PER_MONTH` | Subscription — runs are unlimited once paid. |
+
+### Confirmation thresholds (suggested)
+
+- Estimated cost **>$5** → warn the user.
+- Estimated cost **>$20** → require explicit user confirmation before running.
+- Always present cost as a **rough estimate** ("around $X"), not a guarantee.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| REPLACE | REPLACE | REPLACE |
+| REPLACE | REPLACE | REPLACE |
+
+## Actor-specific notes
+
+### `apify/REPLACE-actor-id`
+
+- REPLACE: input quirk
+- REPLACE: known limitation
+- REPLACE: rate-limit behavior
+
+For a polished gotchas example with detailed cost tables and error-recovery flows, see [apify/agent-skills ultimate-scraper gotchas](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/references/gotchas.md).


### PR DESCRIPTION
## Summary

- Loosen `scripts/generate_agents.py` to validate only the [agentskills.io](https://agentskills.io/specification) minimum (`name` + `description` + folder match), in line with how `anthropics/skills` and `vercel-labs/agent-skills` operate.
- Adopt [`npx skills add apify/awesome-skills`](https://github.com/vercel-labs/skills) as the install path. It auto-discovers `skills/` and reads `.claude-plugin/marketplace.json`, generating per-tool installs at install-time for Claude Code, Codex, Cursor, Gemini, Windsurf, OpenCode, and 50+ other agents.
- Add the contributor onboarding the repo never had: `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, `CODEOWNERS`, and `skills/_template/` — none of these existed in `main`. Target: under 1 minute to PR-ready.

## Changes vs `main`

### New (none of these existed in `main`)

- `CONTRIBUTING.md` (35 lines) — 5-step setup, 3 rules, 3 FAQ entries
- `.github/PULL_REQUEST_TEMPLATE.md` (16 lines) — 4 checkboxes
- `.github/CODEOWNERS` — maintainer-protected paths (`/scripts/`, `/.github/`, `README.md`, `CONTRIBUTING.md`, `agents/AGENTS.md`, `skills/_template/`)
- `skills/_template/SKILL.md` + `references/{actor-index,gotchas}.md` — copy-paste starting point with ultimate-scraper pointers placed exactly where the contributor needs them (workflow, CLI section, actor-index, gotchas)

### Modified

- `scripts/generate_agents.py`: **401 → 287 lines.** The previous validator emitted warnings on every `apify` command without `--json` / `--user-agent` / `2>/dev/null` and flagged references to `run_actor.js`, `mcpc`, or `${CLAUDE_PLUGIN_ROOT}`; CI promoted those warnings to errors for changed skills via the `--strict` flag. Dropped all of that plus `references/*` presence checks, body-length warnings (200/3000 words), `--bump` flag, and version-bumping logic. Added optional `author` / `author_url` frontmatter parsing, name kebab-case + folder-name match check, and `author_url` URL format validation.
- `README.md`: **81 → 55 lines.** Removed per-tool install sections (Claude Code / Codex / Gemini / Cursor / Windsurf blocks), collapsed to a single `npx skills add` command. Added `skills.sh` badge and an `Author` column in the skills table.
- `scripts/AGENTS_TEMPLATE.md`: **22 → 81 lines.** The old template only generated the skills list; the new one also embeds a "How to add a skill" section (imperative form, mirrors `CONTRIBUTING.md`) so AGENTS-aware agents have the contribution guide in their context.
- `agents/AGENTS.md`: regenerated from the richer template (**33 → 87 lines**).
- `.github/workflows/generate-agents.yml`: **30 → 152 lines.** Replaced the single "validate" job with:
  - `validate-pr` (on PRs): one-skill-per-PR check, out-of-scope file check, PR-checklist-filled check, marketplace ↔ SKILL.md sync validation — all with a `maintainer` label escape hatch
  - `regenerate` (on push to `main`): re-runs `generate_agents.py` and pushes a `[skip ci]` commit with refreshed `agents/AGENTS.md` + README skills table, so contributors never have to commit generated files

### Removed

- `gemini-extension.json` — `vercel-labs/skills` generates per-tool installs at install-time, so this side-channel manifest is no longer needed. (This is the only file the commit removes; `.cursor-plugin/`, `.codex-plugin/`, `.agents/`, `docs/`, `scripts/generate_plugins.py`, etc. never existed in `main`.)

## Breaking change

New contributions no longer need to use the `apify` CLI. The three-flag pattern (`--json`, `--user-agent`, `2>/dev/null`) is recommended in `skills/_template/` but **not enforced** by the validator. Skills can use the [Apify MCP connector](https://mcp.apify.com), any MCP client, or [mcpc](https://github.com/apify/mcpc) — cross-tool compatibility becomes the contributor's responsibility.

Existing 9 skills are untouched and continue to validate as-is.

## Out of scope (deferred to follow-up PRs)

- [ ] Migrate the 9 existing skills from `run_actor.js` to `apify` CLI
- [ ] Add `author` / `author_url` frontmatter to existing skills (ecommerce → Lukáš, others → chocho / Duško)

## Prerequisites before merge

- [ ] Create GitHub team `@apify/awesome-skills-maintainers` (referenced by `CODEOWNERS` — without it `CODEOWNERS` is silent, CI still works)
- [ ] Create GitHub label `maintainer` (CI escape-hatch for multi-skill or out-of-scope PRs)

## Test plan

- [ ] After merge, the `regenerate` job pushes a `[skip ci]` commit to `main` with refreshed `agents/AGENTS.md` and README skills table
- [ ] Dummy PR touching two skill dirs → `validate-pr` fails with "one skill per PR"
- [ ] Adding `maintainer` label to that PR → checks pass with a notice
- [ ] Dummy PR with an unchecked `[ ]` checkbox in the description → `validate-pr` fails and lists the unchecked line numbers
- [ ] `npx skills add apify/awesome-skills --list` enumerates all 9 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
