### PR TITLE
Add apify-jobs-data skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,6 +10,33 @@
   },
   "plugins": [
     {
+      "name": "apify-jobs-data",
+      "source": "./skills/apify-jobs-data",
+      "skills": "./",
+      "description": "Extract clean, de-noised job-posting data from LinkedIn, Indeed, Glassdoor, Google Jobs, and 20+ boards in one Apify run — deduplicated across boards with ghost jobs and reposts removed and fields normalized — then analyze it (hiring demand, in-demand skills, salary distribution), export it (CSV / JSON / Apify dataset) for dashboards and BI, or rank it against a résumé. Every Actor is pay-per-result (no subscriptions): the agentx/all-jobs-scraper aggregator (default, covers LinkedIn/Indeed/Glassdoor/Google cheaply), optional misceres Indeed, and optional memo23 Glassdoor salary benchmark.",
+      "keywords": [
+        "jobs",
+        "job-data",
+        "job-postings",
+        "job-scraping",
+        "hiring-demand",
+        "salary",
+        "skills-in-demand",
+        "market-analysis",
+        "dataset-export",
+        "ghost-jobs",
+        "resume-fit",
+        "linkedin-jobs",
+        "indeed",
+        "glassdoor",
+        "google-jobs",
+        "data-extraction",
+        "apify"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
       "name": "apify-easy-competitive-intelligence",
       "source": "./skills/apify-easy-competitive-intelligence",
       "skills": "./",

--- a/skills/apify-jobs-data/SKILL.md
+++ b/skills/apify-jobs-data/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: apify-jobs-data
+description: Extract clean, de-noised job-posting data from LinkedIn, Indeed, Glassdoor, Google Jobs, and 20+ boards in one Apify run — deduplicated across boards with ghost jobs and reposts removed and fields normalized — then analyze it (deduped hiring demand, in-demand skills, coverage-labeled salary distribution), export it (CSV / JSON / Apify dataset) for dashboards and BI, or rank it against a résumé. Use when the user asks to scrape job postings, build a job dataset, analyze hiring demand or in-demand skills or salary ranges for a role or market, export job data for a dashboard or spreadsheet, dedupe job listings across boards, filter out ghost or fake jobs, or rank jobs by fit to a résumé. Triggers - "scrape job postings for X", "what skills are in demand for Y", "salary range for Z in [location]", "export job data to CSV", "filter out the ghost jobs", "which of these jobs fit my résumé".
+author: Oleg Martinez
+author_url: https://github.com/ezumyn-aliegm
+---
+
+# Jobs Data
+
+Extract clean, structured job-posting data from 20+ boards in one Apify run, then put
+it to use. The pipeline is the same regardless of purpose:
+
+**acquire → de-noise → normalize → { analyze | export | rank by résumé }**
+
+The reusable value is the cleaned dataset: postings deduplicated across boards, with
+ghost jobs and reposts removed and fields normalized to a consistent schema. Ghost-job
+and repost pollution corrupts demand counts, salary statistics, and dashboards just as
+much as it wastes a job seeker's time — so de-noise is the shared core, and every
+output mode runs on top of it.
+
+**Never invent a posting, a salary, a count, or a keyword.** Everything is scraped
+live from a named Apify Actor and carries its source; missing fields stay blank, and
+every statistic reports the share of postings it is computed from — see
+[Quality rules](#quality-rules).
+
+Ghost-job and repost detection is the part that depends on scraping rather than the
+LLM: it compares the same job description across boards and tracks re-stamped posting
+dates. The Actors do the data work; the agent routes, de-noises, aggregates, and grounds:
+
+| Step | Apify Actor | Agent |
+|---|---|---|
+| Acquire across 20+ boards | `agentx/all-jobs-scraper` | routes the query |
+| De-noise ghost jobs / reposts | cross-board scraped fields — first-seen date, re-stamp history, JD-body match across "company" names | applies the rule |
+| Salary benchmark (optional) | `memo23/glassdoor-scraper-ppr` | aggregates, labels coverage |
+
+## Note on overlap with analysis-first job skills
+
+A more analysis-first skill may also answer "hiring demand / in-demand skills /
+salary" questions. This skill's center of gravity is the **cleaned dataset** — ghost
+jobs, reposts, and cross-board duplicates removed and fields normalized — which every
+mode then runs on. If you only need a quick market read, an analysis-only skill is
+lighter. Reach for this one when **data quality matters** (deduped demand counts,
+coverage-labeled salary stats), when you need the **raw rows exported** to CSV / an
+Apify dataset for a dashboard, or when you need a **résumé ranked** against live
+postings — none of which an analysis-only skill produces.
+
+## Output modes — pick one or more
+
+The shared core (Steps 1–5) is identical; Step 6 produces whichever mode(s) the user
+wants. Default to whatever the request implies; if unclear, ask.
+
+| Mode | Produces | Reference |
+|---|---|---|
+| **Market & salary analysis** | hiring demand on **deduped** counts (by company / location / seniority), in-demand skills, remote-hybrid mix, and **coverage-labeled** salary distribution | [reference/analysis.md](reference/analysis.md) |
+| **Structured export** | the normalized rows as CSV / JSON, or the raw Apify dataset ID for direct BI / dashboard ingestion | [reference/output-formats.md](reference/output-formats.md) |
+| **Résumé-fit** | postings ranked against a résumé, with ATS-keyword gaps and apply-ready briefs | [reference/fit-scoring.md](reference/fit-scoring.md) |
+
+## Cost discipline (best quality for the lowest cost)
+
+This is a design goal, not an afterthought — keep every run as cheap as it can be
+while still answering the question:
+
+- **One cheap actor, no subscriptions.** Default to the pay-per-result aggregator
+  (~$0.0023/job). A typical run is **cents** (a live 60-job test billed $0.18).
+- **Smallest sample that answers it.** `max_results` is *per board* (×~6 boards), so
+  start small — a quick scan needs ~10–15/board; a market analysis ~25–50/board — and
+  scale only if the result is too thin. Always estimate, and confirm before a big run.
+- **One run feeds every mode.** Analysis, export, and résumé-fit all read the *same*
+  scrape — never re-scrape to add a second mode.
+- **De-noise so you never pay for junk.** Removing ghost jobs / reposts / duplicates
+  keeps the billed sample honest and the counts real.
+- **For salary, prefer the Glassdoor benchmark over a mega-scrape.** Salary disclosure
+  is low (~2–6% in many markets), so scraping thousands of postings to harvest a few
+  disclosed figures is wasteful — one cheap `memo23/glassdoor-scraper-ppr` call per
+  company gives a better signal for less.
+
+## Prerequisites
+(No need to check this upfront.)
+
+Two execution paths — pick the one that matches your environment.
+
+**MCP path (default in an agent session with MCP, recommended).** If the Apify MCP
+server is connected, no setup is needed — auth runs through the user's Apify account.
+Use the `call-actor`, `get-actor-run`, and `get-dataset-items` MCP tools.
+
+**CLI path (scripted / non-interactive execution).** Requires the
+[Apify CLI](https://docs.apify.com/cli) v1.5.0+ and auth via `apify login` or an
+`APIFY_TOKEN` env var ([get a token](https://console.apify.com/settings/integrations)).
+Every CLI call in this skill carries three flags — `--json`,
+`--user-agent apify-awesome-skills/apify-jobs-data`, and `2>/dev/null`.
+
+**Responsible use.** These Actors scrape third-party boards (LinkedIn, Glassdoor,
+Indeed, Google Jobs) against those sites' Terms of Service — the user's call to make.
+All routes run on Apify's infrastructure (no user login), so they never put the
+user's own board accounts at risk.
+
+## Workflow
+
+Copy this checklist and track progress.
+
+```
+Task Progress:
+- [ ] Step 0: Pick the output mode(s)
+- [ ] Step 1: Collect the query anchors (one block)
+- [ ] Step 2: Route to the right board Actor(s) (primary + fallback)
+- [ ] Step 3: Build the input, estimate cost, confirm if over threshold
+- [ ] Step 4: Run, wait, pull the dataset
+- [ ] Step 5: De-noise + normalize into clean rows
+- [ ] Step 6: Produce the selected mode(s) — analysis / export / résumé-fit
+- [ ] Step 7: Deliver, with provenance and coverage
+```
+
+### Step 0: Pick the output mode(s)
+
+Decide what the user wants *done with the data* — it changes only Step 6, not the
+shared core. Infer from the request; confirm if ambiguous:
+
+- "what skills/salary/demand for X", "job-market for Y" → **Market & salary analysis**.
+- "scrape / export / give me a dataset / CSV for a dashboard" → **Structured export**.
+- "which of these fit my résumé", "rank these for me" → **Résumé-fit** (needs a résumé; anchor #7).
+- Multiple are fine — e.g. analysis + export of the same run.
+
+### Step 1: Collect the query anchors
+
+Ask these as **one block** before any Actor call. Defaults shown — always surface
+them so the user can override. (Anchor-block pattern from `apify-verified-email-finder`.)
+
+1. **Role / keywords** — e.g. `senior backend engineer`. Required.
+2. **Location** — city, country, or `remote`. Required. `remote` flips the remote-only filter on.
+3. **Boards** — `auto` (default → aggregator, all major boards) or a named subset (`linkedin`, `indeed`, `glassdoor`, `google`). Drives Step 2.
+4. **Result cap** — for the aggregator this is **per board** (`max_results: 25` ≈ 150 rows across ~6 boards), **minimum 10**. Start small (`10–15` for a quick scan, `25–50` for analysis) and scale only if the sample is too thin — it's the main cost lever, so budget `max_results × boards` ([Cost discipline](#cost-discipline-best-quality-for-the-lowest-cost), Step 3). Maps to each Actor's own field (`max_results` / `maxItems` / `rows` — actor-index.md).
+5. **Recency window** — default `2 weeks`. The aggregator takes this as a natural-language string (`"2 weeks"`, `"1 month"`), not a day count.
+6. **Filters** — optional constraints that *drop* a posting: `salary_floor`, `remote_only`, `job_type` (full-time / contract / internship). Collect what the user volunteers.
+7. **Résumé / profile** — *only for résumé-fit mode*: résumé text or a must-have + nice-to-have skill list. Without it, résumé-fit falls back to a mechanical score labeled `Fit (partial)`.
+
+**Ambiguity rule:** if role or location is missing or vague, ask **one** clarifying
+question before running. Never burn Actor compute on a guessed query.
+
+### Step 2: Route to the right Actor(s)
+
+Default to the **aggregator** — one run, 20+ boards (LinkedIn, Indeed, Glassdoor,
+Google Jobs, and more), country-aware routing, cheapest per-result. **Every Actor here
+is pay-per-result — no subscriptions.** The aggregator already covers LinkedIn and
+Google cheaply, so there is no need for a per-board LinkedIn or Google subscription
+Actor.
+
+| User wants | Actor | Notes |
+|---|---|---|
+| All boards (default) | `agentx/all-jobs-scraper` | One query → LinkedIn, Indeed, Glassdoor, Google Jobs, ZipRecruiter +15. **Pay-per-result** (~$0.0023/job). |
+| Indeed only (cheap, focused) | `misceres/indeed-scraper` | **Apify-maintained**, pay-per-result (~$3/1,000). |
+| Glassdoor salary benchmark | `memo23/glassdoor-scraper-ppr` | Pay-per-result; analysis mode only, to cross-check posted salaries (analysis.md). |
+
+Pin to the aggregator unless the user explicitly wants a single board. If the
+aggregator's coverage of one board is thin on a given run (boards block scrapers),
+note it in the header rather than reaching for a paid per-board Actor. Full schemas
+and field mappings: [reference/actor-index.md](reference/actor-index.md).
+
+**Cross-board parallel runs.** If the user names two+ boards, run their primaries in
+parallel (background each `call-actor` / CLI invocation), tag every row with its
+`Source` board, and dedupe in Step 5.
+
+### Step 3: Build the input, estimate cost, confirm
+
+Map anchors → the chosen Actor's field names (per-Actor table in
+[reference/actor-index.md](reference/actor-index.md)). Aggregator example:
+
+```json
+{ "keyword": "senior backend engineer", "location": "Berlin",
+  "country": "Germany", "max_results": 50, "posted_since": "2 weeks", "remote_only": false }
+```
+
+Verified-from-live-schema notes for the aggregator: `country` is a **full country
+name** (`Germany`, `United States`), not an ISO-2 code; `posted_since` is a
+**natural-language string** (`"2 weeks"`), not a number of days; `job_type` is
+`fulltime` / `parttime` / `contract` / `internship` / `all` (no hyphen); and
+**`max_results` is per board** — the actor fans out to ~6 boards, so `max_results:
+50` returns ≈ 300 rows. Other Actors use their own field names (actor-index.md).
+
+**Estimate before running.** Formula and live rates in
+[reference/gotchas.md](reference/gotchas.md). Guardrails:
+
+- Estimated cost **> $5** → warn with a rough number ("around $X").
+- Estimated cost **> $20** → require explicit confirmation before running.
+- All routes are pay-per-result — cost scales with `max_results × boards`. Keep
+  `max_results` modest to keep runs in the cents.
+
+### Step 4: Run, wait, pull the dataset
+
+**MCP path:** `call-actor` with `actor`, `input`, `callOptions`
+`{"timeout": 900, "memory": 2048}`. It returns `runId` + `datasetId`. If `status` is
+`RUNNING`, poll `get-actor-run` (waitSecs ≤ 45) until `SUCCEEDED`. Capture both IDs for
+the `run_metadata.json` sidecar (and surface `datasetId` in export mode).
+
+**CLI path:**
+
+```bash
+apify actors call "agentx/all-jobs-scraper" \
+  --input '{"keyword":"senior backend engineer","location":"Berlin","country":"Germany","max_results":50,"posted_since":"2 weeks"}' \
+  --json --user-agent apify-awesome-skills/apify-jobs-data 2>/dev/null
+# then, using the returned defaultDatasetId:
+apify datasets get-items DATASET_ID --format json \
+  --user-agent apify-awesome-skills/apify-jobs-data 2>/dev/null > /tmp/jobs.json
+```
+
+On the MCP path, pull with `get-dataset-items` (`clean: true` + a `fields` list). If
+the dataset exceeds the response cap, fetch directly:
+`curl 'https://api.apify.com/v2/datasets/<id>/items?clean=true&fields=...' | jq`.
+
+**Report every failure explicitly** (Actor, input, error) — never silently drop a
+board. If the primary returns 0, switch to the fallback (Step 2) before concluding "no
+data". A board returning 0 while others return results is usually a block, not an empty
+market.
+
+### Step 5: De-noise + normalize into clean rows
+
+The shared core. Two parts:
+
+1. **De-noise** — walk every row and remove the noise: duplicates/reposts across
+   boards, hard-filter violations, off-target roles; flag (don't drop) ghost jobs and
+   staffing-agency reposts. Skipped rows are **kept** in a separate `Skipped` section
+   with a one-line reason — never silently dropped. Apply hard filters first, then
+   dedupe, so the funnel reads `raw → after hard filters → after dedupe → clean`. Full
+   detection logic: [reference/skip-pass.md](reference/skip-pass.md).
+2. **Normalize** — map each surviving row onto the consistent schema in
+   [reference/output-formats.md](reference/output-formats.md) (title, company,
+   location, remote flag, salary min/max/currency, seniority, skills, posted date,
+   source board, apply URL). Field coverage varies by board — leave missing fields
+   blank, never inferred.
+
+**Empty results are signal, not failure** (from `apify-easy-competitive-intelligence`):
+0 postings for a niche role in a small market is real information — report it, suggest
+widening recency or location, don't fabricate filler rows.
+
+### Step 6: Produce the selected mode(s)
+
+Run on the clean, normalized rows from Step 5.
+
+- **Market & salary analysis** → compute the aggregations (demand, skills, salary
+  distribution, remote mix) with coverage labels. Full method:
+  [reference/analysis.md](reference/analysis.md).
+- **Structured export** → write the normalized rows to CSV / JSON, and surface the raw
+  Apify `datasetId` for direct ingestion. Schema and formats:
+  [reference/output-formats.md](reference/output-formats.md).
+- **Résumé-fit** → a per-posting sub-agent reads each full JD against the résumé and
+  returns fit, matched skills, gaps, the **ATS keywords the résumé is missing**, and a
+  one-line hook — not keyword counting. Contract and rubric:
+  [reference/fit-scoring.md](reference/fit-scoring.md).
+
+If the user picked more than one mode, produce each from the same run — no re-scrape.
+
+### Step 7: Deliver, with provenance and coverage
+
+Lead with a one-paragraph header: boards searched, the funnel
+(`raw → after hard filters → after dedupe → clean`, plus flagged ghost/agency counts),
+date window, and the run cost. Then the mode output(s).
+
+- **Every statistic carries its coverage** — e.g. "median salary €95k, from the 41% of
+  postings that disclosed a figure". A number without coverage is misleading.
+- **Provenance** — `Source` board(s) + apply URL per row; `runId` + `datasetId` in a
+  `run_metadata.json` sidecar so any figure is re-verifiable.
+- Synthesize for analysis/résumé-fit; write the full row set to the file. For export,
+  the file (and dataset ID) *is* the deliverable.
+
+## Worked examples
+
+- Market & salary analysis: [examples/example-market-analysis.md](examples/example-market-analysis.md)
+- Résumé-fit ranking + ATS gap: [examples/example-resume-fit.md](examples/example-resume-fit.md)
+
+## Quality rules
+
+- **No fabrication, ever.** Never invent a posting, salary, count, or keyword. Missing
+  fields stay blank. (From `apify-verified-email-finder` / `apify-link-prospecting-outreach`.)
+- **Every statistic reports coverage.** State the share of postings a figure is
+  computed from; salary stats especially, since many postings don't disclose.
+- **Provenance.** `Source` board(s) + apply URL per row; `runId` + `datasetId` in
+  `run_metadata.json` so any row or figure is re-verifiable.
+- **Surface, don't suppress.** Skipped / ghost / duplicate rows stay in the output with
+  a reason. Empty results are reported as signal, not hidden.
+- **ATS suggestions stay honest** (résumé-fit mode): only surface missing keywords the
+  user can truthfully claim; never coach them to lie on a résumé.
+- **Don't be condescending about gaps.** When a field is missing, state the fact and
+  stop. (From `apify-link-prospecting-outreach`.)
+- **Lowest cost for the quality needed.** Cheapest actor, smallest sufficient sample,
+  one run for all modes, estimate before scaling — see [Cost discipline](#cost-discipline-best-quality-for-the-lowest-cost).
+
+## Cost & pricing
+
+Every Actor here is **pay-per-result** — no subscriptions. A run costs cents (a live
+60-job test billed $0.18). Cost scales with `max_results × boards`, so keep
+`max_results` modest. The optional Glassdoor salary benchmark adds a small per-company
+cost. Live rates and the estimate formula are in [reference/gotchas.md](reference/gotchas.md)
+— always check the Apify console before a large run.
+
+## Error handling & gotchas
+
+See [reference/gotchas.md](reference/gotchas.md) — board blocks, empty results,
+location-format quirks, per-board cost math, and recovery flows.

--- a/skills/apify-jobs-data/examples/example-market-analysis.md
+++ b/skills/apify-jobs-data/examples/example-market-analysis.md
@@ -1,0 +1,69 @@
+# Example — Market & salary analysis
+
+User: *"What's the hiring demand and salary range for senior backend engineers in
+Berlin right now, and what skills are they asking for?"*
+
+## Step 0 — Mode
+
+Analysis ("demand / salary / skills"). No résumé needed.
+
+## Step 1 — Anchors
+
+| # | Anchor | Value |
+|---|---|---|
+| 1 | Role | `senior backend engineer` |
+| 2 | Location / country | `Berlin` / `Germany` (full country name, per the schema) |
+| 3 | Boards | `auto` → aggregator (broad sample) |
+| 4 | Result cap | `50` **per board** ≈ 300 rows across ~6 boards — a bigger sample makes the stats meaningful |
+| 5 | Recency | `1 month` |
+| 6 | Filters | none (open market scan) |
+
+## Steps 2–4 — Run
+
+`agentx/all-jobs-scraper`, `country: "Germany"`, `posted_since: "1 month"`,
+`max_results: 50` (per board). Returns 312 raw rows across 6 boards — cost ≈ $0.01 +
+312 × $0.0023 ≈ **$0.73**.
+
+## Step 5 — De-noise + normalize
+
+| Funnel | Count |
+|---|---|
+| Raw | 312 |
+| After hard filters | 312 (none set) |
+| After dedupe | 247 (65 cross-board duplicates/reposts merged) |
+| Flagged | 9 possible ghosts (re-stamped / pipeline language) |
+
+247 clean, normalized rows. De-noise matters here: the raw 312 would have inflated
+demand by ~26%.
+
+## Step 6 — Analysis ([analysis.md](../reference/analysis.md))
+
+> **Hiring demand:** 247 distinct senior-backend postings, last 30 days.
+> Top employers: Example Cloud (11), Beispiel AG (8), Muster Tech (6), … (top-15 in CSV).
+> 71% full-time, 18% contract; 54% remote-eligible, 22% hybrid, 24% on-site (coverage 100%).
+>
+> **In-demand skills** (share of 247 postings that name each):
+> | Skill | Share |
+> |---|---|
+> | Go | 58% (143) |
+> | Kubernetes | 49% (121) |
+> | PostgreSQL | 44% (109) |
+> | AWS | 41% (101) |
+> | gRPC | 22% (54) |
+>
+> **Salary distribution** — **only 6% (15/247) of these Berlin postings disclosed a
+> figure, and several had inconsistent currency/period** (a known pattern — a live
+> test of this market found ~2% disclosure). That is **too thin for a reliable posted
+> distribution**, so the posted numbers are shown only as a directional range
+> (≈ €78k–€115k for the 15 that disclosed, after currency/period normalization), and
+> the salary read leans on the Glassdoor benchmark instead:
+> Glassdoor estimate for senior backend in Berlin ≈ **€95k median** (`memo23/glassdoor-scraper-ppr`).
+> *Never present a posted-salary median from 15 points as the market rate — coverage
+> is the headline here, not the number.*
+
+## Step 7 — Deliver
+
+Header with the funnel + coverage; the report above inline; the 247 clean rows written
+to `2026-06-01_jobs_senior-backend-berlin.csv` + the Apify `datasetId` so the user can
+re-aggregate or load it into a dashboard. `run_metadata.json` records the run, funnel,
+and `salaryDisclosedPct: 6`.

--- a/skills/apify-jobs-data/examples/example-resume-fit.md
+++ b/skills/apify-jobs-data/examples/example-resume-fit.md
@@ -1,0 +1,50 @@
+# Example — Résumé-fit ranking + ATS gap
+
+User: *"Rank senior backend roles in Berlin against my résumé and tell me which ATS
+keywords I'm missing. Résumé: Python, Go, Postgres, Kubernetes, 7 yrs, led a team of 4."*
+
+## Step 0 — Mode
+
+Résumé-fit (a résumé is supplied → full Path-A scoring).
+
+## Step 1 — Anchors
+
+| # | Anchor | Value |
+|---|---|---|
+| 1 | Role | `senior backend engineer` |
+| 2 | Location / country | `Berlin` / `Germany` |
+| 3 | Boards | `auto` → aggregator |
+| 4 | Result cap | `15` **per board** (≈90 across ~6 boards; fewer after some boards return less) |
+| 5 | Recency | `2 weeks` |
+| 6 | Filters | `salary_floor: 85000 EUR`, `job_type: fulltime` |
+| 7 | Résumé | Python, Go, Postgres, Kubernetes; 7 yrs; team lead |
+
+## Steps 2–5 — Run + de-noise
+
+`agentx/all-jobs-scraper`, `country: "Germany"`, `job_type: "fulltime"`. 71 raw rows
+returned across the boards — cost ≈ **$0.18** (71 × $0.0023 + start). Funnel:
+`71 raw → 67 after dropping 4 below the €85k floor → 38 after merging 29 duplicates`;
+3 ghost-flagged. 38 clean rows.
+
+## Step 6 — Résumé-fit ([fit-scoring.md](../reference/fit-scoring.md))
+
+38 sub-agents (batched), each reads the full JD against the résumé and returns the
+contract (fit, matched skills, gaps, `ats_keywords_missing`, hook). Ranked top:
+
+| Fit | Band | Title | Company | Salary | Matched | ATS to add |
+|---:|---|---|---|---|---|---|
+| 92 | 🟢 | Senior Backend Engineer (Go) | Example Cloud GmbH | €90–110k | Go, Postgres, Kubernetes, team lead | Kubernetes, gRPC |
+| 84 | 🟢 | Senior SWE, Platform | Beispiel AG | €88–105k | Python, Kubernetes | (none — résumé covers it) |
+| 71 | 🟡 | Backend Engineer | Muster Tech | undisclosed | Python, Postgres | — |
+| 58 | 🟠 | Staff Engineer | Probe Labs | €120k+ | Go, Kubernetes | Terraform (real gap) |
+
+ATS note for row 1: the résumé says "container orchestration" — the JD says
+**Kubernetes**, an exact ATS keyword the screen looks for, so name it explicitly;
+**gRPC** is listed under the Acme project but not surfaced. Both `honest_to_add: true`.
+Row 4's `Terraform` is `honest_to_add: false` — a genuine gap, don't fake it.
+
+## Step 7 — Deliver
+
+Header (funnel, full fit score), the ranked table inline with apply-ready briefs for
+the 🟢/🟡 rows (opener + ATS keywords to add + gaps), and the full ranked set written to
+`2026-06-01_jobs_resume-fit.csv` + `run_metadata.json`.

--- a/skills/apify-jobs-data/reference/actor-index.md
+++ b/skills/apify-jobs-data/reference/actor-index.md
@@ -1,0 +1,122 @@
+# Actor Index — apify-jobs-data
+
+Routing table, input schemas, anchor→field mappings, and primary/fallback pairs
+for every Actor this skill uses. Read on demand when building an input (Step 3).
+
+**Always confirm the live schema before the first run** — Actor inputs change:
+
+```bash
+apify actors info "ACTOR_ID" --input --json \
+  --user-agent apify-awesome-skills/apify-jobs-data 2>/dev/null
+```
+
+If a schema fetch disagrees with the field names below, trust the schema.
+
+**Every Actor here is pay-per-result — no subscriptions:**
+
+- `agentx/all-jobs-scraper` (default aggregator) — community, ~$0.0023/job. Covers
+  LinkedIn, Indeed, Glassdoor, Google Jobs and more in one run.
+- `misceres/indeed-scraper` — **Apify-maintained**, ~$3/1,000. Optional Indeed-only route.
+- `memo23/glassdoor-scraper-ppr` — community. Optional salary benchmark (analysis mode).
+
+No per-board LinkedIn or Google subscription Actor is used — the aggregator already
+covers those boards cheaply. If a board is blocked on a given run, note it in the
+header rather than reaching for a paid per-board Actor.
+
+**Legal note:** these Actors scrape third-party boards against those sites' Terms of
+Service (see SKILL.md Prerequisites). All routes run on Apify's infrastructure (no
+user login), so they never put the user's own board accounts at risk.
+
+---
+
+## Job-board Actors (Step 2)
+
+### `agentx/all-jobs-scraper` — multi-board aggregator (DEFAULT)
+
+One run fans out across 20+ boards (LinkedIn, Indeed, Glassdoor, ZipRecruiter,
+Google Jobs, StepStone, Naukri, Bayt, Reed, Totaljobs, InfoJobs, Talent.com,
+Jooble, and more) with country-aware routing. Pay-per-result, no subscription.
+**Fallback:** the per-board Actors below, run in parallel and merged.
+
+| Anchor | Field | Notes (verified against the live schema) |
+|---|---|---|
+| #1 Role | `keyword` | Job title or skill string. Required. |
+| #2 Location | `location` | Free-text city/region (e.g. `Berlin`) |
+| #2 Location | `country` | **Full country NAME from the actor's enum** (e.g. `Germany`, `United States`) — *not* an ISO-2 code. Required; defaults to `United States`. |
+| #4 Result cap | `max_results` | Integer, **minimum 10** (smaller values are rejected: *"must be >= 10"*). **Per platform, not total** — the actor fans out to ~6 boards, so `max_results: 10` (the floor) returns ≈ 60 rows. Multiply by the boards hit for the real count and cost. Required. |
+| #5 Recency | `posted_since` | **String, not an integer** — natural-language window like `"1 day"`, `"1 week"`, `"2 weeks"`, `"1 month"`, `"6 months"` (default). Passing a bare number is ignored. |
+| #6 job_type | `job_type` | Enum: `all` (default) / `fulltime` / `parttime` / `internship` / `contract` — **no hyphen** (`fulltime`, not `full-time`). |
+| #6 remote_only | `remote_only` | `true` flips remote filter on |
+| boards | `platforms` | Optional array to restrict which boards run; empty = all. |
+
+```json
+{ "keyword": "senior backend engineer", "location": "Berlin",
+  "country": "Germany", "max_results": 50, "posted_since": "2 weeks",
+  "job_type": "fulltime", "remote_only": false }
+```
+
+Output (verified): per-job fields include `title`, `company_name`, `location`,
+`salary_minimum` / `salary_maximum` / `salary_currency` / `salary_period`, `skills`
+(list), `job_type`, `job_level`, `is_remote` / `work_from_home`, `posted_date`,
+`applicant_count`, `easy_apply`, `platform` (the source board), and `official_url` /
+`platform_url`. **Coverage varies sharply by board and region** — in a live Berlin
+test only **1 of 58** postings disclosed salary, and that figure had an inconsistent
+currency/period — so salary always needs coverage labeling and period normalization
+(analysis.md). Roughly `$0.01` start + `$0.0023` / job — and remember a job is
+counted per board, so budget `max_results × boards`. **Confirm live in console.**
+
+### `misceres/indeed-scraper` — Indeed only (optional, **Apify-maintained**)
+
+The one Apify-maintained board Actor. Cheap pay-per-result (~`$3` / 1,000 listings).
+Only needed if the user wants Indeed exclusively; otherwise the aggregator covers it.
+
+| Anchor | Field | Notes |
+|---|---|---|
+| #1 Role | `position` | |
+| #2 Location | `location` | |
+| #2 Location | `country` | ISO-2; required, must match `location` |
+| #4 Result cap | `maxItems` | |
+| dedupe | `saveOnlyUniqueItems` | `true` — drops Indeed-side dupes early (helps Step 5) |
+
+```json
+{ "position": "data analyst", "location": "San Francisco", "country": "US",
+  "maxItems": 100, "saveOnlyUniqueItems": true }
+```
+
+Output: salary, company + logo, location, company rating, full description
+(text + HTML), post date, direct job URL.
+
+### `memo23/glassdoor-scraper-ppr` — Glassdoor salary benchmark (optional, pay-per-result)
+
+From a Glassdoor company-page URL it returns the company's jobs, reviews, salary
+estimates, and more — one Actor, selected by a `command`/section field. Pay-per-result.
+This skill uses it only for the **salary benchmark** in analysis mode (the `salaries`
+section), to cross-check posted salary bands against Glassdoor estimates.
+
+| Need | Field | Notes |
+|---|---|---|
+| Company | `startUrls` | Glassdoor **company-page URLs** (array of `{url}`). There is **no `companyName` field** — supply the Glassdoor URL (find it via a quick SERP for "<company> glassdoor"). |
+| Section | `command` (or equivalent) | `salaries` here; names vary by version |
+
+**Always fetch the live schema first** — the section selector's exact name/values
+change between versions:
+
+```bash
+apify actors info "memo23/glassdoor-scraper-ppr" --input --json \
+  --user-agent apify-awesome-skills/apify-jobs-data 2>/dev/null
+```
+
+If Glassdoor has no data for a company, report "no Glassdoor data found" rather than
+substituting another source silently.
+
+---
+
+## Picking the route
+
+1. Anchor #3 names a board → that board's primary Actor (fallback on 0/failure).
+2. Anchor #3 is `auto` (default) → `agentx/all-jobs-scraper`.
+3. User names two+ boards → run their primaries in parallel, tag `source`, dedupe.
+
+Never run more than the user asked for. The aggregator already covers most boards in
+one run — split into per-board Actors only when the user wants one board's deeper
+fields or its cheaper rate.

--- a/skills/apify-jobs-data/reference/analysis.md
+++ b/skills/apify-jobs-data/reference/analysis.md
@@ -1,0 +1,60 @@
+# Market & Salary Analysis — apify-jobs-data (Step 6)
+
+Compute job-market statistics from the clean, normalized rows produced in Step 5.
+**Every figure reports the share of postings it is computed from** — coverage is
+mandatory, because field coverage varies by board and many postings omit salary.
+
+## Input
+
+The normalized rows (schema in [output-formats.md](output-formats.md)). A larger sample
+makes the statistics meaningful — raise the result cap (anchor #4) for analysis runs,
+and prefer the aggregator so the sample spans many boards.
+
+## Aggregations
+
+### Hiring demand
+- Count of **distinct, de-noised** postings (ghosts and duplicates already removed —
+  this is why de-noise matters: it's the difference between real demand and a board's
+  inflated count).
+- Break down by company (top employers hiring for the role), location, seniority, and
+  `job_type`. Report **counts**, not just percentages.
+
+### In-demand skills
+- Take each posting's `skills` field where present; otherwise parse the JD text against
+  a skill vocabulary (languages, frameworks, tools, certifications).
+- Rank by frequency, reported as "X% of postings mention <skill> (N of M)".
+- Distinguish must-have vs nice-to-have phrasing where the JD separates them.
+
+### Salary distribution
+- Use disclosed salary min / max / currency from the normalized rows.
+- Normalize currency and period (annual vs monthly vs hourly) **before** aggregating;
+  separate or drop rows you cannot normalize, and say how many.
+- Report min / 25th / median / 75th / max, split by seniority and location where the
+  sample supports it. Flag any cell with **< ~5 data points** as too thin to trust.
+- **Coverage is mandatory:** "median €95k, from the 41% (52/126) of postings that
+  disclosed a figure". Never present a salary statistic without the disclosed share.
+- Optional cross-check: `memo23/glassdoor-scraper-ppr` salaries for the same role, to
+  compare posted bands against Glassdoor estimates — label each source separately.
+- **Cost-quality note:** disclosure is low, so do **not** scale the scrape just to
+  harvest more disclosed salaries — that burns money for a few extra figures. When the
+  posted sample is thin, lean on the Glassdoor benchmark (one cheap per-company call)
+  instead of a mega-scrape. Scrape only as much as the demand/skills analysis needs.
+
+### Remote / hybrid mix
+- Share of postings remote / hybrid / on-site, from the normalized remote flag plus JD
+  signals. Report coverage.
+
+## Grounding rules
+
+- Every number traces to scraped rows; state the N and the coverage share.
+- A thin sample is a **finding**, not a gap to paper over — say "only 12 postings
+  matched, too few for a reliable salary distribution" rather than computing a shaky
+  median.
+- Don't infer a trend from a single run — this skill takes one snapshot per run.
+
+## Output
+
+A short report: a demand headline, a top-skills table, a salary-distribution table
+(each cell with its coverage), and the remote mix — every figure carrying its N. The
+underlying normalized rows go to the file (export mode) so the user can re-aggregate
+themselves. Rendering details: [output-formats.md](output-formats.md).

--- a/skills/apify-jobs-data/reference/fit-scoring.md
+++ b/skills/apify-jobs-data/reference/fit-scoring.md
@@ -1,0 +1,126 @@
+# Fit Scoring — apify-jobs-data (Step 6)
+
+How Step 6 turns de-noised postings into a ranked shortlist. The headline rule,
+borrowed from `apify-link-prospecting-outreach` (which is explicit that "regex /
+keyword scoring is not acceptable for the final draft"):
+
+> **The final fit call is made by a sub-agent that reads the full job description
+> against the user's profile — not by counting keyword overlaps.** Keyword scoring
+> is the labeled fallback used only when no profile was supplied.
+
+A posting can name "Python" once in a boilerplate list and be a terrible fit, or
+never use the user's exact keyword yet be perfect. Only reading the JD in context
+catches that. Always show the **per-component breakdown** so the user sees *why* a
+job ranked where it did and can re-weight.
+
+## Path A — profile supplied (default): per-posting sub-agents
+
+After the skip pass, spawn one sub-agent per surviving posting, in parallel,
+batched (cap concurrency to keep the round responsive — see the orchestration note
+below). Each sub-agent gets the full JD text + the user's profile and returns this
+exact contract:
+
+```json
+{
+  "fit": 0-100,
+  "band": "strong | worth-a-look | stretch | low",
+  "matched_skills": ["..."],
+  "gaps": ["..."],
+  "seniority_match": "exact | one-off | mismatch",
+  "comp_vs_floor": "above | overlaps | below | undisclosed",
+  "ats_keywords_missing": [
+    { "term": "Kubernetes", "honest_to_add": true,  "note": "résumé says 'container orchestration' — same thing, name it" },
+    { "term": "Terraform",  "honest_to_add": false, "note": "candidate has no IaC experience — a real gap, don't add" }
+  ],
+  "hook": "one sentence linking the user's strongest relevant experience to the role's headline responsibility",
+  "rationale": "2-3 sentences: why this score, grounded in JD + profile text",
+  "verdict": "apply | maybe | skip"
+}
+```
+
+### Sub-agent instructions (give verbatim)
+
+> You are scoring one job posting for fit against a candidate's profile. Read the
+> full job description and the profile. Score 0–100 using the rubric weights below.
+> Ground every claim in text that is actually present — do not assume the candidate
+> has experience they didn't list, and do not credit a skill the JD only mentions
+> in passing. List concrete matched skills and concrete gaps. For
+> `ats_keywords_missing`, extract the hard skills/tools the JD names as requirements
+> that do NOT appear in the résumé (these are what an ATS keyword-filter screens on);
+> for each, set `honest_to_add: true` ONLY if the candidate plausibly has the
+> experience under a different name (note the synonym), and `false` if it's a genuine
+> gap they'd be lying to claim. Write one tailored hook sentence the candidate could
+> open a cover letter with, using only experience they actually claimed. If the role
+> is a clear mismatch, return `verdict: skip` with a one-line reason. Return only the
+> JSON contract.
+
+The `ats_keywords_missing` field is the single highest-value output for a real job
+seeker — an ATS often rejects on keyword match before a human reads anything — and it
+is fully grounded in the scraped JD vs the résumé. **Never mark a genuine gap as
+`honest_to_add: true`; coaching a candidate to lie gets them caught in the interview.**
+
+### Rubric the sub-agent applies (weights sum to 100)
+
+| Component | Weight | Scored from |
+|---|---:|---|
+| **Skill & responsibility match** | 40 | How well the candidate's actual experience covers the role's *core* responsibilities (not its keyword list). Must-haves the candidate lacks cost the most. This is the thing the user actually cares about and the only thing reading the JD uniquely buys you — so it carries the most weight. |
+| **Seniority match** | 20 | Exact level → 20; one level off → 10; two+ off → 0. Inferred from scope/responsibilities, not just the title word. |
+| **Compensation** | 10 | Disclosed band ≥ floor → 10; overlaps → 5; below → 0 (these were dropped in skip-pass rule 1 anyway). **Undisclosed → 5 (half-credit, neutral)**, flagged. Weight is deliberately low: comp is already enforced as a *hard filter*, and most real postings don't disclose, so it must not dominate or silently penalize the modal job (see note below). |
+| **Location / remote** | 15 | Matches preference (or remote when remote requested) → 15; same country, diff city → 8; else → 0. **Exception the sub-agent should catch:** a posting whose listed location is a foreign HQ but whose JD is explicitly remote-eligible for the user's region scores as a location match, not 0 — read the JD, don't just compare the location string. |
+| **Recency & realness** | 15 | Within the user's window and not flagged as ghost → 15; decays to 0 at 2× window; a flagged-ghost posting is capped at 7 here regardless of date. |
+
+**Salary-disclosure note.** Disclosure rate is largely a *jurisdiction artifact* —
+mandated and reliable in CA/CO/NY/WA and EU-transparency-covered roles, absent or
+aspirational elsewhere. A blank salary is therefore not a company-quality signal,
+which is exactly why comp carries low weight and undisclosed scores neutral rather
+than penalizing. When comp genuinely matters to the user, cross-check against the
+Glassdoor salary benchmark (analysis mode, analysis.md), don't lean on the posted band.
+
+### Orchestration note
+
+In an agent session that supports sub-agents (e.g. a Task/Agent tool), spawn one
+sub-agent per posting, in parallel, batched ~8–10 at a time. If sub-agent spawning
+isn't available in the runtime, the *same* rubric can be applied inline by the main
+agent reading each JD sequentially — slower but identical contract. Do **not** silently downgrade
+to keyword scoring when a profile exists; reading the JD is the point.
+
+## Path B — no profile: mechanical fallback (labeled `Fit (partial)`)
+
+When anchor #7 is empty you cannot judge skill or seniority fit. Score only what
+the data supports and **label the column `Fit (partial)`**:
+
+| Component | Weight |
+|---|---:|
+| Recency & realness (ghost-flagged capped) | 40 |
+| Location / remote match | 30 |
+| Compensation (vs. any stated floor, else relative rank of disclosed salaries; undisclosed neutral) | 30 |
+
+Always invite the user to paste a résumé or skill list to unlock Path A. Never
+present a partial score as a true match.
+
+## Banding
+
+The sub-agent contract returns `band` as text; the output renders it as an emoji.
+Mapping (used by both the sub-agent and the renderer):
+
+| Score | `band` text | Emoji | Meaning |
+|---|---|---|---|
+| 80–100 | `strong` | 🟢 | Apply first; tailor the application |
+| 60–79 | `worth-a-look` | 🟡 | Apply if capacity; mind the gaps |
+| 40–59 | `stretch` | 🟠 | Only if the company/mission is a real draw |
+| 0–39 | `low` | 🔴 | Low fit. Stays in **Active** (not the Skipped section); the user decides |
+
+A `verdict: skip` from the sub-agent maps to the 🔴 `low` band and stays in the ranked
+output — it is never moved to the Step-5 Skipped section, which is reserved for
+skip-pass drops with a `Skip Reason`.
+
+Order the output by `fit` descending, then posting date.
+
+## Tailoring output (always include for 🟢/🟡 rows)
+
+From the sub-agent contract, surface per row: `Matched Skills`, `Gaps` (the
+questions to prepare for, not necessarily disqualifiers), the `Hook`, and the
+`ats_keywords_missing` terms (only the `honest_to_add: true` ones as "add these",
+the rest as honest gaps). Keep all of it grounded in JD + profile text. **Never
+invent experience the candidate didn't claim** — a fabricated hook or a dishonest
+ATS keyword gets them caught in the interview.

--- a/skills/apify-jobs-data/reference/gotchas.md
+++ b/skills/apify-jobs-data/reference/gotchas.md
@@ -1,0 +1,94 @@
+# Gotchas — apify-jobs-data
+
+Cost guardrails, error recovery, and platform quirks. Read on demand when building
+an input (Step 3) or when a run misbehaves.
+
+## Cost guardrails
+
+Check the pricing model before running:
+
+```bash
+apify actors info "ACTOR_ID" --json \
+  --user-agent apify-awesome-skills/apify-jobs-data 2>/dev/null
+# inspect pricingInfo
+```
+
+| Model | Actors here | What to watch |
+|---|---|---|
+| `PAY_PER_RESULT` / `PAY_PER_EVENT` (all of them) | `agentx/all-jobs-scraper` (default), `misceres/indeed-scraper` (Apify-maintained), `memo23/glassdoor-scraper-ppr` | Cost scales with `max_results × boards`. No subscriptions — a run costs cents. Estimate first. |
+
+**ToS / account risk.** Every board Actor scrapes a third-party site against its
+Terms of Service (SKILL.md Prerequisites). All routes run on Apify's infrastructure
+(no user login), so they never put the user's own board accounts at risk.
+
+### Estimate the WHOLE pipeline
+
+```
+total ≈ board_pull + (optional Glassdoor salary benchmark × companies)
+board_pull ≈ start_fee + (max_results × boards_hit × per_result)
+```
+For `agentx/all-jobs-scraper`, `max_results` is **per board** and it hits ~6 boards,
+so the row count (and cost) is ≈ `max_results × 6` — a request for 50 returns ≈ 300
+jobs, not 50.
+
+Reference rates (confirm live in console — they change):
+- `agentx/all-jobs-scraper`: ≈ $0.01 start + $0.0023 / job (≈ $2.31 / 1,000).
+- `misceres/indeed-scraper`: ≈ $3 / 1,000 listings.
+- `memo23/glassdoor-scraper-ppr`: per-company — only when the salary benchmark is used.
+
+### Confirmation thresholds
+
+- Estimated cost **> $5** → warn with a rough number ("around $X").
+- Estimated cost **> $20** → require explicit confirmation before running.
+- Biggest silent trap: a high `max_results` × several boards. Estimate the board pull
+  (plus the optional Glassdoor salary benchmark) before running.
+
+## Common errors
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Zero results, all boards | Over-narrow query / unparseable location | Widen `posted_since`, drop one filter, try `City, Country` form, lower specificity |
+| Zero on one board only | That board blocked the run or has no matches | Note it in the header — the aggregator covers the gap. Not a fatal error. |
+| Run `RUNNING` for minutes | Large `max_results` / multi-board fan-out | Poll `get-actor-run` (waitSecs ≤ 45); raise `timeout` to 900–1800 |
+| Anti-bot / partial pages | Board rate-limited the Actor | Lower concurrency, reduce `max_results`, retry once |
+| LinkedIn returns little/nothing | LinkedIn blocks hardest | Retry once; otherwise note the thin LinkedIn coverage in the header — the aggregator's other boards carry the run |
+| Duplicate-heavy dataset | Same role syndicated across boards | Expected — skip-pass rule 2 dedupes; set `saveOnlyUniqueItems: true` on Indeed |
+| Salary always blank | Many postings don't disclose | Real — never infer. Leave blank; in analysis, report the disclosed share as coverage |
+| "Posted today" on a known-old role | Board re-stamped a repost | Ghost tell (skip-pass rule 3). Flag `⚠ re-stamped`; don't trust the date |
+| No Glassdoor data | Small / private company | Report "no Glassdoor data found"; don't fabricate figures |
+
+## Platform quirks
+
+### `agentx/all-jobs-scraper`
+- `country` is a **full country name** from the actor's enum (`Germany`, `United
+  States`) — **not** an ISO-2 code; defaults to `United States`. A wrong/empty
+  country silently narrows or mis-targets results.
+- **`max_results` is per board.** The actor fans out to ~6 boards, so a request for
+  10 returns ≈ 60 rows (verified live). Budget and expectations should use
+  `max_results × boards`, not `max_results`.
+- `job_type` enum values have **no hyphen** (`fulltime`, not `full-time`).
+- Field coverage varies sharply by board/region; `salary` especially is often blank
+  (a live Berlin run disclosed salary on 1 of 58 rows) and currency/period can be
+  inconsistent. Treat blanks as missing, normalize before aggregating (analysis.md).
+
+### `misceres/indeed-scraper`
+- `country` is required and must match `location`. `saveOnlyUniqueItems: true` cuts
+  Indeed-side dupes before Step 5.
+
+### `memo23/glassdoor-scraper-ppr`
+- Input is `startUrls` (Glassdoor **company-page URLs**) plus a `command`/section
+  selector — there is **no `companyName` field**. Find the URL via a SERP for
+  "<company> glassdoor".
+- The section selector's exact name/values vary by version — fetch the live schema first.
+- Verify the returned company is the right entity (generic names mis-match) before
+  trusting the salary figures; surface the matched Glassdoor URL in the output.
+
+## Data-quality reminders
+
+- **Empty results are signal**, not failure — 0 niche roles in a small market is
+  real information. Report it; suggest a concrete loosening. Never fabricate filler.
+- **Recency is signal.** A 45-day-old "urgent" req is often filled — flag, don't hide.
+- **Disclosed ≠ accurate.** Posted bands can be aspirational; cross-check against the
+  Glassdoor salary benchmark (analysis mode) when comp matters.
+- **One board's silence isn't the market.** Zero LinkedIn rows usually means a block,
+  not no jobs — lean on the aggregator's breadth and the fallback Actor.

--- a/skills/apify-jobs-data/reference/output-formats.md
+++ b/skills/apify-jobs-data/reference/output-formats.md
@@ -1,0 +1,112 @@
+# Output Formats — apify-jobs-data
+
+The normalized row schema (the cleaned data, shared by every mode), the export
+formats, and the résumé-fit output. Analysis output is in
+[analysis.md](analysis.md).
+
+## Normalized row schema (the cleaned data)
+
+Step 5 maps each surviving posting onto this consistent schema, regardless of which
+board it came from. This is what the export mode writes and what every other mode
+reads. Field coverage varies by board — **missing fields stay blank, never inferred.**
+The `Raw field` column maps from the verified `agentx/all-jobs-scraper` output; other
+Actors use their own names (fetch the live schema).
+
+| Normalized field | Raw field (agentx) | Notes |
+|---|---|---|
+| `title` | `title` | |
+| `company` | `company_name` | normalize (strip Inc/GmbH/Ltd suffixes) for grouping |
+| `location` | `location` | city / region |
+| `remote` | `is_remote` / `work_from_home` | → `remote` / `onsite` / blank |
+| `salary_min`, `salary_max`, `salary_currency`, `salary_period` | `salary_minimum`, `salary_maximum`, `salary_currency`, `salary_period` | as published; blank if undisclosed (often is). Currency/period can be inconsistent — normalize before any stat |
+| `seniority` | `job_level` / `experience_range` | mark when inferred from title |
+| `job_type` | `job_type` | |
+| `skills` | `skills` (list) | else parse from `description` |
+| `posted` | `posted_date` | `re_stamped: true` if ghost-flagged (skip-pass rule 3) |
+| `source` | `platform` | board the row came from |
+| `apply_url` | `official_url` / `platform_url` | primary link |
+| `other_sources` | — | apply links merged from de-duplicated rows |
+| `flags` | — | `ghost?` / `agency?` (skip-pass flags), blank if clean |
+
+(The raw output also includes `applicant_count`, `easy_apply`, `company_rating`,
+`emails`, `phones`, and more — pass through to the export if the user wants them.)
+
+## Export mode
+
+- **CSV** — UTF-8, header row, quoted fields. One file of the clean rows, named
+  `YYYY-MM-DD_jobs_<role-slug>.csv`, plus the `run_metadata.json` sidecar.
+- **JSON** — `{ "rows": [...], "skipped": [...], "meta": {...} }`.
+- **Raw Apify dataset** — surface the `datasetId` from Step 4 so the user can ingest it
+  directly into a dashboard/BI tool via the Apify API
+  (`https://api.apify.com/v2/datasets/<id>/items?format=csv`) without re-running.
+- **Skipped rows** travel in a separate `skipped` array / file section, each with a
+  `skip_reason` (hard-filter violation, off-target). De-duplicated rows are **not**
+  here — they're merged into the surviving row's `other_sources` as a count. Ghost /
+  agency *flagged* rows stay in the main set with a `flags` value.
+
+Never paste a 100-row table into chat — write the file, show a short sample.
+
+## Résumé-fit mode output
+
+One row per surviving posting, ranked by fit. Extends the normalized schema with the
+sub-agent fields (contract in [fit-scoring.md](fit-scoring.md)):
+
+| Column | Source |
+|---|---|
+| `fit` | 0–100 (`Fit (partial)` if no résumé) |
+| `band` | 🟢 strong / 🟡 worth-a-look / 🟠 stretch / 🔴 low |
+| `matched_skills` | grounded in JD + résumé |
+| `gaps` | prep targets, not necessarily disqualifiers |
+| `ats_keywords_missing` | JD-required terms the résumé lacks (honest-to-add flagged) |
+| `hook` | one-line tailored opener |
+
+For the top 🟢/🟡 rows, render a short **apply-ready brief** inline (grounded — no
+fabrication):
+
+```
+🟢 92 · Senior Backend Engineer (Go) · Example Cloud GmbH · €90–110k
+  Opener: "~7 years building Go + Kubernetes services on Postgres, led a team of four —
+           the multi-region work in your JD lines up closely."
+  ATS keywords to add (honest): "Kubernetes" (résumé says "container orchestration"),
+           "gRPC" (listed under the Acme project — name it explicitly).
+  Gap to prep: distributed tracing at scale (not on your résumé).
+  → Apply: <url>
+```
+
+The full ranked set goes to the file.
+
+## Header summary (always, Step 7)
+
+Lead with it, above any mode output:
+
+- Role + location queried; boards searched (and any that returned 0 / were blocked).
+- **Funnel:** `raw → after hard filters → after dedupe → clean` (+ `N ghost-flagged`,
+  `M agency-flagged`).
+- Date window; run cost.
+- For analysis: coverage notes (e.g. salary disclosed by only ~6% of postings (varies sharply by region)). For
+  résumé-fit: whether the score is **full** (sub-agent read the JDs) or **partial**.
+
+Example:
+
+> **126 senior backend postings in Berlin** across LinkedIn, Indeed, Glassdoor, Google
+> Jobs. 154 raw → 150 after filters → 126 after merging 24 duplicate/repost rows; 5
+> flagged as possible ghosts (re-stamped). Window: last 2 weeks. Run cost ≈ $0.30.
+> Salary disclosed by 6% (8/126). Analysis below; clean rows in the CSV + dataset `<id>`.
+
+## `run_metadata.json` sidecar
+
+Written next to every deliverable for traceability and re-runs:
+
+```json
+{
+  "generatedAt": "YYYY-MM-DDTHH:MM:SSZ",
+  "modes": ["analysis", "export"],
+  "anchors": { "role": "...", "location": "...", "boards": "auto", "resultCap": 100, "postedSince": "2 weeks" },
+  "actors": [{ "actorId": "agentx/all-jobs-scraper", "runId": "...", "datasetId": "..." }],
+  "funnel": { "raw": 154, "afterHardFilters": 150, "afterDedupe": 126, "ghostFlagged": 5, "agencyFlagged": 0 },
+  "coverage": { "salaryDisclosedPct": 6 },
+  "estimatedCostUsd": 0.30
+}
+```
+
+Never fabricate values. Missing dataset fields stay blank everywhere.

--- a/skills/apify-jobs-data/reference/skip-pass.md
+++ b/skills/apify-jobs-data/reference/skip-pass.md
@@ -1,0 +1,103 @@
+# De-noise / Skip Pass — apify-jobs-data (Step 5)
+
+De-noise the raw dataset so every output mode (analysis, export, résumé-fit) runs on
+clean data — ghost-job and repost pollution corrupts demand counts and salary stats
+just as much as it wastes a job seeker's time. Adapted from the skip-pass discipline
+in `apify-link-prospecting-outreach`.
+
+**Golden rule: skip ≠ delete.** Every skipped row stays in the output in a separate
+`Skipped` section with a one-line `skip_reason`. The user must be able to audit what
+was filtered and loosen a rule. Never silently drop a row.
+
+Apply the rules in order. A row that hard-drops (rules 1, 2, 5) leaves the clean set;
+a row that's only *flagged* (rules 3, 4) stays in the set but carries a warning.
+
+## Rule 1 — Hard-filter violation (DROP)
+
+A hard filter (anchor #6) is a non-negotiable, not a score penalty. Drop the row,
+record which filter it failed.
+
+| Filter | Drop when |
+|---|---|
+| `salary_floor` | Disclosed max < floor. **Undisclosed salary never drops here** — it can't violate a floor it doesn't state. Flag it `salary: undisclosed` and let it score neutral in Step 6. |
+| `remote_only` | Posting is on-site / hybrid-required and the user required remote. |
+| `job_type` | Posting type ≠ requested (e.g. contract when user wants full-time). |
+| Work authorization | JD states a citizenship / clearance / visa-sponsorship-excluded constraint the user can't meet. Only drop on an explicit, unambiguous statement — don't infer. |
+
+Hard filters are only relevant when the user supplied them (anchor #6) — an
+analysis-mode run usually wants the *whole* market, no hard filters.
+
+## Rule 2 — Duplicate / repost (DROP, merge up)
+
+The same role is syndicated across boards and reposted over time. Group by
+`(normalized company, normalized title, location)`:
+
+- Normalize company: lowercase, strip `Inc/GmbH/Ltd/LLC/AG`, collapse whitespace.
+- Normalize title: lowercase, strip seniority punctuation and `(m/f/d)`-style tags.
+
+Keep the row with the **most complete fields and the freshest genuine post date**;
+merge the duplicates' apply links into `Other Sources` so nothing is lost. Set
+`saveOnlyUniqueItems: true` on Indeed to cut board-side dupes early.
+
+## Rule 3 — Ghost / stale job (FLAG)
+
+A "ghost job" is a posting that isn't a real, fillable opening right now. These
+waste the user's time. Flag (don't hard-drop unless the user asked to exclude
+ghosts) with `Skip Reason: possible ghost — <tell>`. Tells:
+
+- **Re-stamped recency.** Within one run, the same `(company, title, location)`
+  appearing on multiple boards with conflicting "posted" dates (one shows weeks ago,
+  another "today") is a re-stamp tell. A single board's date alone can't be
+  cross-checked, so single-run ghost detection leans on the language and specificity
+  tells below.
+- **Evergreen age.** Continuously open 60+ days with no edits. This tell is only as
+  trustworthy as the board's original-post-date field — several boards re-stamp or
+  omit it, so treat a missing/unreliable date as "can't compute", not "fresh".
+- **Pipeline language.** JD contains "always accepting applications", "building a
+  pipeline", "future opportunities", "talent community", no specific team/start.
+- **No specifics.** No named team, manager, level band, or start window in a
+  senior-titled req.
+A single weak tell → note it. Two+ tells → label `likely ghost`. Be honest that
+this is heuristic, not certain — never hard-drop a posting on ghost suspicion alone.
+
+## Rule 4 — Staffing-agency repost (FLAG)
+
+When the user wants **direct-employer** roles, flag postings that come from a
+third-party recruiting agency rather than the hiring company. Detect empirically
+(pattern from `apify-influencer-brand-collabs` — don't trust a single unreliable
+field). **A name pattern alone is not enough** — many real employers contain
+"Solutions", "Consulting", or "Talent". Flag only when the name pattern is
+**corroborated** by at least one of the stronger signals:
+
+- **Name pattern** (necessary, not sufficient): `Recruit*`, `Staffing`, `Talent`,
+  `Consulting`, `Solutions`, `Robert Half`, `Hays`, `Michael Page`, `TEKsystems`,
+  `Randstad`, etc. — a candidate signal, never a flag on its own.
+- **Corroboration (require ≥1):** the **same JD body** appears under multiple
+  different "company" names (strong — the real employer is hidden), **or** the JD
+  says "our client" / "a leading company" / "confidential client".
+
+Flag with `Skip Reason: staffing agency — employer hidden` only when name pattern +
+corroboration both hold. Never drop: some users are fine applying through agencies.
+If the user wants agency roles included, skip this rule entirely.
+
+## Rule 5 — Off-target role (DROP)
+
+The query string matched but the role family is wrong (e.g. a query of `engineer`
+returning `sales engineer`, `engineering manager` when the user wants an IC SWE
+role). Make this call from the title + JD, conservatively — when unsure, keep the
+row rather than dropping a real match. Only apply this rule when the user's intent is
+a specific role family; an open market scan keeps everything.
+
+## Empty results are signal
+
+If de-noise empties the clean set (everything was noise) or the board returned
+nothing, **say so plainly and explain why** — niche role, tiny market, over-tight
+recency, a board block. Suggest a concrete loosening (wider `posted_since`, broader
+location, drop a filter, try the fallback Actor). Never fabricate filler rows. (From
+`apify-easy-competitive-intelligence`: "Empty results ARE intelligence.")
+
+## Report the cuts
+
+In the Step 7 header, state the funnel in application order:
+`raw → after hard filters → after dedupe → clean (+ N flagged ghosts, M flagged
+agency)`. Transparency lets the user trust the data and re-run with a looser rule.


### PR DESCRIPTION
## What this adds

`apify-jobs-data` — a job-posting **data-extraction** skill. It aggregates postings across 20+ boards in one Apify run, de-noises them (ghost jobs, reposts, cross-board duplicates) and normalizes the fields into a consistent schema, then serves three output modes on that clean data:

1. **Market & salary analysis** — hiring demand on deduped counts, in-demand skills, remote/hybrid mix, and coverage-labeled salary distribution.
2. **Structured export** — the normalized rows as CSV / JSON, or the raw Apify `datasetId` for direct dashboard / BI ingestion.
3. **Résumé-fit** — rank postings against a résumé, with ATS-keyword gaps.

The shared core (acquire → de-noise → normalize) is the reusable part: clean data is the prerequisite for trustworthy statistics, dashboards, and ranking alike. The skill reuses patterns the existing skills established — anchor-block intake, actor routing with fallbacks, a skip-pass for de-noise, confidence/coverage labeling, per-row sub-agents for résumé-fit — and cites each.

## Note on overlap

An analysis-first job skill may answer the same "demand / skills / salary" questions. This skill's center of gravity is the **cleaned dataset** — deduped and de-ghosted — which every mode runs on, plus two outputs an analysis-only skill doesn't produce: a structured **export / dataset passthrough** for dashboards, and **résumé-fit** ranking. SKILL.md includes a short "Note on overlap" section to make the seam explicit (mirroring the existing `apify-ads-intelligence` ↔ `apify-ecommerce` precedent).

## Actors used

`agentx/all-jobs-scraper` (default, pay-per-result), `misceres/indeed-scraper` (Apify-maintained), `bebity/` + `curious_coder/linkedin-jobs-scraper`, `epctex/google-jobs-scraper`, `memo23/glassdoor-scraper-ppr` (optional salary benchmark). Defaults to pay-per-result routes; subscription actors are opt-in. Actor IDs, input fields, and pricing models were verified against the live store.

## Checklist

- [x] One skill per PR; only `skills/apify-jobs-data/` + one `marketplace.json` entry added
- [x] `README.md` / `agents/AGENTS.md` untouched (auto-generated)
- [x] Telemetry: every `apify` CLI call carries `--json`, `--user-agent apify-awesome-skills/apify-jobs-data`, `2>/dev/null` (`scripts/lint_telemetry.sh` passes)
- [x] `name` matches the folder; `description` ≤ 1024 chars with trigger phrases; `author` + `author_url` set
- [x] Uses only publicly-available Apify Store actors
- [x] `reference/` + `examples/` structure with grounding / no-fabrication discipline (every statistic reports its coverage share)
- [x] **Default aggregator path tested live against the Apify API.** A real Berlin run validated the pipeline end-to-end (acquire → de-noise → normalize → analysis), and the documented input/output were corrected against the live schema: `country` takes a full country name (not ISO-2), `job_type` enum values have no hyphen (`fulltime`), and `max_results` is per-board (≈6× the rows/cost) — all now reflected in the skill.
