### PR TITLE
Add skill: apify-youtube-transcripts-llm-training-data

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,23 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-youtube-transcripts-llm-training-data",
+      "source": "./skills/apify-youtube-transcripts-llm-training-data",
+      "skills": "./",
+      "description": "Build llm training data from YouTube transcripts in bulk; transcript text plus provenance metadata per video for fine-tuning and RAG corpora.",
+      "keywords": [
+        "apify",
+        "youtube",
+        "transcripts",
+        "llm",
+        "training-data",
+        "rag",
+        "dataset"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-youtube-transcripts-llm-training-data/SKILL.md
+++ b/skills/apify-youtube-transcripts-llm-training-data/SKILL.md
@@ -43,6 +43,7 @@ Batch corpus run, English preferred, metadata on for provenance:
 ```bash
 apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":["https://www.youtube.com/watch?v=jNQXAC9IVRw","https://www.youtube.com/watch?v=dQw4w9WgXcQ"],"languages":["en"],"include_metadata":true}' \
   --json \
+  --output-dataset \
   --user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data \
   2>/dev/null
 ```
@@ -52,11 +53,12 @@ Mixed-language sources normalized into a Spanish corpus:
 ```bash
 apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],"translate_to":"es"}' \
   --json \
+  --output-dataset \
   --user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data \
   2>/dev/null
 ```
 
-Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data`, and `2>/dev/null`.
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data`, and `2>/dev/null`. The `--output-dataset` flag prints the dataset rows (the transcript data) on success instead of just run metadata.
 
 ## Run it from Claude or another AI agent (MCP)
 

--- a/skills/apify-youtube-transcripts-llm-training-data/SKILL.md
+++ b/skills/apify-youtube-transcripts-llm-training-data/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: apify-youtube-transcripts-llm-training-data
+description: Build LLM training data from YouTube transcripts in bulk with the Apify Actor johnvc/YoutubeTranscripts. Feed it an array of video URLs and get one clean row per video, with non_timestamped transcript text ready for tokenization, timestamped snippets, language_code, and provenance metadata (title, channel_name, upload_date, view_count) for dataset documentation. Filter by language or translate every transcript into one target language for a consistent corpus. Use when the user wants LLM training data from videos, a fine-tuning or RAG corpus from YouTube, bulk YouTube transcripts for machine learning, or a text dataset from spoken video content without running speech-to-text. Pay-per-video billing, MCP-ready for Claude and other AI agents.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# YouTube Transcripts as LLM Training Data
+
+Turn a list of YouTube videos into a clean text corpus for LLM fine-tuning, RAG, or analysis. One run takes an array of URLs and returns one row per video: the full transcript as a single text field, plus the provenance metadata (title, channel, upload date, views) a documented dataset needs.
+
+## When to use this skill
+
+- The user wants LLM training data, a fine-tuning corpus, or RAG documents sourced from YouTube videos.
+- They want bulk transcripts from a channel dump, a playlist export, or a keyword-collected URL list.
+- They want spoken-video content as text without running their own speech-to-text.
+- They need a single-language corpus from mixed-language sources (translate everything to one target).
+
+Not for: discovering which videos to include (collect URLs first; see the chain table in `references/actor-index.md`), videos without caption tracks (those return error rows), or verbatim audio ground truth (captions are YouTube's own tracks, not fresh ASR).
+
+## What you get (one row per video)
+
+The corpus fields: `non_timestamped` (the full transcript as one string, the training-text column), `language_code`, `source_type` (Manual or Auto-generated, a quality signal), `snippet_count`, `total_seconds`. The provenance fields for dataset documentation: `title`, `channel_name`, `channel_url`, `upload_date`, `view_count`, `like_count`, `tags`, `categories`, `url`, `video_id`. Optional alignment data: `timestamped` (snippets with `text`, `start`, `duration`). Failures arrive as error rows (`success` false), so a bad URL never kills the batch.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/YoutubeTranscripts?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/YoutubeTranscripts`
+- Pricing: pay per video transcribed; failed videos are free (see `references/gotchas.md`).
+
+## Run it with the Apify CLI
+
+Batch corpus run, English preferred, metadata on for provenance:
+
+```bash
+apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":["https://www.youtube.com/watch?v=jNQXAC9IVRw","https://www.youtube.com/watch?v=dQw4w9WgXcQ"],"languages":["en"],"include_metadata":true}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data \
+  2>/dev/null
+```
+
+Mixed-language sources normalized into a Spanish corpus:
+
+```bash
+apify actors call "johnvc/YoutubeTranscripts" -i '{"youtube_url":["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],"translate_to":"es"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-youtube-transcripts-llm-training-data`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/YoutubeTranscripts`
+
+Then ask, for example: "Pull the transcripts for these 50 videos and build me a JSONL training file with text and metadata columns." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Collect the URL list. Channel exports, playlist dumps, or keyword discovery (see the chain table); dedupe by `video_id` before running.
+2. Decide the corpus language policy. Same-language sources: set `languages` to that code. Mixed sources: set `translate_to` to normalize, and note the translation caveat below.
+3. Run the batch. Pass the whole array in one call; the Actor processes videos in parallel and records failures as error rows without stopping.
+4. Filter for quality. Drop rows where `success` is false. If caption quality matters, prefer rows with `source_type` Manual, or set `transcript_type` to `manual` up front.
+5. Export the corpus. Map `non_timestamped` to your text column and carry `title`, `channel_name`, `upload_date`, `url`, and `language_code` as metadata columns; write JSONL or CSV.
+6. Document provenance. The metadata fields exist so the dataset card can say what the corpus contains and where it came from.
+
+## Inputs
+
+- `youtube_url` (array of URLs, the batch)
+- `languages` (ordered array of ISO 639-1 codes, default `["en"]`)
+- `translate_to` (single ISO code, normalizes the corpus language; see limits)
+- `transcript_type` (`manual` restricts to human-written captions, a quality filter)
+- `include_metadata` (boolean, default true; keep it on for provenance)
+- `list_only` (boolean; free dry run that shows the available languages per video)
+
+## Cost
+
+Billing is per video successfully transcribed, at a fraction of a cent per video; a 10,000-video corpus costs well under a dollar. Failed videos are not charged. Details and the live-price check are in `references/gotchas.md`.
+
+## Honest limits
+
+- Captions are YouTube's own tracks. Auto-generated captions contain recognition errors; filter on `source_type` Manual when accuracy matters more than coverage.
+- Translation (`translate_to`) covers only the languages YouTube exposes for auto-translation, roughly 18 codes. Rows without a `translated_to` field were NOT translated; exclude them or re-plan the corpus language.
+- Respect the licensing context of the content you collect; a transcript corpus inherits the source videos' copyright status. That judgment belongs to the dataset builder, not this API.
+
+## Troubleshooting
+
+- Many error rows in one channel batch: that channel likely disables captions; check a few URLs with `"list_only": true`.
+- Corpus language is inconsistent: some rows fell back to a different track. Group by `language_code` and re-run outliers with `translate_to`.
+- Batch runs long: thousands of URLs take minutes; split into parallel runs of about 500 URLs if wall-clock matters.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Google Short Videos API (discover short-form videos by keyword to feed this corpus builder): https://apify.com/johnvc/google-short-videos-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-youtube-transcripts-llm-training-data/references/actor-index.md
+++ b/skills/apify-youtube-transcripts-llm-training-data/references/actor-index.md
@@ -1,0 +1,21 @@
+# Actor index: YouTube transcripts as LLM training data
+
+The primary Actor for this skill, plus the Actors worth chaining when a corpus needs discovery or enrichment. The agent reads this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| YouTube | Bulk transcripts for a training or RAG corpus | `johnvc/YoutubeTranscripts` | community | Pay per video. Batch via `youtube_url` array; `non_timestamped` is the text column; `include_metadata` adds provenance (title, channel, upload date, views). |
+
+## Chain with related Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Discover video URLs by keyword before building the corpus | `johnvc/google-short-videos-api` | Keyword in, video URLs out; feed them into `youtube_url` here. |
+
+## How to extend
+
+1. Search candidates: `apify actors search "youtube transcript" --json --limit 20 2>/dev/null`
+2. Fetch the input schema: `apify actors info "johnvc/YoutubeTranscripts" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-youtube-transcripts-llm-training-data/references/gotchas.md
+++ b/skills/apify-youtube-transcripts-llm-training-data/references/gotchas.md
@@ -1,0 +1,33 @@
+# Gotchas: YouTube transcripts as LLM training data (johnvc/YoutubeTranscripts)
+
+Cost guardrails, error recovery, and corpus-quality notes. The agent reads this on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event. One charge per video successfully transcribed, about $0.00001 per video at the time of writing (about a penny per 1,000 videos), plus small platform fees per run start and per dataset item. Confirm the live price on the Store card or with `apify actors info "johnvc/YoutubeTranscripts" --json 2>/dev/null` (look at `pricingInfo`).
+
+Corpus math:
+
+- 1,000 videos: around two cents all-in. 10,000 videos: around twenty cents.
+- Failed videos (no captions, invalid URL) are not charged the per-video fee, so a noisy URL list does not inflate cost.
+- A `list_only` dry run over a URL sample is free of the per-video charge and shows caption availability before you commit.
+
+Cost is never the constraint at realistic corpus sizes; wall-clock time is. Confirm with the user only for runs over roughly 50,000 URLs, and split those into parallel batches anyway.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Many error rows from one channel | That channel disables captions | Expected. Drop the rows; spot-check with `"list_only": true`. |
+| Error row with `error_type` IpBlocked or RequestBlocked | Transient fetch block | The Actor retries with fresh sessions; rerun just the failed URLs. |
+| Rows in unexpected languages | Preferred track missing; the Actor fell back to what exists | Group by `language_code`; re-run outliers with `translate_to`, or drop them. |
+| `translated_to` missing on a translated run | Target code not supported for that video | Only about 18 codes are auto-translatable. Exclude those rows or choose a supported target. |
+| Run TIMED-OUT | Batch too large for the run timeout | Split into batches of about 500 URLs or raise the run timeout. |
+
+## Corpus-quality notes
+
+- `source_type` is the main quality signal: Manual captions are human-written; Auto-generated ones carry recognition errors. `transcript_type: "manual"` filters at fetch time; filtering the output on `source_type` preserves coverage stats.
+- Dedupe by `video_id`, not URL; the same video arrives under watch, short-link, and Shorts URL forms.
+- `non_timestamped` is one continuous string per video with no speaker labels or paragraph breaks; sentence-split downstream if the training format needs segments.
+- Keep `title`, `channel_name`, `upload_date`, `url`, and `language_code` as metadata columns; a dataset card needs them and they cost nothing extra.
+- Licensing judgment stays with the dataset builder: transcripts inherit the copyright status of the source videos.


### PR DESCRIPTION
Adds one skill: apify-youtube-transcripts-llm-training-data. Builds LLM training corpora from YouTube transcripts in bulk via the johnvc/YoutubeTranscripts Actor (pay per video); transcript text plus provenance metadata per row. One skills/ folder plus one marketplace.json entry; telemetry flags on every CLI call. Follows the one-skill-per-PR rule.