### PR TITLE
Add apify-sec-regulatory-intelligence skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,33 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-sec-regulatory-intelligence",
+      "source": "./skills/apify-sec-regulatory-intelligence",
+      "skills": "./",
+      "description": "Monitor and extract U.S. SEC and global financial-regulator filings via Apify Actors \u2014 insider trades (Form 4), 8-K events, 13F holdings & changes, activist 13D/G, Form D / Reg A+, late-filing NT, N-PORT/N-PX fund data, Form ADV, Form 144, SEC litigation/enforcement, FINRA BrokerCheck, and enforcement from FINMA, MAS, HK SFC, India SEBI, Australia ASIC, Japan EDINET, China A-share, and UK RNS. Factual public filing data for research \u2014 not investment advice.",
+      "keywords": [
+        "sec",
+        "edgar",
+        "regulatory",
+        "filings",
+        "insider-trading",
+        "form-4",
+        "8-k",
+        "13f",
+        "13d",
+        "form-d",
+        "finra",
+        "enforcement",
+        "litigation",
+        "compliance",
+        "due-diligence",
+        "mutual-fund",
+        "global-regulators"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-sec-regulatory-intelligence/SKILL.md
+++ b/skills/apify-sec-regulatory-intelligence/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: apify-sec-regulatory-intelligence
+description: Monitor and extract U.S. SEC and global financial-regulator filings via Apify Actors. Use to track insider trades (Form 4), material corporate events (8-K), institutional 13F holdings and changes, activist stakes (13D/G), private placements (Form D / Reg A+), late-filing warnings (Form NT), fund holdings & proxy votes (N-PORT / N-PX), investment advisers (Form ADV), restricted-stock pre-sales (Form 144), SEC litigation & enforcement, FINRA BrokerCheck, or enforcement from global regulators (Swiss FINMA, Singapore MAS, Hong Kong SFC, India SEBI, Australia ASIC, Japan EDINET, China A-share, UK RNS). Triggers - "track insider buying", "who's buying/selling [ticker]", "recent 8-K events", "13F changes for [fund]", "activist 13D filings", "new Form D raises", "SEC enforcement this year", "check a broker on FINRA", "companies that filed late", "regulatory enforcement in [country]", "SEC filings for [company]". Factual public filing data for research - not financial, legal, or investment advice.
+author: NexGenData
+author_url: https://apify.com/nexgendata
+---
+
+# SEC & Regulatory Intelligence
+
+Extract and monitor public regulatory filings - U.S. SEC plus major global regulators - using NexGenData's Apify Actors. Every result links back to its official source filing. **This is factual public data for research; it is not financial, legal, or investment advice and contains no trading signals.**
+
+**Rules for every `apify` command (CI-enforced in awesome-skills):**
+1. `--user-agent apify-awesome-skills/apify-sec-regulatory-intelligence` (telemetry attribution)
+2. `--json` (machine-readable output; use `--format json` for `datasets get-items`)
+3. `2>/dev/null` (suppress progress messages that break JSON parsers)
+
+## Prerequisites
+- Apify CLI v1.5.0+ (`npm install -g apify-cli`)
+- Authenticated: `apify login`, or `export APIFY_TOKEN=...` ([get a token](https://console.apify.com/settings/integrations))
+
+## Workflow
+
+### Step 1 — Pick the Actor
+Identify the filing type / regulator from the user's goal and choose the Actor from **`references/actor-index.md`**. Most U.S. tasks map to one Actor; for "all SEC events for a company" use `nexgendata/sec-event-router` (unified timeline). If the index has no match, search the Store:
+
+    apify actors search "KEYWORDS" --user-agent apify-awesome-skills/apify-sec-regulatory-intelligence --json --limit 10 2>/dev/null
+
+### Step 2 — Fetch the exact input schema (don't guess)
+Schemas evolve; always confirm fields before running:
+
+    apify actors info "nexgendata/SLUG" --user-agent apify-awesome-skills/apify-sec-regulatory-intelligence --input --json 2>/dev/null
+
+Read `references/gotchas.md` for cost guardrails and date-window defaults before running.
+
+### Step 3 — Run
+Keep result caps modest first (these are pay-per-row Actors). Typical call:
+
+    apify actors call "nexgendata/sec-form-4-insider-trading-scraper" --input '{"dateFrom":"2026-06-01","dateTo":"2026-06-13","tickers":["AAPL","NVDA"],"transactionTypes":["P","S"],"maxFilings":25}' --user-agent apify-awesome-skills/apify-sec-regulatory-intelligence --json 2>/dev/null
+
+From output: `.defaultDatasetId`, `.status`, `.id`. For long-running pulls, start async and poll:
+
+    apify actors start "nexgendata/SLUG" --input '{...}' --user-agent apify-awesome-skills/apify-sec-regulatory-intelligence --json 2>/dev/null
+    apify runs info RUN_ID --user-agent apify-awesome-skills/apify-sec-regulatory-intelligence --json 2>/dev/null   # poll until .status == SUCCEEDED
+
+### Step 4 — Fetch results & deliver
+    apify datasets get-items DATASET_ID --user-agent apify-awesome-skills/apify-sec-regulatory-intelligence --format json 2>/dev/null
+
+Report: row count, the key fields, and each row's `source_url` (every filing links to the official regulator). Save large pulls with the Write tool as `YYYY-MM-DD_descriptive-name.csv`/`.json`. For multi-step asks (e.g., "insider clusters, then pull each company's 8-Ks"), chain Actors and suggest the next step.
+
+## Quick map (full list in references/actor-index.md)
+| If the user wants... | Actor |
+|---|---|
+| Insider buys/sells (Form 4) | `nexgendata/sec-form-4-insider-trading-scraper` |
+| 3+ insiders buying the same stock | `nexgendata/insider-cluster-detector` |
+| Material corporate events (8-K) | `nexgendata/sec-form-8k-material-events-scraper` |
+| Institutional 13F holdings + deltas | `nexgendata/sec-form-13f-tracker-pro`, `nexgendata/13f-holdings-delta-tracker` |
+| Activist stakes (13D/G) | `nexgendata/sec-schedule-13dg-activist-tracker` |
+| Private placements (Form D / Reg A+) | `nexgendata/sec-form-d-tracker`, `nexgendata/sec-reg-a-plus-crowdfunding-offerings-tracker` |
+| Late-filing early warnings (NT) | `nexgendata/sec-form-nt-late-filing-tracker` |
+| Any-filing company search (10-K/10-Q…) | `nexgendata/sec-edgar-search`, `nexgendata/sec-edgar-filings-scraper` |
+| Unified per-company SEC timeline | `nexgendata/sec-event-router` |
+| SEC litigation / enforcement | `nexgendata/sec-litigation-releases` |
+| Broker / firm registration check | `nexgendata/finra-brokercheck-search` |
+| Global regulator enforcement | `nexgendata/finma-mas-sfc-enforcement-tracker`, `nexgendata/hk-sfc-enforcement-tracker`, `nexgendata/singapore-mas-enforcement`, `nexgendata/australia-asic-enforcement`, `nexgendata/india-sebi-filings-tracker` |
+| APAC insider/ownership | `nexgendata/japan-edinet-insider-filings`, `nexgendata/hkex-insider-short-tracker`, `nexgendata/china-ashare-insider-trades` |
+| Filings as Markdown for RAG/LLM | `nexgendata/sec-filings-rag-markdown`, `nexgendata/regulatory-enforcement-rag` |
+
+## Compliance
+All data is public regulatory filing data, retrieved from official sources (sec.gov and equivalents). Present it as facts with source links. **Never frame output as financial/investment/legal advice, a recommendation, or a trading signal.** Not affiliated with the U.S. SEC, FINRA, or any regulator.

--- a/skills/apify-sec-regulatory-intelligence/references/actor-index.md
+++ b/skills/apify-sec-regulatory-intelligence/references/actor-index.md
@@ -1,0 +1,76 @@
+# Actor index — SEC & Regulatory Intelligence
+
+All Actors below are **public** on the Apify Store under `nexgendata/`. Always confirm the live input schema with `apify actors info "nexgendata/SLUG" --input --json 2>/dev/null` before running — fields shown here are typical, not authoritative. Every Actor returns rows with a `source_url` to the official filing.
+
+## U.S. SEC — insider & ownership
+| Actor | Use it for | Key inputs (typical) |
+|---|---|---|
+| `sec-form-4-insider-trading-scraper` | Insider (officer/director/10%+) buys & sells, transaction-level | `dateFrom`,`dateTo` (req), `tickers[]`, `transactionTypes[]` (P=buy,S=sell), `maxFilings` |
+| `sec-form4-insider-tracker` | Alt Form 4 view — CEO/CFO buy/sell focus | `tickers`, date window, `maxFilings` |
+| `insider-cluster-detector` | 3+ different insiders buying the SAME stock (cluster signal) | `min_cluster_size`(3), `date_range`("last_30d"), `min_value_usd`, `exclude_sells`, `tickers[]` |
+| `sec-form-144-restricted-stock-sales-tracker` | Planned insider restricted-stock sales (pre-sale notice) | date window, `tickers`, `maxFilings` |
+| `sec-schedule-13dg-activist-tracker` | Activist / >5% stakes (13D/G + amendments) | `dateFrom`,`dateTo` (req), `formTypes[]` (SC 13D / 13G…), `targetTickers[]` |
+| `sec-form-13f-tracker-pro` | Institutional 13F holdings (filer, positions) | `dateFrom`,`dateTo` (req), `filerCik`, `tickers[]`, `query`, `maxHoldingsPerFiling` |
+| `13f-holdings-delta-tracker` | 13F position CHANGES quarter-over-quarter (adds/exits) | filer / fund, period |
+
+## U.S. SEC — corporate events & filings
+| Actor | Use it for | Key inputs |
+|---|---|---|
+| `sec-form-8k-material-events-scraper` | Material events (M&A, results, exec changes) by SEC item code | `dateFrom`,`dateTo` (req), `itemFilter[]` (e.g. 1.01, 2.01, 5.02), `tickers[]` |
+| `sec-edgar-8k-filings` | 8-K material-events tracker (alt) | date window, tickers |
+| `sec-event-router` | UNIFIED per-company SEC filings/events timeline | company/ticker, date window |
+| `sec-edgar-search` | Any-filing company search (10-K, 10-Q, etc.) | `query` (req), `formTypes` ("10-K,10-Q"), date window, `maxResults` |
+| `sec-edgar-filings-scraper` | Pull 10-K/10-Q & filing documents | company, form types |
+
+## U.S. SEC — capital raises, funds, advisers
+| Actor | Use it for | Key inputs |
+|---|---|---|
+| `sec-form-d-tracker` | Private placements / exempt offerings (Form D) | `query`, date window, `minOfferingAmount`, `industryFilter`, `maxResults` |
+| `sec-form-d-scraper` | Form D private-placement filings (alt) | date window, filters |
+| `sec-reg-a-plus-crowdfunding-offerings-tracker` | Reg A/A+ crowdfunding + Form D amendments | date window, filters |
+| `sec-form-nport-p-mutual-fund-holdings` | Fund / ETF portfolio holdings (N-PORT-P) | fund/CIK, period |
+| `sec-form-nport-mutual-fund-holdings` | Mutual-fund holdings & risk data (N-PORT) | fund/CIK, period |
+| `sec-form-npx-mutual-fund-proxy-votes` | Fund proxy-vote disclosures (N-PX) | fund, period |
+| `sec-form-adv-investment-adviser-tracker` | Investment-adviser registrations (Form ADV) | adviser/firm, filters |
+| `sec-form-11-k-employee-stock-plan-tracker` | Employee stock-plan filings (11-K) | company, period |
+
+## U.S. — late filings, enforcement, registration
+| Actor | Use it for | Key inputs |
+|---|---|---|
+| `sec-form-nt-late-filing-tracker` | Companies that filed LATE (NT) — forensic early warning | `form_type`("all"), `days_back`(90), `min_market_cap`, `max_filings` |
+| `sec-litigation-releases` | SEC litigation / enforcement releases | `yearStart`,`yearEnd`, `keywordFilter`, `maxReleases` |
+| `finra-brokercheck-search` | Broker / firm registration & disclosure metadata | `query` (req), `searchType` ("firm"/"individual"), `maxResults` |
+| `court-records-search` | Public court case records | `query`, filters |
+| `ftc-enforcement-actions-scraper` | FTC enforcement actions | date / keyword |
+| `epa-echo-enforcement-scraper` | EPA ECHO environmental enforcement | facility / date |
+
+## Global regulators (NexGenData's differentiator)
+| Actor | Region / regulator | Use it for |
+|---|---|---|
+| `finma-mas-sfc-enforcement-tracker` | CH / SG / HK | Combined FINMA + MAS + SFC enforcement actions |
+| `singapore-mas-enforcement` | Singapore MAS | MAS financial-regulator actions |
+| `hk-sfc-enforcement-tracker` | Hong Kong SFC | 證監會 disciplinary actions, prosecutions, fines |
+| `india-sebi-filings-tracker` | India SEBI | SEBI filings & orders |
+| `australia-asic-enforcement` | Australia ASIC | ASIC regulatory actions |
+| `japan-edinet-insider-filings` | Japan EDINET | 大量保有報告書 / buybacks / insider filings |
+| `hkex-insider-short-tracker` | Hong Kong HKEX | 董事股權變動 / short positions |
+| `china-ashare-insider-trades` | China A-share | 高管增减持 insider transactions |
+| `investegate-rns-aggregator` | UK LSE/AIM | RNS regulatory-announcement metadata |
+
+## News & company context
+| Actor | Use it for |
+|---|---|
+| `crunchbase-news-scraper` | Daily funding & M&A headlines |
+| `globenewswire-press-releases-scraper` | Listed-company press releases |
+| `company-data-aggregator` | LEI + SEC funding + tech profile for a company |
+
+## RAG / LLM feeds
+| Actor | Use it for |
+|---|---|
+| `sec-filings-rag-markdown` | SEC filings converted to clean Markdown for RAG/LLM ingestion |
+| `regulatory-enforcement-rag` | Regulatory enforcement actions as Markdown for RAG |
+
+## MCP option
+| Server | Use it for |
+|---|---|
+| `regulatory-filings-mcp` | The whole regulatory cluster exposed as an MCP server — connect directly via the [Apify MCP connector](https://mcp.apify.com) instead of per-Actor CLI calls. |

--- a/skills/apify-sec-regulatory-intelligence/references/gotchas.md
+++ b/skills/apify-sec-regulatory-intelligence/references/gotchas.md
@@ -1,0 +1,26 @@
+# Gotchas — cost guardrails & error recovery
+
+## Cost (these are pay-per-event Actors)
+- Every Actor here bills **per result row** plus a tiny per-run start fee. **Start with small caps** (`maxFilings` / `maxResults` / `maxReleases` ≈ 10–25) and a **narrow date window**, confirm the data is what the user wants, then widen. Don't pull a year of Form 4 across all tickers on the first run.
+- If the user sets a spend cap, the platform stops the run when it's reached — so a tight `maxFilings` is the cheapest way to preview.
+- For "how much will this cost?" — multiply expected rows by the Actor's per-row price shown on its Store page (`apify actors info "nexgendata/SLUG" --readme 2>/dev/null` includes pricing).
+
+## Date windows
+- US SEC Actors generally take `dateFrom`/`dateTo` (`YYYY-MM-DD`). Several require them (Form 4, 8-K, 13F, 13D/G). Default to a **recent window** (last 7–30 days) unless the user asks for history.
+- `sec-form-nt-late-filing-tracker` uses `days_back` (default 90) — **Form NT is genuinely rare/low-volume**, so a short window can return zero rows. Widen `days_back` before concluding "nothing filed."
+- `sec-form-13f-tracker-pro` data is **seasonal** — 13F is filed within 45 days of quarter-end, so off-cycle windows return little. Tie windows to quarter-ends (mid-Feb / mid-May / mid-Aug / mid-Nov).
+
+## Tickers vs CIK
+- EDGAR identifies filers by **CIK**, and many filings don't expose a ticker. Ticker filters work for large issuers; for precise filer targeting use CIK where the schema accepts it (`filerCik`, etc.). If a ticker returns nothing, the filer may simply not tag it.
+
+## Global Actors
+- The non-US regulators (FINMA/MAS/SFC/SEBI/ASIC/EDINET/HKEX/A-share/RNS) are **lower-volume and language-localized** (several return native-language fields, e.g. 證監會, 大量保有報告書, 高管增减持). Empty results often mean "no enforcement in that window," not a failure.
+
+## Error recovery
+- Auth error → `apify login` or `export APIFY_TOKEN=...`.
+- `0 results` → widen the date window / raise the cap / drop the ticker filter; re-confirm the schema with `--input --json`.
+- Run `FAILED` → read `apify runs info RUN_ID --json 2>/dev/null` (`.statusMessage`); most failures are bad date formats or an unsupported filter value.
+- Always include each row's `source_url` when presenting results — it's the auditable link to the official filing.
+
+## Compliance (non-negotiable)
+This is **public regulatory filing data for research**. Present it as facts with source links. **Do not** generate buy/sell recommendations, price targets, or anything framed as financial, legal, or investment advice. Not affiliated with the SEC, FINRA, or any regulator.


### PR DESCRIPTION
Adds a SEC & regulatory intelligence skill that routes an agent to the right public Apify Actor for:

- U.S. SEC: insider trades (Form 4), material events (8-K), institutional holdings (13F) + deltas, activist stakes (13D/G), private placements (Form D / Reg A+), late filings (NT), fund holdings & proxy votes (N-PORT / N-PX), advisers (Form ADV), restricted-stock pre-sales (Form 144), SEC litigation/enforcement, FINRA BrokerCheck.
- Global regulators: Swiss FINMA, Singapore MAS, Hong Kong SFC, India SEBI, Australia ASIC, Japan EDINET, China A-share, UK LSE/AIM RNS.

Includes `references/actor-index.md` (routing table) and `references/gotchas.md` (cost guardrails, date-window/seasonality notes, compliance). All `apify` CLI commands carry the three required telemetry flags; description is under 1024 chars; `lint_telemetry.sh` and `generate_agents.py` pass locally. Factual public filing data for research — not financial or investment advice.