### PR TITLE
Add apify-apac-company-financial-data skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,34 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-apac-company-financial-data",
+      "source": "./skills/apify-apac-company-financial-data",
+      "skills": "./",
+      "description": "Extract APAC company, exchange, and financial-disclosure data via Apify Actors across Korea, Japan, Taiwan, China, Hong Kong, Singapore, India, and SE Asia \u2014 company registries (Singapore ACRA, Japan corporate number, India MCA/OGD), listed-company disclosures (Japan TDnet, Taiwan MOPS, HKEX, SGX, India SEBI), insider/large-shareholder filings (Japan EDINET, HKEX, China A-share), stock screeners (KOSPI, TSE, TWSE, SGX, NSE/BSE, Eastmoney, plus Vietnam/Indonesia/Thailand/Philippines/Malaysia), IPO calendars (HKEX, Korea, pan-APAC), and Asian regulator enforcement (Singapore MAS, HK SFC). Factual public data for research \u2014 not investment advice.",
+      "keywords": [
+        "apac",
+        "asia",
+        "company-registry",
+        "korea",
+        "japan",
+        "taiwan",
+        "china",
+        "hong-kong",
+        "singapore",
+        "india",
+        "stock-screener",
+        "ipo",
+        "disclosures",
+        "insider-trading",
+        "edinet",
+        "sgx",
+        "hkex",
+        "enforcement"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-apac-company-financial-data/SKILL.md
+++ b/skills/apify-apac-company-financial-data/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: apify-apac-company-financial-data
+description: Extract APAC company, exchange, and financial-disclosure data via Apify Actors — Korea, Japan, Taiwan, China, Hong Kong, Singapore, India, and SE Asia. Use to look up company registries (Singapore ACRA/UEN, Japan 法人番号, India MCA/OGD), pull listed-company disclosures (Japan TDnet 適時開示, Taiwan MOPS, HKEX 披露易, SGX, India SEBI), track insider/large-shareholder filings (Japan EDINET 大量保有報告書, HKEX 董事股權變動, China A-share 高管增减持), screen stocks on Asian exchanges (KOSPI, TSE/日経225, TWSE, SGX/STI, NSE/BSE India, Eastmoney A-shares, plus Vietnam/Indonesia/Thailand/Philippines/Malaysia), follow IPO calendars (HKEX, Korea, pan-APAC), and check Asian regulator enforcement (Singapore MAS, HK SFC). Triggers — "company registry in Singapore/Japan/India", "listed-company filings in Korea/Taiwan/Hong Kong", "insider filings in Japan/HK/China", "screen Asian stocks / KOSPI / TSE / TWSE / SGX", "Asia IPO calendar", "MAS/SFC enforcement". Factual public data for research — not financial or investment advice.
+author: NexGenData
+author_url: https://apify.com/nexgendata
+---
+
+# APAC Company & Financial Data
+
+Extract and monitor public APAC company, exchange, and financial-disclosure data — Korea, Japan, Taiwan, China, Hong Kong, Singapore, India, and wider Southeast Asia — using NexGenData's Apify Actors. Every result links back to its official source (exchange, registry, or regulator). **This is factual public data for research; it is not financial, legal, or investment advice and contains no trading signals.**
+
+**Rules for every `apify` command (CI-enforced in awesome-skills):**
+1. `--user-agent apify-awesome-skills/apify-apac-company-financial-data` (telemetry attribution)
+2. `--json` (machine-readable output; use `--format json` for `datasets get-items`)
+3. `2>/dev/null` (suppress progress messages that break JSON parsers)
+
+## Prerequisites
+- Apify CLI v1.5.0+ (`npm install -g apify-cli`)
+- Authenticated: `apify login`, or `export APIFY_TOKEN=...` ([get a token](https://console.apify.com/settings/integrations))
+- A few Actors need a **user-supplied source API key** (Korea OpenDART, Japan EDINET). See `references/gotchas.md` before running those.
+
+## Workflow
+
+### Step 1 — Pick the Actor
+Identify the **country + data type** (registry / disclosures / insider filings / stock screen / IPO / enforcement) from the user's goal and choose the Actor from **`references/actor-index.md`**. Most tasks map to one country-specific Actor; for "any Asian IPO in the next month" use the pan-APAC `apac-ipo-calendar-sweep`. If the index has no match, search the Store:
+
+    apify actors search "KEYWORDS" --user-agent apify-awesome-skills/apify-apac-company-financial-data --json --limit 10 2>/dev/null
+
+### Step 2 — Fetch the exact input schema (don't guess)
+Field names differ by country (e.g. `ticker_filter` vs `tickers` vs `stockCode` vs `stockCodes`); always confirm before running:
+
+    apify actors info "nexgendata/SLUG" --user-agent apify-awesome-skills/apify-apac-company-financial-data --input --json 2>/dev/null
+
+Read `references/gotchas.md` for cost guardrails, locale/encoding notes, date-window defaults, and which Actors need a source API key.
+
+### Step 3 — Run
+Keep result caps modest first (these are pay-per-row Actors). Typical call:
+
+    apify actors call "nexgendata/japan-tdnet-timely-disclosures" --input '{"date_from":"2026-06-01","date_to":"2026-06-13","ticker_filter":"7203","max_disclosures":25}' --user-agent apify-awesome-skills/apify-apac-company-financial-data --json 2>/dev/null
+
+From output: `.defaultDatasetId`, `.status`, `.id`. For long-running pulls, start async and poll:
+
+    apify actors start "nexgendata/SLUG" --input '{...}' --user-agent apify-awesome-skills/apify-apac-company-financial-data --json 2>/dev/null
+    apify runs info RUN_ID --user-agent apify-awesome-skills/apify-apac-company-financial-data --json 2>/dev/null   # poll until .status == SUCCEEDED
+
+### Step 4 — Fetch results & deliver
+    apify datasets get-items DATASET_ID --user-agent apify-awesome-skills/apify-apac-company-financial-data --format json 2>/dev/null
+
+Report: row count, the key fields, and each row's `source_url` (every record links to the official exchange/registry/regulator). Many APAC sources return native-language fields (한국어, 日本語, 中文) — preserve them and add an English gloss. Save large pulls with the Write tool as `YYYY-MM-DD_descriptive-name.csv`/`.json`. For multi-step asks (e.g., "screen KOSPI, then pull each name's disclosures"), chain Actors and suggest the next step.
+
+## Quick map (full list in references/actor-index.md)
+| If the user wants... | Actor |
+|---|---|
+| Singapore company / UEN / director lookup | `nexgendata/singapore-acra-company-lookup` |
+| Japan company by 法人番号 (corporate number) | `nexgendata/japan-houjin-bangou-corporate-registry` |
+| India company / CIN (OGD master data) | `nexgendata/ogd-india-companies-registry` |
+| Japan listed-company disclosures (TDnet 適時開示) | `nexgendata/japan-tdnet-timely-disclosures` |
+| Taiwan listed-company announcements (MOPS) | `nexgendata/taiwan-mops-company-announcements` |
+| Hong Kong company announcements (HKEXnews 披露易) | `nexgendata/hkex-news-announcements` |
+| Singapore exchange disclosures (SGX) | `nexgendata/sgx-company-announcements` |
+| India SEBI filings | `nexgendata/india-sebi-filings-tracker` |
+| Japan large-shareholder / buyback (EDINET 大量保有報告書) | `nexgendata/japan-edinet-insider-filings` |
+| Hong Kong director dealings / short positions (HKEX) | `nexgendata/hkex-insider-short-tracker` |
+| China A-share insider transactions (高管增减持) | `nexgendata/china-ashare-insider-trades` |
+| Screen Korean stocks (KOSPI/KOSDAQ) | `nexgendata/kospi-stock-screener` |
+| Screen Japanese stocks (TSE / 日経225) | `nexgendata/tse-japan-stock-screener` |
+| Screen Taiwan stocks (TWSE) | `nexgendata/twse-stock-screener` |
+| Screen Singapore stocks (SGX / STI) | `nexgendata/sgx-singapore-stock-screener` |
+| Screen India stocks (NSE/BSE) | `nexgendata/nse-india-stock-screener`, `nexgendata/bse-india-stock-screener` |
+| Screen China A-shares (Eastmoney) | `nexgendata/eastmoney-china-stock-screener` |
+| Asia-wide IPO calendar | `nexgendata/apac-ipo-calendar-sweep` |
+| Hong Kong IPO calendar | `nexgendata/hkex-ipo-calendar` |
+| Korea IPO pipeline (코스피/코스닥) | `nexgendata/korea-ipo-pipeline-tracker` |
+| Asian regulator enforcement (MAS / SFC) | `nexgendata/singapore-mas-enforcement`, `nexgendata/hk-sfc-enforcement-tracker`, `nexgendata/finma-mas-sfc-enforcement-tracker` |
+
+## Compliance
+All data is public company, exchange, and regulatory data, retrieved from official APAC sources (exchanges, company registries, and financial regulators). Present it as facts with source links. **Never frame output as financial/investment/legal advice, a recommendation, or a trading signal.** Not affiliated with any exchange, registry, or regulator.

--- a/skills/apify-apac-company-financial-data/references/actor-index.md
+++ b/skills/apify-apac-company-financial-data/references/actor-index.md
@@ -1,0 +1,71 @@
+# Actor index — APAC Company & Financial Data
+
+All Actors below are **public** on the Apify Store under `nexgendata/`. Always confirm the live input schema with `apify actors info "nexgendata/SLUG" --input --json 2>/dev/null` before running — fields shown here are typical, not authoritative. Field names vary by country. Every Actor returns rows with a `source_url` to the official exchange, registry, or regulator.
+
+## Company registries & corporate lookup
+| Actor | Use it for | Key inputs (typical) |
+|---|---|---|
+| `singapore-acra-company-lookup` | Singapore ACRA / BizFile+ company lookup — UEN, status, directors | `queries[]` or `query` (company name/UEN); aliases `companies[]`/`names[]`/`name` |
+| `japan-houjin-bangou-corporate-registry` | Japan corporate registry (法人番号 / NTA) — number, name, address | `corporate_number`, `company_name_filter` (商号), `prefecture_filter`, `category_filter`, `max_records`; optional `nta_api_key` |
+| `ogd-india-companies-registry` | India MCA companies master data (via OGD) — CIN, ROC, status | `company_name_contains`, `roc`, `state`, `max_results`; optional `api_key` |
+
+## Listed-company disclosures & announcements
+| Actor | Region / source | Key inputs |
+|---|---|---|
+| `japan-tdnet-timely-disclosures` | Japan TDnet — 適時開示 timely disclosures (TSE) | `date_from`,`date_to` (YYYY-MM-DD), `company_filter`, `ticker_filter` (4-digit code), `disclosure_type`, `max_disclosures` |
+| `taiwan-mops-company-announcements` | Taiwan MOPS — 公開資訊觀測站 重大訊息 | `date_from`,`date_to` (TPE), `company_filter` (中文/EN), `ticker_filter` (4-digit), `disclosure_type`, `max_disclosures` |
+| `hkex-news-announcements` | Hong Kong HKEXnews — 披露易 listed-company announcements | `tickers[]`, `categoryFilter`, `lookbackDays`, `maxResults` |
+| `sgx-company-announcements` | Singapore SGX — company disclosure feed | `tickers[]`, `category`, `lookbackDays`, `maxResults` |
+| `india-sebi-filings-tracker` | India SEBI — filings & orders | `filing_types[]`, `company_filter[]`, `days_back`, `start_date`/`end_date`, `sector_filter`, `status_filter`, `max_filings` |
+
+## Insider / large-shareholder filings
+| Actor | Region / source | Key inputs |
+|---|---|---|
+| `japan-edinet-insider-filings` | Japan EDINET — 大量保有報告書 (large-holder) / 自社株買い (buyback) | `apiKey` (EDINET key, **required**), `date_from`,`date_to`, `doc_type`, `filer_name`, `issuer_ticker` (4-digit), `enrich_xbrl`, `max_filings` |
+| `hkex-insider-short-tracker` | Hong Kong HKEX — 董事股權變動 (director dealings) / 沽空持倉 (short positions) | `stockCode`, `disclosureType`, `startDate`,`endDate`, `minSharesChanged`, `limit` |
+| `china-ashare-insider-trades` | China A-share — 高管增减持 insider transactions | `stockCodes[]`, `dateRange` (preset) or `startDate`/`endDate`, `transactionType`, `maxRecords` |
+
+## Stock screeners (Asian exchanges)
+| Actor | Exchange / index | Key inputs |
+|---|---|---|
+| `kospi-stock-screener` | Korea KOSPI / KOSDAQ | `market`, `limit`, `sector`, `min_market_cap_billion_krw`, `enrich_sector` |
+| `tse-japan-stock-screener` | Japan TSE / 日経225 | `index`, `limit`, `min_market_cap_jpy_billion`, `sector`, `enrich_fundamentals` |
+| `twse-stock-screener` | Taiwan TWSE | `limit`, `min_trade_value_twd`, `min_volume`, `max_pe_ratio`, `min_dividend_yield`, `sector`, `include_etfs` |
+| `sgx-singapore-stock-screener` | Singapore SGX / STI | `market`, `limit`, `min_market_cap_sgd`, `sector`, `enrich_fundamentals` |
+| `nse-india-stock-screener` | India NSE (+ index screener) | `limit`, `exchange`, `min_market_cap_crore`, `sector` |
+| `bse-india-stock-screener` | India BSE (Bombay) equities | company / cap / sector filters (confirm via `--input`) |
+| `eastmoney-china-stock-screener` | China A-shares (Eastmoney 东方财富) | `market`, `sort_by`, `sort_order`, `max_results` |
+| `chinese-adrs-stock-screener` | China ADRs on NYSE/NASDAQ | cap / sector filters (confirm via `--input`) |
+| `star-market-china-stock-screener` | Shanghai STAR Market 上海科创板 | cap / sector filters |
+| `chinext-china-stock-screener` | Shenzhen ChiNext 深圳创业板 | cap / sector filters |
+| `bse-beijing-stock-screener` | Beijing Stock Exchange 北京证券交易所 | cap / sector filters |
+| `hkex-hang-seng-stock-screener` | Hong Kong HKEX / Hang Seng 恒生指數 | cap / sector filters |
+| `hose-vietnam-stock-screener` | Vietnam HOSE / VN30 | cap / sector filters |
+| `idx-indonesia-stock-screener` | Indonesia IDX / LQ45 | cap / sector filters |
+| `set-thailand-stock-screener` | Thailand SET / SET50 | cap / sector filters |
+| `pse-philippines-stock-screener` | Philippines PSE / PSEi | cap / sector filters |
+| `bursa-malaysia-stock-screener` | Malaysia Bursa / KLCI | cap / sector filters |
+
+## IPO calendars & pipelines
+| Actor | Region | Key inputs |
+|---|---|---|
+| `apac-ipo-calendar-sweep` | Pan-APAC IPO sweep (all major Asian markets) | `country`, `status`, `lookbackDays`, `lookaheadDays`, `sector`, `minProceedsUsdMillion`, `limit` |
+| `hkex-ipo-calendar` | Hong Kong HKEX (主板 / GEM) | `mode`, `lookbackDays`, `lookaheadDays`, `listingBoard`, `sector`, `minProceedsHkdMillion`, `limit` |
+| `korea-ipo-pipeline-tracker` | Korea 코스피/코스닥 IPO pipeline | `opendart_api_key` (**required**), `stage_filter`, `market_filter`, `min_offering_size_KRW`, `date_from`/`date_to`, `max_records` |
+
+## Regulator enforcement (Asia)
+| Actor | Region / regulator | Key inputs |
+|---|---|---|
+| `singapore-mas-enforcement` | Singapore MAS — financial-regulator actions | `action_type`, `date_from`,`date_to`, `firm_filter`, `individual_filter`, `max_results` |
+| `hk-sfc-enforcement-tracker` | Hong Kong SFC — 證監會 紀律處分 / 檢控 / 罰款 | `action_type`, `party_type`, `decision_date_from`,`decision_date_to`, `keyword`, `limit` |
+| `finma-mas-sfc-enforcement-tracker` | CH / SG / HK combined (FINMA + MAS + SFC) | `regulator`, `action_type`, `days_back`, `min_fine_amount` (USD), `max_actions` |
+
+## Markets context & flows
+| Actor | Use it for | Key inputs |
+|---|---|---|
+| `china-etf-flow-tracker` | China ETF fund flows (Eastmoney 东方财富 ETF资金流向) | confirm via `--input` |
+| `analyst-price-targets` | Analyst consensus / upgrades / downgrades (incl. APAC tickers) | confirm via `--input` |
+| `pr-newswire-asia-press-releases-scraper` | PR Newswire Asia — corporate press releases | confirm via `--input` |
+| `india-rbi-monetary-policy-statements` | India RBI MPC monetary-policy statements | confirm via `--input` |
+
+> Note: several APAC registry / exchange / regulator Actors are still in the public-flip queue (e.g. Korea DART/KIND/KRX, Taiwan MOEA/FSC, Japan FSA/JPX, India MCA detailed-filings, China CNIPA, Singapore MAS-FI-directory, PSE Edge). They are **omitted here on purpose** — this index routes only to Actors that are currently `isPublic:true`. As flips proceed, add the new public slugs here.

--- a/skills/apify-apac-company-financial-data/references/gotchas.md
+++ b/skills/apify-apac-company-financial-data/references/gotchas.md
@@ -1,0 +1,39 @@
+# Gotchas — cost guardrails, locale & error recovery
+
+## Cost (these are pay-per-event Actors)
+- Every Actor here bills **per result row** plus a tiny per-run start fee. **Start with small caps** (`max_disclosures` / `maxResults` / `limit` / `max_records` / `maxRecords` ≈ 10–25) and a **narrow date window**, confirm the data is what the user wants, then widen. Don't screen an entire exchange or pull a year of disclosures on the first run.
+- Stock screeners with `enrich_*` flags (`enrich_sector`, `enrich_fundamentals`, `enrich_xbrl`) make **extra per-row fetches** — slower and more expensive. Leave enrichment **off** for a first pass; turn it on only for the final shortlist.
+- For "how much will this cost?" — multiply expected rows by the Actor's per-row price on its Store page (`apify actors info "nexgendata/SLUG" --readme 2>/dev/null` includes pricing).
+
+## Source API keys required (user must supply their own)
+A few Actors call an official API that needs a **free key the user registers themselves** — we don't ship one:
+- `japan-edinet-insider-filings` → `apiKey` (Japan FSA **EDINET** subscription key).
+- `korea-ipo-pipeline-tracker` → `opendart_api_key` (Korea FSS **OpenDART** key).
+- Optional (work without, better with a key): `japan-houjin-bangou-corporate-registry` (`nta_api_key`), `ogd-india-companies-registry` (`api_key`).
+If the user hasn't got one, point them to the source's free developer portal; don't hard-code or share keys.
+
+## Field names differ by country (don't assume)
+APAC Actors were built per-source, so the same concept has different field names:
+- Date windows: `date_from`/`date_to` (Japan TDnet, Taiwan MOPS, EDINET, Singapore MAS), `startDate`/`endDate` (HKEX insider, China A-share), `start_date`/`end_date` (SEBI), `decision_date_from`/`decision_date_to` (HK SFC), or `lookbackDays`/`lookaheadDays` (HKEX/SGX/IPO sweep).
+- Ticker/code: `ticker_filter` (Japan/Taiwan, 4-digit), `issuer_ticker` (EDINET), `tickers[]` (HKEX/SGX announcements), `stockCode` (HKEX insider, single), `stockCodes[]` (China A-share, array).
+- Result cap: `max_disclosures` / `maxResults` / `max_results` / `max_records` / `maxRecords` / `limit` — all different. **Always run `apify actors info … --input --json` first.**
+
+## Locale, encoding & calendars
+- Many APAC sources return **native-language fields** (한국어, 日本語, 繁體中文/简体中文). Preserve the original string and add an English gloss when presenting. Examples: 適時開示 (timely disclosure), 大量保有報告書 (large-shareholding report), 重大訊息 (material announcement), 高管增减持 (executive buy/sell), 證監會 (HK SFC).
+- Use 4-digit securities codes, not Western tickers, for Japan (e.g. Toyota = `7203`) and Taiwan (e.g. TSMC = `2330`). China A-shares use 6-digit codes (e.g. `600519`); HK uses up to 5 digits (e.g. `00700`).
+- Time zones matter for "today's" disclosures — Taiwan MOPS is TPE, TDnet is JST, etc. A UTC date window can miss the local trading day; widen by one day if a fresh filing seems missing.
+
+## Volume & seasonality
+- Registries (ACRA / 法人番号 / OGD India) are **lookup** Actors: give a specific company name/number, not an open-ended sweep, or you'll pay for noise.
+- Insider / large-shareholder and enforcement feeds are **lower-volume**; an empty window usually means "nothing filed," not a failure — widen the dates before concluding zero.
+- IPO calendars are bursty and seasonal; use `lookaheadDays` for upcoming listings and `lookbackDays` for recent ones, and don't expect a steady stream off-cycle.
+
+## Error recovery
+- Auth error (Apify) → `apify login` or `export APIFY_TOKEN=...`.
+- `401/403` from inside the run → a **source** API key is missing/invalid (EDINET / OpenDART) — see above.
+- `0 results` → widen the date window / raise the cap / drop the company/ticker filter; re-confirm the schema with `--input --json` (you may be using the wrong field name).
+- Run `FAILED` → read `apify runs info RUN_ID --json 2>/dev/null` (`.statusMessage`); most failures are bad date formats, a wrong code format (Western ticker instead of numeric code), or an unsupported filter value.
+- Always include each row's `source_url` when presenting results — it's the auditable link to the official exchange / registry / regulator.
+
+## Compliance (non-negotiable)
+This is **public company, exchange, and regulatory data for research**. Present it as facts with source links. **Do not** generate buy/sell recommendations, price targets, or anything framed as financial, legal, or investment advice. Not affiliated with any exchange, company registry, or financial regulator.


### PR DESCRIPTION
Adds an APAC company & financial data skill that routes an agent to the right public Apify Actor across Korea, Japan, Taiwan, China, Hong Kong, Singapore, India, and Southeast Asia:

- **Company registries:** Singapore ACRA/UEN, Japan corporate number, India MCA/OGD.
- **Listed-company disclosures:** Japan TDnet, Taiwan MOPS, HKEXnews, SGX, India SEBI.
- **Insider / large-shareholder filings:** Japan EDINET, HKEX director dealings & short positions, China A-share.
- **Stock screeners:** KOSPI, TSE, TWSE, SGX/STI, NSE/BSE India, Eastmoney A-shares, plus Vietnam/Indonesia/Thailand/Philippines/Malaysia/STAR/ChiNext/Beijing.
- **IPO calendars:** pan-APAC sweep, HKEX, Korea pipeline.
- **Asian regulator enforcement:** Singapore MAS, HK SFC, combined FINMA+MAS+SFC.

Includes references/actor-index.md (per-country routing table with key inputs) and references/gotchas.md (cost guardrails, locale/encoding & numeric-code notes, source-API-key requirements for EDINET/OpenDART, compliance). All apify CLI commands carry the three required telemetry flags; the description is under 1024 chars; lint_telemetry.sh and generate_agents.py pass locally. Factual public company/exchange/regulator data for research — not financial or investment advice.