### PR TITLE
Create tech stack prospecting skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -185,6 +185,26 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-tech-stack-prospecting",
+      "source": "./skills/apify-tech-stack-prospecting",
+      "skills": "./",
+      "description": "Discover and qualify B2B prospects by their tech stack. Chains Google Search signal queries to find companies using specific technologies, contact-info scraping to extract decision-maker emails and phones, and LinkedIn company enrichment to add firmographic data (size, industry, headcount).",
+      "keywords": [
+        "b2b",
+        "prospecting",
+        "tech-stack",
+        "lead-generation",
+        "firmographics",
+        "linkedin",
+        "google-search",
+        "contact-scraping",
+        "devtools",
+        "sales-intelligence"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-tech-stack-prospecting/SKILL.md
+++ b/skills/apify-tech-stack-prospecting/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: apify-tech-stack-prospecting
+description: >-
+  Discover and qualify B2B prospects by their tech stack. Chains Google Search signal queries to find companies using specific technologies, contact-info scraping to extract decision-maker emails and phones, and LinkedIn company enrichment to add firmographic data (size, industry, headcount). Use when user asks to find companies using a specific framework or tool, build a prospect list by technology, identify companies by language or framework, find companies integrating AI into their products, locate devtools customers, qualify engineering leads by stack, or wants a list of companies to reach out to based on what they're built on.
+---
+
+# Tech Stack Prospecting
+
+Discover companies by what they're built on, extract contact information from their sites, and enrich with firmographic data — producing a qualified B2B prospect list in a single pipeline run.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## Workflow
+
+1. **Clarify the target.** Ask the user for their primary technology signal (e.g., "Ruby on Rails"), a secondary qualifier (e.g., "hiring AI engineers", "uses OpenAI"), geography, and desired output format (quick preview, CSV, or JSON).
+2. **Discover companies via search signals.** Build Google Search queries that surface companies *using* the stack — job postings, engineering blogs, GitHub READMEs — and run `apify/google-search-scraper`. Extract unique root domains from results; discard job boards, news sites, and directories.
+3. **Extract contact information.** Feed the domain list into `vdrmota/contact-info-scraper`, crawling `/about`, `/contact`, and `/team` pages at depth 2. Capture emails, phones, and LinkedIn company URLs.
+4. **Enrich with firmographics.** Pass LinkedIn company URLs from step 3 into `apify/linkedin-companies-scraper` to get company name, industry, headcount, and headquarters.
+5. **Merge and deliver.** Join the three datasets on domain. Report count, file location, and top prospects. Warn the user before running enrichment on more than 100 companies — costs scale linearly.
+
+For a worked 4-step workflow, see [apify/agent-skills ultimate-scraper](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/SKILL.md).
+
+## Actor routing
+
+| User need | Actor ID | Tier | Best for |
+|-----------|----------|------|----------|
+| Discover companies via tech/hiring signal queries | `apify/google-search-scraper` | apify | Surfacing company domains from job postings, engineering blogs, GitHub READMEs |
+| Extract emails, phones, and social links from company sites | `vdrmota/contact-info-scraper` | community | Crawling `/about`, `/contact`, `/team` pages for direct contact info |
+| Add company size, industry, and headcount | `apify/linkedin-companies-scraper` | apify | Firmographic enrichment from LinkedIn company pages |
+
+`Tier` = `apify` (Apify-maintained, prefer) or `community` (third-party).
+
+### Signal query templates
+
+Construct Google Search queries that surface companies **using** the technology, not articles *about* it:
+
+| Signal type | Query template |
+|-------------|---------------|
+| Job posting signal | `site:linkedin.com/jobs "TECH" "ROLE"` |
+| Engineering blog signal | `"built with TECH" OR "we use TECH" engineering blog` |
+| GitHub README signal | `site:github.com "TECH" "SECONDARY_TECH" README` |
+| Direct stack mention | `"powered by TECH" OR "built on TECH" site:*.io OR site:*.com` |
+
+Run 3–5 queries per stack signal. 25–50 results per query is a safe default.
+
+### Merged output columns
+
+| Column | Source Actor |
+|--------|-------------|
+| `domain` | `apify/google-search-scraper` |
+| `discovery_signal` | `apify/google-search-scraper` (which query surfaced it) |
+| `emails` | `vdrmota/contact-info-scraper` |
+| `phones` | `vdrmota/contact-info-scraper` |
+| `linkedin_url` | `vdrmota/contact-info-scraper` |
+| `company_name` | `apify/linkedin-companies-scraper` |
+| `industry` | `apify/linkedin-companies-scraper` |
+| `employee_count` | `apify/linkedin-companies-scraper` |
+| `headquarters` | `apify/linkedin-companies-scraper` |
+
+## Calling Actors — choose your interface
+
+Skills in this repo can call Actors via any of these interfaces. Pick the one that fits your runtime; cross-tool compatibility is your responsibility.
+
+### Option A: Apify CLI (recommended for portability)
+
+Works in any shell-capable agent. Three flags on every call:
+
+    apify actors call "ACTOR_ID" -i 'JSON_INPUT' \
+      --json \
+      --user-agent apify-awesome-skills/apify-tech-stack-prospecting \
+      2>/dev/null
+
+| Flag | Why |
+|------|-----|
+| `--json` | Stable machine-readable output |
+| `--user-agent` | Apify telemetry attribution |
+| `2>/dev/null` | Suppress progress messages that break JSON |
+
+Other useful commands:
+
+    # Search Actors
+    apify actors search "KEYWORDS" --json --limit 10 2>/dev/null
+
+    # Fetch Actor schema
+    apify actors info "ACTOR_ID" --input --json \
+      --user-agent apify-awesome-skills/apify-tech-stack-prospecting 2>/dev/null
+
+    # Fetch results
+    apify datasets get-items DATASET_ID --format json \
+      --user-agent apify-awesome-skills/apify-tech-stack-prospecting 2>/dev/null
+
+For the canonical command set with all flags, see [apify/agent-skills ultimate-scraper](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/SKILL.md).
+
+### Option B: Apify MCP connector
+
+Hosted MCP server at <https://mcp.apify.com>. Documented at <https://docs.apify.com/platform/integrations/mcp>.
+
+### Option C: MCP client of your choice (e.g. `mcpc`)
+
+Standalone CLI client. See <https://github.com/apify/mcpc>.
+
+## Troubleshooting
+
+- `APIFY_TOKEN not found` → Create a `.env` file with `APIFY_TOKEN=your_token` or run `apify login`
+- `0 results from Google Search scraper` → Broaden queries; remove `site:` restrictions; try alternate signal types from the query template table above
+- `No emails found by contact scraper` → Company may use contact forms only; use the extracted `linkedin_url` for manual outreach
+- `LinkedIn scraper rate-limited or blocked` → Reduce batch size to 20–30 companies; spread runs over time
+- `Actor not found` → Actor IDs are case-sensitive; verify spelling before retrying
+- For detailed cost guardrails and recovery, see [references/gotchas.md](references/gotchas.md)

--- a/skills/apify-tech-stack-prospecting/SKILL.md
+++ b/skills/apify-tech-stack-prospecting/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: apify-tech-stack-prospecting
+author: Wilbur Suero
+author_url: https://github.com/wilburhimself
 description: >-
   Discover and qualify B2B prospects by their tech stack. Chains Google Search signal queries to find companies using specific technologies, contact-info scraping to extract decision-maker emails and phones, and LinkedIn company enrichment to add firmographic data (size, industry, headcount). Use when user asks to find companies using a specific framework or tool, build a prospect list by technology, identify companies by language or framework, find companies integrating AI into their products, locate devtools customers, qualify engineering leads by stack, or wants a list of companies to reach out to based on what they're built on.
 ---

--- a/skills/apify-tech-stack-prospecting/references/actor-index.md
+++ b/skills/apify-tech-stack-prospecting/references/actor-index.md
@@ -1,0 +1,39 @@
+# Actor index — apify-tech-stack-prospecting
+
+Comprehensive Actor routing table for the three-stage discovery → contact → enrichment pipeline.
+
+| Stage | User intent | Actor ID | Tier | Notes |
+|-------|-------------|----------|------|-------|
+| Discovery | Find companies via tech/hiring signal queries | `apify/google-search-scraper` | apify | Core discovery step; returns organic SERP results. Use `resultsPerPage: 25–50`, `maxPagesPerQuery: 1–2`. PAY_PER_EVENT (per result page). |
+| Contact | Extract emails, phones, and social links from company websites | `vdrmota/contact-info-scraper` | community | Crawls `/about`, `/contact`, `/team` at depth 2. Set `maxDepth: 2` and `maxPagesPerCrawl: 20` to bound cost. PAY_PER_EVENT (per page crawled). |
+| Enrichment | Add company name, industry, headcount, HQ from LinkedIn | `apify/linkedin-companies-scraper` | apify | Input: `companyUrls` array of LinkedIn company page URLs (not profile URLs). PAY_PER_EVENT (per company). Cap batches at 30 to avoid blocks. |
+
+`Tier` = `apify` (Apify-maintained, prefer) or `community` (third-party).
+
+## Signal query construction
+
+The discovery stage quality depends entirely on the queries. Use the templates from `SKILL.md`; key rules:
+
+- Combine a **tech signal** ("uses Rails", "built with Next.js") with an **intent qualifier** ("hiring", "engineering blog", "GitHub") to filter out tutorial sites.
+- Use `site:` restrictions only when precision matters more than volume — they significantly reduce result count.
+- 3–5 queries per technology signal, 25–50 results each, is the cost-efficient default before committing to broader sweeps.
+
+## How to inspect Actor schemas
+
+```bash
+# Fetch input schema for any Actor
+apify actors info "ACTOR_ID" --input --json \
+  --user-agent apify-awesome-skills/apify-tech-stack-prospecting 2>/dev/null
+
+# Search for alternative Actors if a tier-1 choice is unavailable
+apify actors search "contact scraper email" --json --limit 10 2>/dev/null
+```
+
+## Alternative Actors
+
+If `vdrmota/contact-info-scraper` is unavailable or underperforms on a target domain:
+
+| Alternative | Actor ID | When to prefer |
+|-------------|----------|----------------|
+| General site crawler with email extraction | `apify/website-content-crawler` | When contact pages are JavaScript-rendered |
+| Email extractor only | `apify/email-address-scraper` | Faster when you only need emails, no phones |

--- a/skills/apify-tech-stack-prospecting/references/gotchas.md
+++ b/skills/apify-tech-stack-prospecting/references/gotchas.md
@@ -1,0 +1,56 @@
+# Gotchas — apify-tech-stack-prospecting
+
+Cost guardrails, error recovery, and Actor-specific pitfalls for the three-stage pipeline.
+
+## Cost guardrails
+
+All three Actors use `PAY_PER_EVENT` pricing. Confirm before running any stage that involves more than ~50 inputs.
+
+| Stage | Actor | Unit billed | Typical run | Warn threshold |
+|-------|-------|-------------|-------------|----------------|
+| Discovery | `apify/google-search-scraper` | per result page | 5 queries × 50 results = ~3 pages each ≈ 15 page-loads | >50 queries |
+| Contact | `vdrmota/contact-info-scraper` | per page crawled | 100 domains × 20 pages/domain = 2 000 pages | >100 domains |
+| Enrichment | `apify/linkedin-companies-scraper` | per company scraped | 1 unit per company URL | >100 companies |
+
+Check live rates before quoting: `apify actors info "ACTOR_ID" --json 2>/dev/null` → `pricingInfo` field.
+
+### Confirmation thresholds
+
+- Estimated cost **>$5** → warn the user and show the estimate.
+- Estimated cost **>$20** → require explicit confirmation before running.
+- Present all estimates as rough ("around $X"), never as guarantees.
+- Enrichment on >100 companies scales linearly and can become expensive quickly — always call this out explicitly.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `APIFY_TOKEN not found` | Missing env var or `.env` file | Run `apify login` or set `APIFY_TOKEN=<token>` in the environment |
+| Google Search scraper returns 0 results | Queries too narrow (`site:` restrictions + long phrases) | Remove `site:` filters; broaden the query; try alternate signal types from the query table |
+| Contact scraper returns 0 emails for a domain | Company uses contact forms, Cloudflare, or auth-gated pages | Use the `linkedin_url` from the same run for manual or MCP-based outreach |
+| LinkedIn scraper rate-limited or returns 429 | Too many company URLs in one batch; LinkedIn session throttle | Reduce batch to 20–30 companies; wait 10–15 min between batches |
+| `Actor not found` error | Actor ID typo or the community actor was removed | IDs are case-sensitive; verify with `apify actors search` before retrying |
+| Dataset missing after run | Run did not reach `SUCCEEDED` status | Check run status: `apify runs info RUN_ID --json 2>/dev/null`; inspect logs in console |
+
+## Actor-specific notes
+
+### `apify/google-search-scraper`
+
+- Keep `resultsPerPage` ≤ 50 for the discovery stage; 100 is allowed but rarely improves domain quality for this use case.
+- Set `maxPagesPerQuery: 1` on the first pass; bump to 2 only if the first page yielded fewer than 10 unique root domains.
+- Deduplicate results by root domain immediately — the same company often appears on multiple SERP positions.
+- Discard known noise domains: job boards (`linkedin.com`, `indeed.com`, `glassdoor.com`), news aggregators, Wikipedia, and developer docs sites.
+
+### `vdrmota/contact-info-scraper`
+
+- **Always cap `maxDepth: 2` and `maxPagesPerCrawl: 20`** — without these limits a single domain can crawl thousands of pages.
+- Pages behind login walls, Cloudflare JS challenges, or requiring cookies are silently skipped; expect partial results on enterprise sites.
+- The scraper extracts emails from `mailto:` links and plain-text patterns. Obfuscated emails (e.g. `name [at] company [dot] com`) are not extracted.
+- Social profiles (`linkedin_url`) are extracted from `<a href="https://linkedin.com/company/...">` links; these are the input for the enrichment stage.
+
+### `apify/linkedin-companies-scraper`
+
+- Input must be **company page URLs** (`linkedin.com/company/...`), not person profile URLs (`linkedin.com/in/...`). Passing profile URLs silently returns no data.
+- LinkedIn blocks scrapers aggressively. If >5 consecutive companies return empty results, stop and retry after 15–30 minutes.
+- `employee_count` is a LinkedIn-reported estimate and often rounded (e.g., "51–200"). Treat as a firmographic signal, not an exact headcount.
+- The scraper does not return individual contact names or emails — it provides company-level firmographics only.


### PR DESCRIPTION
## Skill

- **Name:** `apify-tech-stack-prospecting`
- **What it does:** Discovers B2B prospects by tech stack — chains Google Search signal queries to surface companies using a specific technology, extracts decision-maker contact info, and enriches each company with LinkedIn firmographics (size, industry, headcount).
- **Author:** Wilbur Suero

## Checklist

- [x] PR adds **one** skill in `skills/apify-tech-stack-prospecting/` (no other file changes except `.claude-plugin/marketplace.json`)
- [x] `SKILL.md` frontmatter has `name` (matches folder, `apify-` prefix) and `description` (≤ 1024 chars)
- [x] Added entry to `.claude-plugin/marketplace.json`
- [x] Tested the skill end-to-end at least once

## Notes

Three-stage pipeline: `apify/google-search-scraper` (discovery) → `vdrmota/contact-info-scraper` (contact extraction) → `apify/linkedin-companies-scraper` (firmographic enrichment). Each stage feeds the next via domain/LinkedIn URL. Reference files cover Actor routing, cost guardrails, and per-Actor pitfalls.

<!-- Optional: design decisions, links to similar skills, anything reviewers should know -->
