### PR TITLE
Add skill: apify-youtube-transcript-api

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,23 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-youtube-transcript-api",
+      "source": "./skills/apify-youtube-transcript-api",
+      "skills": "./",
+      "description": "Get YouTube transcripts as structured JSON, SRT, or VTT with a hosted youtube transcript api; one row per video with text, language metadata, title, channel, and views.",
+      "keywords": [
+        "apify",
+        "youtube",
+        "youtube-transcript",
+        "transcript",
+        "subtitles",
+        "captions",
+        "api"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-youtube-transcript-api/SKILL.md
+++ b/skills/apify-youtube-transcript-api/SKILL.md
@@ -43,6 +43,7 @@ Single video:
 ```bash
 apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":"https://www.youtube.com/watch?v=jNQXAC9IVRw"}' \
   --json \
+  --output-dataset \
   --user-agent apify-awesome-skills/apify-youtube-transcript-api \
   2>/dev/null
 ```
@@ -52,11 +53,12 @@ Batch, with SRT and VTT added to each row:
 ```bash
 apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":["https://www.youtube.com/watch?v=jNQXAC9IVRw","https://www.youtube.com/shorts/s4UkCaf_scs"],"output_formats":["srt","vtt"]}' \
   --json \
+  --output-dataset \
   --user-agent apify-awesome-skills/apify-youtube-transcript-api \
   2>/dev/null
 ```
 
-Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-youtube-transcript-api`, and `2>/dev/null`.
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-youtube-transcript-api`, and `2>/dev/null`. The `--output-dataset` flag prints the dataset rows (the transcript data) on success instead of just run metadata.
 
 ## Run it from Claude or another AI agent (MCP)
 

--- a/skills/apify-youtube-transcript-api/SKILL.md
+++ b/skills/apify-youtube-transcript-api/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: apify-youtube-transcript-api
+description: Get YouTube transcripts as structured JSON with a hosted YouTube transcript API (the Apify Actor johnvc/YoutubeTranscripts). Pass one video URL or a batch array and get back non_timestamped text, timestamped snippets, language metadata, and optional SRT, VTT, and plain text formats, plus video title, channel, and view count. Works with standard videos and Shorts, handles language preference and translation, and runs from cloud IPs without IpBlocked errors. Use when the user wants a youtube transcript api, needs to get or download a YouTube transcript or subtitles, asks to extract the transcript from a YouTube video, or wants captions as JSON, SRT, or VTT. Pay-per-video billing, MCP-ready for Claude and other AI agents.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# YouTube Transcript API: Captions to Structured JSON
+
+Fetch the transcript of any YouTube video as clean JSON with a hosted YouTube transcript API. Pass a single URL or a batch array; each video comes back as one row with the full plain text, timestamped snippets, language details, and the video's title, channel, and view count.
+
+## When to use this skill
+
+- The user wants a YouTube transcript API, or asks to get, fetch, or download the transcript of a YouTube video.
+- They want subtitles or captions as JSON, SRT, VTT, or plain text.
+- They ask to extract the transcript from a YouTube video, a Short, or a list of URLs.
+- Their own transcript library keeps failing with IpBlocked or RequestBlocked from a cloud or datacenter IP.
+
+Not for: videos with no caption track at all (those return an error row, not a transcript), private or age-gated videos, or generating captions with speech-to-text (this API reads YouTube's published caption tracks; it does not run ASR).
+
+## What you get (one row per video)
+
+`non_timestamped` (full transcript text), `timestamped` (snippets with `text`, `start`, `duration`), `language`, `language_code`, `source_type` (Manual or Auto-generated), `is_translatable`, `translation_languages`, `total_seconds`, `duration_human`, `snippet_count`, `video_id`, `url`, `success`. With metadata on (the default): `title`, `channel_name`, `channel_url`, `view_count`, `like_count`, `upload_date`, `thumbnail_url`, `tags`, `categories`. Optional extra formats: `srt`, `vtt`, `text`. A video that cannot be transcribed comes back as an error row (`success` false with `error_type` and `error_message`) instead of failing the run.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/YoutubeTranscripts?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/YoutubeTranscripts`
+- Pricing: pay per video transcribed; failed videos are free (see `references/gotchas.md`).
+
+## Run it with the Apify CLI
+
+Single video:
+
+```bash
+apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":"https://www.youtube.com/watch?v=jNQXAC9IVRw"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-youtube-transcript-api \
+  2>/dev/null
+```
+
+Batch, with SRT and VTT added to each row:
+
+```bash
+apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":["https://www.youtube.com/watch?v=jNQXAC9IVRw","https://www.youtube.com/shorts/s4UkCaf_scs"],"output_formats":["srt","vtt"]}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-youtube-transcript-api \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-youtube-transcript-api`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/YoutubeTranscripts`
+
+Then ask, for example: "Get the transcript of this YouTube video and summarize it." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Collect the URL or URLs. Standard watch URLs, Shorts, youtu.be, embed, and mobile URLs all work; batches go in one array.
+2. Pick the language if it matters. `languages` is an ordered preference list (default `["en"]`); first available track wins, with fallback to whatever exists.
+3. Optional: discover before fetching. `"list_only": true` returns `available_transcripts` per video (language, manual vs generated, translatable) without fetching or charging for any transcript.
+4. Optional: request `output_formats` (`srt`, `vtt`, `text`) if the user needs subtitle files rather than JSON.
+5. Run the Actor and read the dataset. Deliver `non_timestamped` for reading or LLM input, `timestamped` for alignment, `srt` or `vtt` for players.
+
+## Inputs
+
+- `youtube_url` (string or array, required)
+- `languages` (ordered array of ISO 639-1 codes, default `["en"]`)
+- `translate_to` (single ISO code; see limits below)
+- `transcript_type` (`any`, `manual`, `generated`; default `any`)
+- `output_formats` (array: `srt`, `vtt`, `text`)
+- `preserve_formatting` (boolean, keeps inline italic and bold tags)
+- `list_only` (boolean, discovery mode, free of the per-video charge)
+- `include_metadata` (boolean, default true; set false for slightly faster runs)
+
+## Cost
+
+Billing is per video successfully transcribed, at a fraction of a cent per video; a thousand-video batch costs on the order of a few cents. Failed videos and `list_only` discovery runs are not charged the per-video fee. Details and the live-price check are in `references/gotchas.md`.
+
+## Honest limits
+
+- Translation (`translate_to`) only covers the languages YouTube exposes for auto-translation, roughly 18 codes. An unsupported code returns the original track unchanged; check for the `translated_to` field in the output to confirm translation actually happened.
+- No captions means no transcript: the API reads YouTube's caption tracks, so a video with captions disabled returns an error row.
+- Very large batches take time; the Actor processes several videos in parallel, but thousands of URLs can run for many minutes.
+
+## Troubleshooting
+
+- Error row with `error_type` IpBlocked or RequestBlocked: rare and transient; the Actor retries with fresh sessions automatically. Rerun the failed URLs; only successes are charged.
+- Empty `translated_to` after requesting translation: the target code is not in `translation_languages` for that video. Pick a supported code from a `list_only` run.
+- Timed-out run on a huge batch: split the input into smaller arrays, or raise the run timeout in the run options.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Google Short Videos API (find Shorts by keyword, then feed the URLs into this transcript API): https://apify.com/johnvc/google-short-videos-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-youtube-transcript-api/references/actor-index.md
+++ b/skills/apify-youtube-transcript-api/references/actor-index.md
@@ -1,0 +1,21 @@
+# Actor index: YouTube transcript API
+
+The primary Actor for this skill, plus the Actors worth chaining when a task needs more than transcripts. The agent reads this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| YouTube | Get the transcript of one or many videos as JSON, SRT, VTT, or text | `johnvc/YoutubeTranscripts` | community | Pay per video. Inputs: `youtube_url` (string or array), `languages`, `translate_to`, `transcript_type`, `output_formats`, `list_only`, `include_metadata`. One flat row per video with transcript plus title, channel, views. |
+
+## Chain with related Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Find Shorts or short-form videos by keyword, then transcribe them | `johnvc/google-short-videos-api` | Feed its video URLs into `youtube_url` here. |
+
+## How to extend
+
+1. Search candidates: `apify actors search "youtube transcript" --json --limit 20 2>/dev/null`
+2. Fetch the input schema: `apify actors info "johnvc/YoutubeTranscripts" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-youtube-transcript-api/references/gotchas.md
+++ b/skills/apify-youtube-transcript-api/references/gotchas.md
@@ -1,0 +1,34 @@
+# Gotchas: YouTube transcript API (johnvc/YoutubeTranscripts)
+
+Cost guardrails, error recovery, and input quirks. The agent reads this on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event. One charge per video successfully transcribed, about $0.00001 per video at the time of writing (about a penny per 1,000 videos), plus small platform fees per run start and per dataset item. Confirm the live price on the Store card or with `apify actors info "johnvc/YoutubeTranscripts" --json 2>/dev/null` (look at `pricingInfo`).
+
+Estimate before running:
+
+- Cost is roughly (number of URLs) times the per-video price, plus one dataset-item fee per row. Example: 1,000 videos is around two cents all-in.
+- Failed videos (no captions, invalid URL, blocked fetch) are not charged the per-video fee.
+- `list_only` discovery runs skip the per-video charge entirely.
+
+Suggested confirmation thresholds: cost is negligible at any realistic batch size, so confirm with the user only when the run is over roughly 50,000 URLs (wall-clock time, not cost, becomes the constraint). Always present cost as "around $X", not a guarantee.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Error row with `error_type` IpBlocked or RequestBlocked | A transient block on the fetch session | The Actor already retries with fresh sessions; rerun the failed URLs. Only successes are charged. |
+| Error row, message says transcripts are disabled | The video has no caption track | Expected. Skip the row; the rest of the batch still returns. |
+| Error row with `error_type` ValueError | The URL is not a valid YouTube video URL | Check the URL; watch, Shorts, youtu.be, embed, and mobile formats are accepted. |
+| `translated_to` missing after requesting translation | The target code is not supported for that video | Run `"list_only": true` and pick a code from `translation_languages`. |
+| Run TIMED-OUT on a large batch | Batch too big for the run timeout | Split the array or raise the timeout in run options. |
+
+## Actor-specific notes
+
+- `youtube_url` accepts a single string or an array; batches process several videos in parallel.
+- `languages` is an ordered preference list; the first available track wins. If none of the preferred codes exist, the Actor falls back to what the video has.
+- Translation via `translate_to` covers only the codes YouTube exposes for auto-translation (roughly 18). Gate on the `translated_to` output field, never assume.
+- `include_metadata` defaults to true and adds title, channel, views, upload date, thumbnail, tags per row; it costs nothing extra but adds a second or two per video. Set false for speed.
+- `source_type` distinguishes Manual captions from Auto-generated; filter with `transcript_type` when only human captions will do.
+- Output is flat, one row per video, so it loads straight into a sheet, a database, or an LLM pipeline.


### PR DESCRIPTION
Adds one skill: apify-youtube-transcript-api. Fetches YouTube transcripts as structured JSON, SRT, or VTT via the johnvc/YoutubeTranscripts Actor (pay per video). One skills/ folder plus one marketplace.json entry; telemetry flags on every CLI call. Follows the one-skill-per-PR rule.