### PR TITLE
feat(apify-reddit-research): add Reddit research skill with two-Actor chain

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -185,6 +185,46 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-reddit-research",
+      "source": "./skills/apify-reddit-research",
+      "skills": "./",
+      "description": "Research discussions, sentiment, opinions, and trends on Reddit. Use when the user asks what Reddit thinks about a topic/brand/product/company, wants subreddit analysis, needs to find real conversations, monitor brand mentions, analyze customer sentiment, research trends, or gather Reddit data for competitive intelligence and market research.",
+      "keywords": [
+        "reddit",
+        "reddit-research",
+        "reddit-sentiment",
+        "reddit-scraper",
+        "social-listening",
+        "brand-monitoring",
+        "market-research",
+        "customer-sentiment",
+        "subreddit-analysis",
+        "discussion-research"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-x-monitoring",
+      "source": "./skills/apify-x-monitoring",
+      "skills": "./",
+      "description": "Monitor brands and competitors on X (Twitter). Track mentions, sentiment, complaints, praise, and activity from specific accounts. Use when the user wants to monitor what people are saying about a brand or competitor on X, detect negative buzz, track competitor posts, or run social listening on X.",
+      "keywords": [
+        "x",
+        "twitter",
+        "x-monitoring",
+        "twitter-monitoring",
+        "brand-monitoring",
+        "competitor-monitoring",
+        "social-listening",
+        "sentiment",
+        "mentions",
+        "x-research"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-reddit-research/SKILL.md
+++ b/skills/apify-reddit-research/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: apify-reddit-research
+description: Research discussions, sentiment, opinions, and trends on Reddit. Use when the user asks what Reddit thinks about a topic/brand/product/company, wants subreddit analysis, needs to find real conversations, monitor brand mentions, analyze customer sentiment, research trends, or gather Reddit data for competitive intelligence and market research. Supports keyword search, specific subreddits, user profiles, and post URLs.
+author: Jose Gabriel Rivera
+author_url: https://github.com/grivera82
+---
+
+# Reddit Research
+
+This skill helps agents research discussions, sentiment, and trends on Reddit. It chains two Actors:
+
+- `trudax/reddit-scraper-lite` — Finds conversations, posts, comments, and links across Reddit.
+- `apify/website-content-crawler` (optional) — Crawls the most relevant pages linked in those discussions for deeper context.
+
+It is particularly strong for brand monitoring, competitor analysis, customer sentiment research, and market intelligence.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## When to use this skill
+
+Use this skill when the user says things like:
+- "What does Reddit think about [topic/product/brand]?"
+- "Find discussions about [X] on Reddit"
+- "Reddit sentiment on [company]"
+- "Research r/[subreddit]"
+- "Scrape Reddit for [keyword]"
+- "What are people saying about [new feature/launch]?"
+- "Find complaints/praise about [product] on Reddit"
+- "Market research on Reddit for [category]"
+
+## Actor routing
+
+| Step | Actor ID | Purpose | When to use |
+|------|----------|---------|-------------|
+| 1 | `trudax/reddit-scraper-lite` | Discover Reddit discussions, sentiment, and links | Always (core of the skill) |
+| 2 (optional) | `apify/website-content-crawler` | Enrich the best linked articles/pages found in Reddit threads | When you need deeper context beyond comments |
+
+### Why this skill chains two Actors
+
+- **Step 1** (`trudax/reddit-scraper-lite`): Discover real conversations, sentiment, and links people are sharing on Reddit.
+- **Step 2** (optional but powerful): `apify/website-content-crawler` crawls the most relevant linked pages to get full article/review content.
+
+This combination delivers significantly more value than scraping Reddit alone, especially for brand monitoring and competitive intelligence.
+
+## Prerequisites & CLI Rules
+
+**Every `apify` CLI command in this skill must use these three flags** (CI will reject the PR otherwise):
+
+```bash
+apify actors call trudax/reddit-scraper-lite \
+  -i 'JSON_HERE' \
+  --user-agent apify-awesome-skills/apify-reddit-research \
+  --json 2>/dev/null
+```
+
+- `--user-agent` → required for telemetry / bounty attribution
+- `--json` → machine-readable output
+- `2>/dev/null` → hides progress spinners that break JSON parsing
+
+## Workflow (Two-Actor Chain)
+
+1. Clarify the goal (brand monitoring, competitor research, sentiment, etc.).
+2. Run `trudax/reddit-scraper-lite` to discover relevant Reddit discussions, sentiment, and links.
+3. Review the results and pull out the most useful URLs mentioned in posts and comments.
+4. (Optional but recommended) Chain to `apify/website-content-crawler` to crawl the best linked pages for full content.
+5. Synthesize the findings: Reddit sentiment + source material.
+6. Deliver a clear summary and offer the raw datasets.
+
+## Main Actor Usage
+
+This skill primarily uses two Actors in sequence:
+
+1. `trudax/reddit-scraper-lite` — Discover relevant Reddit discussions and extract URLs.
+2. `apify/website-content-crawler` — Enrich the most promising linked articles found in those discussions.
+
+### Recommended input patterns for the Reddit discovery Actor (Step 1)
+
+**Tip for brand monitoring:** Broad keywords (e.g. "Claude AI") frequently return noisy/old/irrelevant results (game characters, people named Claude in old politics threads, etc.). Recent live tests showed this clearly. Always prefer:
+- Specific subreddits via `startUrls`
+- Tighter phrases + negative/positive keywords
+- Time filters (`time: "week"` or `time: "month"`)
+
+**1. Keyword search across Reddit (most common starting point)**
+```json
+{
+  "searches": ["Claude AI OR Anthropic"],
+  "searchPosts": true,
+  "searchComments": true,
+  "sort": "relevance",
+  "time": "week",
+  "maxItems": 100,
+  "includeNSFW": false
+}
+```
+
+**2. Targeted subreddit monitoring (usually cleaner results)**
+```json
+{
+  "startUrls": [{ "url": "https://www.reddit.com/r/singularity/" }],
+  "maxPostCount": 30,
+  "maxItems": 80
+}
+```
+
+**3. Negative sentiment / complaints about a brand**
+```json
+{
+  "searches": ["Claude AI (bad OR sucks OR disappointed OR scam OR worse)"],
+  "searchPosts": true,
+  "searchComments": true,
+  "sort": "relevance",
+  "time": "month",
+  "maxItems": 50
+}
+```
+
+**4. Specific post + full comment thread**
+```json
+{
+  "startUrls": [{ "url": "https://www.reddit.com/r/..." }],
+  "maxComments": 200
+}
+```
+
+### Chaining the Second Actor (Website Content Enrichment)
+
+After running the Reddit discovery Actor, you will often find high-value URLs in the posts and comments (articles, reviews, company pages, etc.). You can optionally chain to the second Actor to crawl those pages for deeper context.
+
+**Concrete example:**
+
+```bash
+# Step 2: Enrich a linked article found in Reddit results
+apify actors call apify/website-content-crawler \
+  -i '{
+    "startUrls": [{"url": "https://www.anthropic.com/news/claude-3-5-sonnet"}],
+    "maxCrawlPages": 2
+  }' \
+  --user-agent apify-awesome-skills/apify-reddit-research \
+  --json 2>/dev/null
+```
+
+**Why this two-Actor chain is valuable:**
+- The Reddit Actor captures community sentiment and surfaces the links people are actually sharing.
+- The Website Crawler pulls the real source content behind those links.
+- Combined, the agent gets both the social discussion and the underlying material — much stronger than Reddit data alone for brand monitoring and competitive research.
+
+### Option B & C (MCP)
+
+Both Actors work via the [Apify MCP connector](https://mcp.apify.com) or `mcpc`.
+
+## Cost & Limits
+
+- The Reddit Actor is pay-per-result (~$3.40 per 1,000 items stored).
+- The Website Crawler adds extra cost only when you choose to use it.
+- Always set sensible limits (`maxItems`, `maxPostCount`, `maxComments`).
+- Warn the user before large or deep comment-heavy runs.
+- Residential proxies are enabled by default.
+
+## Common Pitfalls & Gotchas
+
+- **The scraper is often flaky.** In live testing, multiple runs returned "0 succeeded" even with small limits. This is common with Reddit actors. Always inspect the run after it finishes.
+- You can be charged ~$0.04 (actor start fee) **even when you get zero results**.
+- `status: "SUCCEEDED"` does **not** guarantee good data. Check `statusMessage` and the number of successful vs failed requests.
+- Reddit is aggressive with rate limiting. Large or very fast scrapes can still fail even with residential proxies.
+- NSFW content is included by default. Always set `"includeNSFW": false` for professional/brand work unless the user specifically wants it.
+- Comments can explode in size. Use `maxComments` and `skipComments: true` when you only need the posts.
+- `maxItems` is the global limit. `maxPostCount` and `maxComments` control per-page depth.
+- Very new or niche topics often return few results — try broader keywords or different time filters.
+- Deleted/removed posts and comments are common on Reddit.
+
+See [references/gotchas.md](references/gotchas.md) for detailed error handling and retry strategies.
+
+## Output Guidance
+
+The Actor returns rich structured data (posts, comments, scores, authors, dates, URLs, etc.).
+
+**Never** just dump hundreds of raw items to the user. Instead:
+- Summarize the main themes and sentiment
+- Show top posts with scores and links
+- Offer to export the full dataset as CSV or JSON when they need the raw data
+- Include the Apify dataset URL for transparency
+
+**When the run returns little or no data** (very common):
+- Always show the user the exact `statusMessage` (e.g. "Finished! Total 12 requests: 1 succeeded, 11 failed.").
+- Explain that Reddit scrapers are frequently flaky and that getting 0 results or mostly failed requests does **not** mean the brand has no discussion.
+- Offer 2-3 concrete retry options:
+  - Use a more specific subreddit (e.g. r/singularity instead of broad search)
+  - Tighten or broaden the keyword
+  - Switch to `startUrls` for a specific subreddit or post
+  - Remove the `time` filter
+- Share the `consoleUrl` so they can inspect it themselves.
+- Be transparent: "This Actor often has bad runs. This is normal behavior on Reddit scrapers."

--- a/skills/apify-reddit-research/examples/example-brand-monitoring.md
+++ b/skills/apify-reddit-research/examples/example-brand-monitoring.md
@@ -1,0 +1,50 @@
+# Example: Brand Monitoring on Reddit
+
+## Goal
+The user wants to understand recent sentiment around "Claude AI" on Reddit, including what articles people are linking to.
+
+## Step 1 — Reddit Discovery
+
+```bash
+apify actors call trudax/reddit-scraper-lite \
+  -i '{
+    "searches": ["Claude AI OR Anthropic"],
+    "searchPosts": true,
+    "searchComments": true,
+    "sort": "relevance",
+    "time": "week",
+    "maxItems": 100
+  }' \
+  --user-agent apify-awesome-skills/apify-reddit-research \
+  --json 2>/dev/null
+```
+
+**Typical output highlights (from real runs):**
+- Posts and comments mentioning the brand (note: broad keywords can sometimes surface older/irrelevant threads)
+- Upvote counts and engagement
+- Links to articles, reviews, or comparisons being shared
+
+**Tip from testing:** Using more specific subreddits or tighter queries often yields cleaner, more relevant results.
+
+## Step 2 — (Optional) Enrich Key Links
+
+From the Reddit results, pick the most relevant URLs (e.g. a detailed review or announcement) and crawl them:
+
+```bash
+apify actors call apify/website-content-crawler \
+  -i '{
+    "startUrls": [{"url": "https://www.anthropic.com/news/claude-3-5-sonnet"}],
+    "maxCrawlPages": 2
+  }' \
+  --user-agent apify-awesome-skills/apify-reddit-research \
+  --json 2>/dev/null
+```
+
+## Final Deliverable
+The agent can now provide:
+- Summary of recent sentiment on Reddit
+- Key themes from discussions
+- Context from the actual articles people are sharing
+- Links + engagement data for the most important threads
+
+This two-step approach gives much richer output than Reddit data alone.

--- a/skills/apify-reddit-research/references/actor-index.md
+++ b/skills/apify-reddit-research/references/actor-index.md
@@ -1,0 +1,26 @@
+# Actor index — apify-reddit-research
+
+This skill uses a two-Actor chain optimized for brand and topic monitoring on Reddit:
+
+| Step | Actor ID | Purpose | Recommended for |
+|------|----------|---------|-----------------|
+| 1 | `trudax/reddit-scraper-lite` | Discover posts, comments, sentiment, and links from Reddit | Primary step for almost all use cases |
+| 2 (optional) | `apify/website-content-crawler` | Crawl and extract content from the most relevant URLs found in Reddit threads | Deeper research when you need the actual articles/reviews being discussed |
+
+## Common patterns
+
+- Brand monitoring → Reddit discovery + selective page crawling
+- Competitor analysis → Focus on specific subreddits + enrichment of key links
+- Trend research → Broad searches + follow high-engagement links
+
+## How to extend
+
+1. Search for candidates: `apify actors search "reddit" --json --limit 10 2>/dev/null`
+2. Fetch input schema: `apify actors info "trudax/reddit-scraper-lite" --input --json 2>/dev/null`
+3. Test small runs before adding new routing.
+
+Primary documentation:
+- https://apify.com/trudax/reddit-scraper-lite
+- https://apify.com/apify/website-content-crawler
+
+For a more advanced reference, see the official Apify agent-skills ultimate-scraper.

--- a/skills/apify-reddit-research/references/gotchas.md
+++ b/skills/apify-reddit-research/references/gotchas.md
@@ -1,0 +1,59 @@
+# Gotchas — apify-reddit-research
+
+Cost guardrails, error recovery, and Reddit-specific pitfalls.
+
+## Cost guardrails
+
+`trudax/reddit-scraper-lite` uses **PAY_PER_EVENT** pricing.
+
+- ~$3.40 per 1,000 results stored
+- Cost is driven mainly by `maxItems`, `maxPostCount`, and `maxComments`
+
+### Recommended confirmation thresholds
+
+- Expected cost **>$6** → warn the user and show rough estimate
+- Expected cost **>$15** → require explicit confirmation before running
+- Always be conservative — Reddit threads can grow quickly
+
+## Common errors & fixes (based on live testing)
+
+| Error / Symptom | Likely Cause | Fix / What to tell the user |
+|-----------------|--------------|-----------------------------|
+| Run finishes with "0 succeeded, X failed" (even if status = SUCCEEDED) | Reddit blocking or temporary Actor issues | Very common. In recent tests we saw runs with only 1 success out of 12 requests. Show the consoleUrl. Offer retries with tighter subreddit focus or different keywords. |
+| Dataset is empty (0 items stored) even on "SUCCEEDED" | Actor could not extract data | You may still pay the ~$0.04 startup fee. Be honest: "The scraper had a bad run — this happens often." |
+| Very few or zero relevant results | Broad keywords matching old/unrelated threads (e.g. people named "Claude" in old posts) | Use more specific queries, add subreddit restrictions via startUrls, or add time filters. Broad brand names are noisy. |
+| Run takes very long or times out | Huge comment threads or very large subreddit | Lower `maxComments` and `maxPostCount`. Use `skipComments: true` if comments not needed |
+| 403 / rate limit errors | Aggressive scraping or datacenter proxies | The Actor defaults to residential proxies. Retry later with smaller limits. |
+| NSFW content appearing | `includeNSFW` defaults to true | Explicitly set `"includeNSFW": false` for brand/professional work |
+| Duplicate or weird data | Mixing search + startUrls incorrectly | Prefer one method per run (either `searches` or `startUrls`) |
+
+## Actor-specific notes for `trudax/reddit-scraper-lite`
+
+- **Comments explode fast**: One popular post can return thousands of comments. Always cap with `maxComments`.
+- **Subreddit URLs**: Use clean URLs like `https://www.reddit.com/r/saas/` (no trailing paths needed for most cases).
+- **Search vs startUrls**: 
+  - Use `searches` for open research across Reddit.
+  - Use `startUrls` when the user gives you a specific subreddit or post.
+- **Deleted content**: Expect missing posts and comments. Reddit removes a lot.
+- **Date filters**: `time` only applies to post searches. Use `postDateLimit` / `commentDateLimit` for more precise control when needed.
+
+## Interpreting run results (very important)
+
+After every run, look at these fields in the output:
+
+- `statusMessage`: Often says things like "Finished! Total 1 requests: 0 succeeded, 1 failed." This is the most honest signal.
+- `chargedEventCounts.result`: How many items you actually paid for. 0 is common during flaky periods.
+- `consoleUrl`: Always share this with the user when things go wrong — they can see the detailed log.
+
+**Real pattern observed in testing (May 2026):** Multiple small runs returned 0 results and "0 succeeded" even with conservative settings. In these cases:
+- Be honest with the user immediately.
+- Offer 2–3 retry options (different keywords, subreddit instead of search, remove time filter, lower limits).
+- Mention that Reddit scrapers frequently go through periods of high failure rates.
+
+If the user needs reliable data right now, consider suggesting they check the Actor's page on the Apify Store for recent run success rates.
+
+## Output quality tips
+
+- Always summarize themes + sentiment instead of raw dumping.
+- When user wants the full data, save as CSV/JSON and give them the file + the Apify dataset console link.
+- Include key fields: title, score, subreddit, author, created, url, comment count.


### PR DESCRIPTION
## Summary

Adds `apify-reddit-research`, a skill for researching discussions, sentiment, and trends on Reddit with an optional second step to enrich linked web pages.

## Key Features

- **Primary Actor**: `trudax/reddit-scraper-lite` for discovering posts, comments, and sentiment across Reddit (supports keyword search, specific subreddits, user profiles, and individual posts).
- **Optional second Actor**: `apify/website-content-crawler` to crawl and extract content from the most relevant articles/reviews linked in Reddit threads.
- Strong focus on practical brand and competitor monitoring use cases.
- Includes detailed guidance on handling the common flakiness of Reddit scrapers and how to craft effective queries.
- Real testing insights included in the gotchas.

## Why this skill?

Many users want to understand what people are actually saying about brands, products, or topics on Reddit. This skill gives agents both the social conversation layer *and* (optionally) the source content behind the links being shared.

## Testing

- Multiple real runs performed with the Reddit Actor (including keyword searches and subreddit monitoring).
- Tested the two-Actor chaining pattern.
- All telemetry requirements followed (`--user-agent`, `--json`, `2>/dev/null`).

## Checklist

- [x] Follows CONTRIBUTING.md rules
- [x] Telemetry lint passes
- [x] Chains two Actors (as recommended for higher-quality skills)
- [x] Clear trigger phrases and practical workflow
- [x] Includes free-plan considerations and common failure modes

