### PR TITLE
apify-linkedin-intelligence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -207,6 +207,30 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-linkedin-intelligence",
+      "source": "./skills/apify-linkedin-intelligence",
+      "skills": "./",
+      "description": "Turn LinkedIn into a B2B go-to-market data source with Apify Actors across the three data pillars — company firmographics, people profiles, and job postings. Powers four workflows: TAM sizing, prospect/lead list building, headcount benchmarking, and hiring-signal selling. Use when the user says size my TAM, build a prospect list of <title> at <companies>, find decision makers, how many employees does <company> have, benchmark headcount vs competitors, who is hiring for <role>, hiring signals for sales, LinkedIn company/people/jobs scraper, or enrich these LinkedIn URLs. Chains firmographics + people + jobs instead of relying on a single scraper, and confirms input schemas before running because LinkedIn Actor inputs drift.",
+      "keywords": [
+        "linkedin",
+        "b2b",
+        "lead-generation",
+        "prospecting",
+        "tam-sizing",
+        "firmographics",
+        "headcount",
+        "hiring-signals",
+        "sales-intelligence",
+        "people-profiles",
+        "job-postings",
+        "icp",
+        "go-to-market",
+        "apollo-alternative"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-linkedin-intelligence/SKILL.md
+++ b/skills/apify-linkedin-intelligence/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: apify-linkedin-intelligence
+description: Turn LinkedIn into a B2B go-to-market data source using Apify Actors across the three LinkedIn data pillars — company firmographics, people profiles, and job postings. Use for TAM sizing (count and size companies in a market), prospect / lead list building (find decision-makers by title, company, seniority, geo), headcount benchmarking (compare employee counts and growth across competitors), and hiring-signal selling (turn new job postings into buying signals and timed outreach). Trigger phrases include "size my TAM on LinkedIn", "build a prospect list of <title> at <companies>", "find decision makers / ICP contacts", "how many employees does <company> have", "benchmark headcount vs competitors", "who is hiring for <role>", "hiring signals for sales", "LinkedIn company / people / jobs scraper", or "enrich these LinkedIn URLs". Chains firmographics + people + jobs instead of a single scraper, and confirms input schemas before running because LinkedIn Actor inputs drift.
+author: Yoghesh D
+author_url: https://github.com/yogeshd
+---
+
+# LinkedIn intelligence for B2B go-to-market
+
+Turn LinkedIn's three data pillars — **companies** (firmographics), **people** (profiles), and **jobs** (postings) — into four sales/RevOps workflows: TAM sizing, prospect list building, headcount benchmarking, and hiring-signal selling.
+
+## The key insight
+
+LinkedIn value comes from **chaining the three pillars**, not from any one scraper:
+
+- A **company search** gives you the *accounts* in a market (TAM).
+- A **people search** inside those accounts gives you the *contacts* (prospects).
+- A **jobs feed** for those accounts gives you the *timing* (hiring signals = budget + pain).
+
+So the routing decision is "which pillar(s) does this question touch", then chain them. The output of one pillar (a company slug, a company name, a profile URL) is the input to the next.
+
+| Pillar | Answers | Primary use |
+|--------|---------|-------------|
+| Company | "which/how many companies, how big" | TAM sizing, headcount benchmarking |
+| People | "who are the decision-makers" | prospect/lead lists, ICP enrichment |
+| Jobs | "who is hiring, for what, when" | hiring-signal selling, expansion timing |
+
+**Always confirm the input schema before running** (`apify actors info "ACTOR_ID" --input --json`). LinkedIn Actor inputs differ between Actors and change often — the same intent ("scrape a company") uses `profileUrls` in one Actor and `companyUrls`/`identifier` in another. A wrong field name silently returns 0 results.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## Workflow
+
+1. **Classify the goal** into one of the four workflows below (or a combination), and identify which pillar(s) it needs.
+2. **Resolve identifiers first.** LinkedIn Actors key off exact slugs/URLs, not loose names. Discover them via SERP before scraping — `apify/google-search-scraper` with `"<company> site:linkedin.com/company"` (company slug) or `"<title> <company> site:linkedin.com/in"` (people). A wrong slug returns 0 rows silently.
+3. **Confirm the schema.** Run `apify actors info "ACTOR_ID" --input --json` and build input against the *actual* field names. Note where output lands (dataset vs key-value store — see gotchas).
+4. **Estimate cost, then run.** LinkedIn Actors are usually `PAY_PER_EVENT` (per profile/company/job). Multiply by your row count and confirm with the user if the estimate is significant (see [references/gotchas.md](references/gotchas.md)).
+5. **Deliver.** Report row count, the columns, and a link to the dataset/console. Default to CSV for lists; summarize counts/medians for TAM and benchmarking.
+
+### The four workflows
+
+| Workflow | Pillars chained | Recipe |
+|----------|-----------------|--------|
+| **TAM sizing** | Company | Search companies by industry + headcount band + geo → dedupe → report count, size distribution, and the account list. Treat counts as **modeled/directional**, not exact. |
+| **Prospect list building** | Company → People | Get target accounts (or take a user list) → people-search each by title/seniority → enrich profiles → output one contact per row, deduped. |
+| **Headcount benchmarking** | Company | Scrape firmographics for a competitor set → compare `employeeCount`, follower count, industry, HQ → rank. Re-run on a schedule to track headcount growth over time. |
+| **Hiring-signal selling** | Jobs (→ Company → People) | Pull recent job postings for target accounts/roles → a new posting = active budget + pain → optionally chain to people-search for the hiring manager → draft timed outreach. |
+
+## Actor routing
+
+LinkedIn is a protected platform — **never** use a generic crawler (`website-content-crawler`, `rag-web-browser`) on `linkedin.com`. Use a dedicated Actor.
+
+| User need | Actor ID | Tier | Best for |
+|-----------|----------|------|----------|
+| Company firmographics | `dev_fusion/Linkedin-Company-Scraper` | community | Employee count, industry, HQ, followers, about. **Output lands in the key-value store, not the dataset.** Field is `profileUrls`. |
+| Company firmographics (alt) | `harvestapi/linkedin-company` | community | Firmographics with dataset output; good when you have many slugs. |
+| People profiles (enrich URLs) | `harvestapi/linkedin-profile-scraper` | community | Full profile from a profile URL: title, company, location, experience, headline. |
+| People search (build lists) | `harvestapi/linkedin-profile-search` | community | Find people by keywords/title/company/location without knowing URLs — the prospecting engine. |
+| Job postings | `curious_coder/linkedin-jobs-scraper` | community | Jobs from a LinkedIn jobs **search URL** (not keywords). `count` min is 10. Returns company firmographics too (`companyEmployeesCount`, `companyWebsite`). |
+| Job postings (alt) | `harvestapi/linkedin-job` | community | Jobs feed with dataset output; pair with company search. |
+| Resolve slugs / profile URLs | `apify/google-search-scraper` | apify | Discover the exact `linkedin.com/company/<slug>` or `linkedin.com/in/<handle>` before scraping. |
+
+`Tier` = `apify` (Apify-maintained, prefer) or `community` (third-party). These are starting points — run `apify actors search "linkedin" --json --limit 20` to find current alternatives, and always confirm the schema (step 3). See [references/actor-index.md](references/actor-index.md) for the full table and field notes.
+
+## Calling Actors — Apify CLI
+
+Three flags on every call (`--json`, `--user-agent`, `2>/dev/null`):
+
+    # 0. Resolve the exact company slug first (names != slugs: "Oxylabs" -> "oxylabs-io")
+    apify actors call "apify/google-search-scraper" \
+      -i '{"queries":"Acme Corp site:linkedin.com/company","maxPagesPerQuery":1,"resultsPerPage":5}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence \
+      2>/dev/null
+
+    # 1. Company firmographics (TAM / headcount benchmarking) — output is in the KV store
+    apify actors call "dev_fusion/Linkedin-Company-Scraper" \
+      -i '{"profileUrls":["https://www.linkedin.com/company/oxylabs-io/"]}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence \
+      2>/dev/null
+
+    # 2. People search (build a prospect list by title + company + geo)
+    apify actors call "harvestapi/linkedin-profile-search" \
+      -i '{"currentCompanies":["Acme Corp"],"jobTitles":["VP Sales","Head of Revenue"],"locations":["United States"],"maxItems":50}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence \
+      2>/dev/null
+
+    # 3. Enrich specific profile URLs
+    apify actors call "harvestapi/linkedin-profile-scraper" \
+      -i '{"profileUrls":["https://www.linkedin.com/in/some-handle/"]}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence \
+      2>/dev/null
+
+    # 4. Hiring signals — jobs from a LinkedIn jobs SEARCH URL (not keywords), count >= 10
+    apify actors call "curious_coder/linkedin-jobs-scraper" \
+      -i '{"urls":["https://www.linkedin.com/jobs/search/?keywords=Account%20Executive&location=United%20States"],"count":10,"scrapeCompany":true}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence \
+      2>/dev/null
+
+    # Inspect input schema (DO THIS before every new Actor) / fetch dataset results
+    apify actors info "harvestapi/linkedin-profile-search" --input --json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence 2>/dev/null
+    apify datasets get-items DATASET_ID --format json \
+      --user-agent apify-awesome-skills/apify-linkedin-intelligence 2>/dev/null
+
+The input fields above are **illustrative** — confirm them against each Actor's real schema before running. The Apify MCP server (<https://mcp.apify.com>) and any MCP client (e.g. `mcpc`) are equivalent alternatives.
+
+## Troubleshooting
+
+- **0 rows returned** → almost always a wrong slug/name/URL or wrong input field. Re-resolve the slug via SERP (step 2), and re-check the field name against `apify actors info ... --input`.
+- **Company scraper "returned nothing"** → `dev_fusion/Linkedin-Company-Scraper` writes to the **key-value store**, not the dataset. Read the KV store keys after the run.
+- **Jobs Actor rejects keywords** → `curious_coder/linkedin-jobs-scraper` needs a full `linkedin.com/jobs/search/?...` URL, and `count` min is 10. URL-encode multi-word values (`Bright Data` → `Bright%20Data`).
+- **Headcount looks off** → LinkedIn employee/TAM counts are **modeled and directional**, not a ground-truth census. Label them as estimates; cross-check against the company website or jobs Actor's `companyEmployeesCount`.
+- **Cost climbing on a big list** → these Actors bill per result. Cap `maxItems`, run a small sample first to validate the schema, then scale. See [references/gotchas.md](references/gotchas.md).

--- a/skills/apify-linkedin-intelligence/references/actor-index.md
+++ b/skills/apify-linkedin-intelligence/references/actor-index.md
@@ -1,0 +1,40 @@
+# Actor index — apify-linkedin-intelligence
+
+Full routing table for LinkedIn's three data pillars. The agent reads this after
+`SKILL.md` to pick the right Actor for a specific intent, then **confirms the
+schema** with `apify actors info "ACTOR_ID" --input --json` before running —
+LinkedIn Actor input field names drift and differ between Actors.
+
+| Pillar | User intent | Actor ID | Tier | Notes |
+|--------|-------------|----------|------|-------|
+| Company | Firmographics for known slugs | `dev_fusion/Linkedin-Company-Scraper` | community | Input field `profileUrls` (full `linkedin.com/company/<slug>/` URLs). **Output written to the key-value store, not the dataset.** Returns employee count, industry, HQ, followers, specialties, about. |
+| Company | Firmographics, many slugs, dataset output | `harvestapi/linkedin-company` | community | Dataset output; convenient for benchmarking sets. Confirm the URL/identifier field name in the schema. |
+| People | Enrich known profile URLs | `harvestapi/linkedin-profile-scraper` | community | Full profile: name, headline, current title/company, location, experience, education, skills. Input is a list of `linkedin.com/in/<handle>` URLs. |
+| People | Search/discover by ICP (no URLs yet) | `harvestapi/linkedin-profile-search` | community | **The prospecting engine.** Filter by title, company, location, keywords. Confirm exact filter field names (e.g. `jobTitles`, `currentCompanies`, `locations`) and the result cap (`maxItems`). |
+| Jobs | Postings from a jobs search URL | `curious_coder/linkedin-jobs-scraper` | community | Input `urls` = full `linkedin.com/jobs/search/?...` URLs (NOT keywords). `count` min is 10. `scrapeCompany: true` adds firmographics (`companyEmployeesCount`, `companyWebsite`, `companyLinkedinUrl`). |
+| Jobs | Postings, dataset output, pair w/ company set | `harvestapi/linkedin-job` | community | Alternative jobs feed; confirm input shape in schema. |
+| Resolver | Find exact slug / profile URL | `apify/google-search-scraper` | apify | `"<company> site:linkedin.com/company"` → slug; `"<title> <company> site:linkedin.com/in"` → people URLs. Take the first matching `organicResults[].url`. |
+
+## Field cheat-sheet (confirm against live schema)
+
+`curious_coder/linkedin-jobs-scraper` output keys (verified in a sibling skill):
+`id`, `title`, `companyName`, `companyLinkedinUrl`, `companyWebsite`,
+`companyEmployeesCount`, `location`, `country`, `postedAt`,
+`postedAtTimestamp`, `salary`, `salaryInsights`, `seniorityLevel`,
+`employmentType`, `jobFunction`, `industries`, `descriptionText`,
+`applicantsCount`, `applyUrl`, `workplaceTypes`, `workRemoteAllowed`, `link`.
+
+## Workflow → Actor chains
+
+- **TAM sizing** → `harvestapi/linkedin-company` (or people/company search) → dedupe → size distribution.
+- **Prospect list** → `apify/google-search-scraper` (resolve) → `harvestapi/linkedin-profile-search` (discover) → `harvestapi/linkedin-profile-scraper` (enrich).
+- **Headcount benchmarking** → `apify/google-search-scraper` (slugs) → `dev_fusion/Linkedin-Company-Scraper` (read KV store) → compare `employeeCount`.
+- **Hiring signals** → `curious_coder/linkedin-jobs-scraper` (search URL) → optionally `harvestapi/linkedin-profile-search` for the hiring manager.
+
+## How to extend
+
+1. Search for candidates: `apify actors search "linkedin <pillar>" --json --limit 20 2>/dev/null`
+2. Fetch input schema: `apify actors info "ACTOR_ID" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it, and note its output sink (dataset vs KV store) and the exact input field name.
+
+Prefer `apify`-maintained Actors where a comparable one exists.

--- a/skills/apify-linkedin-intelligence/references/gotchas.md
+++ b/skills/apify-linkedin-intelligence/references/gotchas.md
@@ -1,0 +1,79 @@
+# Gotchas — apify-linkedin-intelligence
+
+Cost guardrails, error recovery, and LinkedIn-specific pitfalls. The agent reads
+this on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+LinkedIn Actors are almost always `PAY_PER_EVENT` — you pay per profile,
+company, or job returned. Cost = (rows requested) × (per-result price). Check the
+model first:
+
+    apify actors info "ACTOR_ID" --json 2>/dev/null   # look at pricingInfo
+
+| Model | What to watch for |
+|-------|-------------------|
+| `FREE` | No cost — safe to run. |
+| `PAY_PER_EVENT` | **The common case here.** Cost scales linearly with `maxItems`/`count`. Estimate before running. |
+| `FLAT_PRICE_PER_MONTH` | Subscription — runs unlimited once paid. |
+
+### Confirmation thresholds (suggested)
+
+- Estimated cost **>$5** → warn the user.
+- Estimated cost **>$20** → require explicit confirmation before running.
+- Always present cost as a **rough estimate** ("around $X"), not a guarantee.
+
+### Sample-then-scale (do this on every large list)
+
+1. Run with `maxItems`/`count` set to ~10 to confirm the schema and output shape.
+2. Inspect the columns and that rows are non-empty.
+3. Only then raise the cap to the full list. This avoids paying for a 5,000-row
+   run that returns 0 usable rows because of a wrong field name.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Run finishes, 0 dataset rows | Wrong slug/name/URL, or `dev_fusion/Linkedin-Company-Scraper` wrote to the **KV store** | Re-resolve the slug via SERP; read the KV store keys, not the dataset. |
+| `count` rejected / too low | `curious_coder/linkedin-jobs-scraper` `count` minimum is 10 | Set `count: 10` or higher. |
+| Jobs Actor returns unrelated jobs | Passed keywords instead of a jobs search URL, or unencoded spaces | Use a full `linkedin.com/jobs/search/?...` URL; URL-encode (`Bright Data` → `Bright%20Data`). |
+| Wrong input field name | LinkedIn Actor inputs vary (`profileUrls` vs `companyUrls` vs `identifier`) | Always `apify actors info "ACTOR_ID" --input --json` before building input. |
+| Headcount disagrees with reality | LinkedIn counts are modeled estimates | Label as directional; cross-check vs company site or jobs Actor `companyEmployeesCount`. |
+
+## Identifier resolution (the #1 silent failure)
+
+Company **names are not slugs**: `Oxylabs` → `oxylabs-io`, `Bright Data` →
+`bright-data-ltd`. A wrong slug returns 0 rows with no error. Resolve first:
+
+    apify actors call "apify/google-search-scraper" \
+      -i '{"queries":"<company> site:linkedin.com/company","maxPagesPerQuery":1,"resultsPerPage":5}' \
+      --json --user-agent apify-awesome-skills/apify-linkedin-intelligence 2>/dev/null
+
+Take the first `organicResults[].url` matching `linkedin.com/company/<slug>`.
+For people, query `"<title> <company> site:linkedin.com/in"`.
+
+## Actor-specific notes
+
+### `dev_fusion/Linkedin-Company-Scraper`
+
+- Input field is `profileUrls`, **not** `urls`.
+- Output lands in the **key-value store**, not the dataset — read KV store keys.
+
+### `curious_coder/linkedin-jobs-scraper`
+
+- Input `urls` must be LinkedIn jobs **search URLs**, not keyword strings.
+- `count` minimum is 10. `scrapeCompany: true` enriches each job with firmographics.
+
+### `harvestapi/linkedin-profile-search`
+
+- The discovery/prospecting engine — use it when you do NOT yet have profile URLs.
+- Confirm the exact filter field names and the `maxItems` cap in the schema before
+  scaling; cap it to control `PAY_PER_EVENT` cost.
+
+## Compliance / data-handling note
+
+LinkedIn profile data about identifiable people is personal data. Use it for
+legitimate B2B outreach, respect rate limits, and honor opt-outs / data-subject
+requests. Surface this to the user when building large people lists.
+
+For a polished gotchas example with detailed cost tables, see [apify/agent-skills ultimate-scraper gotchas](https://github.com/apify/agent-skills/blob/main/skills/apify-ultimate-scraper/references/gotchas.md).


### PR DESCRIPTION
## Skill

- **Name:** `apify-linkedin-intelligence.`
- **What it does:** Turn LinkedIn into a B2B go-to-market data source using Apify Actors across the three LinkedIn data pillars — company firmographics, people profiles, and job postings. Use for TAM sizing (count and size companies in a market), prospect / lead list building (find decision-makers by title, company, seniority, geo), headcount benchmarking (compare employee counts and growth across competitors), and hiring-signal selling (turn new job postings into buying signals and timed outreach)
- **Author:** Yoghesh

## Checklist

- [x] PR adds **one** skill in `skills/apify-<name>/` (no other file changes except `.claude-plugin/marketplace.json`)
- [x] `SKILL.md` frontmatter has `name` (matches folder, `apify-` prefix) and `description` (≤ 1024 chars)
- [x] Added entry to `.claude-plugin/marketplace.json`
- [x] Tested the skill end-to-end at least once

## Notes

LinkedIn is the #4 most-used Actor category on the Store (the three best LinkedIn scrapers cover company firmographics, people profiles, and job postings), yet it only gets a passing mention inside apify-lead-generation. No dedicated skill exists for TAM sizing, prospect list building, headcount benchmarking, or hiring-signal sales workflows. This is a gap the entire B2B community would use immediately.