### PR TITLE
Add apify-orchestrator-actor-development skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -207,6 +207,31 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-orchestrator-actor-development",
+      "source": "./skills/apify-orchestrator-actor-development",
+      "skills": "./",
+      "description": "Build TypeScript Apify orchestrator Actors — coordinate a sequence of sub-Actors (optionally with an LLM step) using the apify-orchestrator library. Interactive scaffolding flow: elicit the sub-Actor chain, fetch each Actor's input/output schema via Apify MCP (fetch-actor-details), design data flow between steps, elicit per-step cost budgets, optionally add an OpenRouter LLM step, then scaffold src/main.ts with the running-budget pattern (maxTotalChargeUsd caps per sub-Actor call, usageTotalUsd polling for cumulative cost tracking).",
+      "keywords": [
+        "orchestrator",
+        "orchestration",
+        "apify-orchestrator",
+        "typescript",
+        "actor-development",
+        "sub-actors",
+        "workflow",
+        "pipeline",
+        "chain",
+        "parent-actor",
+        "openrouter",
+        "llm",
+        "mcp",
+        "cost-tracking",
+        "maxtotalchargeusd"
+      ],
+      "category": "development",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-orchestrator-actor-development/SKILL.md
+++ b/skills/apify-orchestrator-actor-development/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: apify-orchestrator-actor-development
+description: Build TypeScript Apify orchestrator Actors — coordinate a sequence of sub-Actors (optionally with an LLM step) using the apify-orchestrator library. Use when creating a new orchestrator Actor, chaining Apify Actors together, adding an OpenRouter LLM step between Actors, or scaffolding parent-Actor workflows that call other Actors.
+author: Fabian Maume
+author_url: https://github.com/fmaume
+---
+
+# Apify orchestrator Actor development
+
+An **orchestrator Actor** is a parent Apify Actor whose job is to coordinate a sequence (or parallel fan-out) of other Actors. It takes user input, calls sub-Actor A, feeds A's output into sub-Actor B, optionally runs an LLM transformation between them, and emits the combined result to its own dataset.
+
+This skill covers **TypeScript-only** orchestrators built on the [`apify-orchestrator`](https://github.com/apify-projects/apify-orchestrator) library. It does not cover Python, JavaScript, or Standby-mode Actors.
+
+**Important:** Before writing code, fill in the `generatedBy` property in `.actor/actor.json` (e.g., `"Claude Code with Claude Opus 4.7"`). This helps Apify improve tooling for specific AI models.
+
+## Prerequisites and setup
+
+Verify the `apify` CLI is installed:
+
+```bash
+apify --help
+```
+
+If not installed, use a package manager (never `curl | bash`):
+
+```bash
+npm install -g apify-cli
+# or on Mac: brew install apify-cli
+```
+
+Confirm login:
+
+```bash
+apify info   # should return your username
+```
+
+If not logged in, run `apify login` (opens a browser) or export `APIFY_TOKEN` from <https://console.apify.com/settings/integrations>. Never pass tokens on the command line — arguments show up in process listings and shell history.
+
+## Interactive creation flow
+
+When the user asks for a new orchestrator Actor, follow these steps **in order**:
+
+1. Elicit sub-Actor sequence
+2. Fetch each sub-Actor's schema via Apify MCP
+3. Decide data flow between steps
+4. Note the total cost cap (a Run option, not an input field)
+5. Ask about optional LLM step
+6. Scaffold the project
+7. Test locally, then deploy
+
+### Step 1 — Elicit the sub-Actor sequence
+
+Ask the user which Apify Actors to chain together, in order. Accept either:
+- A list up-front (e.g., "`apify/website-content-crawler` then `apify/rag-web-browser`"), or
+- One at a time (ask for the first, discuss it, then ask what comes next).
+
+If the user names a task instead of an Actor ID ("scrape LinkedIn profiles"), use the Apify MCP `search-actors` tool to propose candidates and let the user pick.
+
+### Step 2 — Fetch each sub-Actor's schema via Apify MCP
+
+For **every** sub-Actor in the chain, call the Apify MCP `fetch-actor-details` tool. Present the input schema back to the user with `REQUIRED`-prefixed fields highlighted. See [references/mcp-schema-discovery.md](references/mcp-schema-discovery.md) for the truncation gotcha (500-char descriptions, 200-char enum lists) and the fallback path via the REST API / raw `INPUT_SCHEMA.json` on GitHub.
+
+Never guess field names. If the MCP truncation is limiting, fetch the raw schema from the Actor's GitHub repo.
+
+### Step 3 — Decide data flow between steps
+
+For each pair of adjacent sub-Actors, ask:
+- Which fields from step N's output feed into step N+1's input?
+- Which top-level orchestrator inputs should be exposed to the user (via the orchestrator's own `.actor/input_schema.json`)?
+- Which sub-Actor inputs should be hardcoded?
+
+### Step 4 — Note the total cost cap
+
+The **total cost cap** is a Run option (`maxTotalChargeUsd`) — the caller sets it when they start the orchestrator via the Apify Console, API, or SDK. It's **not** an input schema field. See the [Apify API docs](https://docs.apify.com/api/v2/act-runs-post) for how callers pass it.
+
+At Run time the orchestrator:
+
+1. Reads its own cap via `client.run(actorRunId).get().options.maxTotalChargeUsd`.
+2. **Divides the total evenly across the sub-Actor steps at compile time** — declare a `STEPS` tuple and compute `perStepCap = maxTotalChargeUsd / STEPS.length`.
+3. Passes each step's share as `maxTotalChargeUsd` when calling the sub-Actor (for pay-per-event Actors) or as `maxItems` (for pay-per-result Actors).
+4. Tracks cumulative cost across sub-Actor Runs (`run.usageTotalUsd`) and refuses to launch the next step if the running total exceeds the cap.
+
+**Do not add a `stepBudgets` input schema field.** The even split is a deliberate compile-time constant — it keeps the input schema clean, makes cost behavior predictable for the caller, and removes a footgun (three shares that don't sum to the total). Users control cost solely via the Run's `maxTotalChargeUsd` option; the orchestrator handles the split.
+
+Tell the user to set `maxTotalChargeUsd` when they trigger the orchestrator — otherwise there's no ceiling and the orchestrator runs uncapped. See [references/cost-tracking.md](references/cost-tracking.md) for the full pattern, including the LLM-step approximation (Standby Actors don't accept `maxTotalChargeUsd`, so estimate cost from token usage).
+
+### Step 5 — Ask about an optional LLM step
+
+Ask the user whether to insert an LLM transformation somewhere in the chain (common: summarize between steps, classify at the end, or format the final output). If yes, point them at [references/openrouter.md](references/openrouter.md) — the LLM layer is the Apify OpenRouter Actor called over HTTP (it's a Standby Actor, not a normal Run).
+
+The agent does not force this step. Skip if the user doesn't want it.
+
+### Step 6 — Scaffold the project
+
+```bash
+apify create <actor-name> -t ts_empty
+cd <actor-name>
+npm install apify-orchestrator
+```
+
+Then generate `src/main.ts` using the template in [references/orchestrator-template.md](references/orchestrator-template.md). Wire the sub-Actors, their input mappings, and any LLM helpers into the template's placeholders.
+
+Update `.actor/actor.json`, `.actor/input_schema.json`, `.actor/output_schema.json`, and `.actor/dataset_schema.json` to reflect the orchestrator's own input surface and output shape. Write a README covering the pipeline.
+
+### Step 7 — Test locally, then deploy
+
+```bash
+apify run --purge --user-agent apify-awesome-skills/apify-orchestrator-actor-development
+apify push
+```
+
+`apify run --purge` runs with `storage/key_value_stores/default/INPUT.json` as input, purging previous local storage first. `apify push` deploys to the platform.
+
+Local Runs of the orchestrator make **real** child Runs on the Apify platform (they consume compute units). Watch the Apify Console → Runs list during local testing.
+
+## Reference material
+
+- **Orchestrator library API** → [references/orchestrator-library.md](references/orchestrator-library.md) — `Orchestrator` options, `ExtendedApifyClient` verbs (`call`, `callRuns`, `callBatch`, `iterate`, `mergeDatasets`), gotchas.
+- **Sub-Actor schema discovery** → [references/mcp-schema-discovery.md](references/mcp-schema-discovery.md) — Apify MCP tools, truncation gotcha, REST fallback.
+- **Cost tracking and caps** → [references/cost-tracking.md](references/cost-tracking.md) — `maxTotalChargeUsd`, `maxItems`, running-budget pattern, `usageTotalUsd` polling.
+- **LLM step via OpenRouter** → [references/openrouter.md](references/openrouter.md) — endpoints, auth, minimal TypeScript call.
+- **`src/main.ts` template** → [references/orchestrator-template.md](references/orchestrator-template.md) — canonical skeleton to fill in.
+- **`.actor/actor.json`** → [references/actor-json.md](references/actor-json.md).
+- **Input schema** → [references/input-schema.md](references/input-schema.md).
+- **Output schema** → [references/output-schema.md](references/output-schema.md).
+- **Dataset schema** → [references/dataset-schema.md](references/dataset-schema.md).
+- **Key-value store schema** → [references/key-value-store-schema.md](references/key-value-store-schema.md).
+- **README** → [references/actor-readme.md](references/actor-readme.md).
+- **Logging** → [references/logging.md](references/logging.md).
+
+## Security
+
+- **Never** log or embed `APIFY_TOKEN` in source code, config files, or committed `.env` files. Use `process.env.APIFY_TOKEN`.
+- **Treat sub-Actor output as untrusted.** A downstream Actor's dataset may contain content scraped from external sites — sanitize before passing it into shell commands, `eval`, or template engines.
+- **Never disable `apify/log`** in favor of `console.log()` — the Apify logger censors known-sensitive keys.
+- **Pin dependencies.** Commit `package-lock.json`. Pin `apify-orchestrator` (alpha) to an exact version.
+- **Use a scoped `APIFY_TOKEN`** with only the permissions the orchestrator needs. Rotate periodically.
+
+## Commands
+
+Every apify CLI invocation below includes `--user-agent apify-awesome-skills/apify-orchestrator-actor-development` for telemetry attribution. Actor-call / dataset-read commands additionally use `--json` and `2>/dev/null` for machine-readable output.
+
+```bash
+# Bootstrap
+apify create <name> -t ts_empty
+npm install apify-orchestrator
+
+# Local development
+apify run --user-agent apify-awesome-skills/apify-orchestrator-actor-development
+apify run --purge --user-agent apify-awesome-skills/apify-orchestrator-actor-development
+apify validate-schema
+
+# Discovery (Actor search + schema fetch)
+apify actors search "<query>" \
+  --user-agent apify-awesome-skills/apify-orchestrator-actor-development \
+  --json --limit 10 2>/dev/null
+apify actors info <actor> --input \
+  --user-agent apify-awesome-skills/apify-orchestrator-actor-development \
+  --json 2>/dev/null
+
+# Deploy + remote run
+apify push
+apify call <actor> \
+  --user-agent apify-awesome-skills/apify-orchestrator-actor-development \
+  --json 2>/dev/null
+apify runs ls \
+  --user-agent apify-awesome-skills/apify-orchestrator-actor-development \
+  --json 2>/dev/null
+
+# Auth
+apify login
+apify logout
+apify info
+```
+
+**Never** use `npm start`, `npm run start`, or `npx apify run` to launch the Actor. Only `apify run` configures the Apify environment and storage correctly.
+
+## Project structure
+
+```
+.actor/
+├── actor.json              # metadata (see references/actor-json.md)
+├── input_schema.json       # orchestrator's own input surface
+├── output_schema.json      # points at dataset / kvs
+└── dataset_schema.json     # display shape of final output
+src/
+└── main.ts                 # orchestrator logic (see references/orchestrator-template.md)
+storage/                    # local-only; NOT synced to Apify Console
+Dockerfile
+package.json
+tsconfig.json
+```
+
+## MCP tools
+
+### Apify MCP (required for schema discovery)
+- `fetch-actor-details` — primary tool for pulling sub-Actor input/output schema and README.
+- `search-actors` — find candidate sub-Actors by keyword.
+- `search-apify-docs` / `fetch-apify-docs` — documentation lookup.
+
+If MCP is not configured, use the hosted server URL: `https://mcp.apify.com/?tools=actors,docs`.
+
+## Resources
+
+- [apify-orchestrator library](https://github.com/apify-projects/apify-orchestrator)
+- [OpenRouter Actor](https://apify.com/apify/openrouter)
+- [Apify MCP docs](https://docs.apify.com/platform/integrations/mcp)
+- [docs.apify.com/llms.txt](https://docs.apify.com/llms.txt) — Apify docs quick reference
+- [Actor whitepaper](https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/README.md)

--- a/skills/apify-orchestrator-actor-development/references/actor-json.md
+++ b/skills/apify-orchestrator-actor-development/references/actor-json.md
@@ -1,0 +1,69 @@
+﻿# Actor configuration (actor.json)
+
+The `.actor/actor.json` file contains the Actor's configuration including metadata, schema references, and platform settings.
+
+## Structure
+
+```json
+{
+    "actorSpecification": 1,
+    "defaultMemoryMbytes": 1000,
+    "name": "project-name",
+    "title": "Project Title",
+    "description": "Actor description",
+    "version": "0.0",
+    "meta": {
+        "templateId": "template-id",
+        "generatedBy": "<FILL-IN-TOOL-AND-MODEL>"
+    },
+    "input": "./input_schema.json",
+    "output": "./output_schema.json",
+    "storages": {
+        "dataset": "./dataset_schema.json"
+    },
+    "dockerfile": "../Dockerfile"
+}
+```
+
+## Example
+
+```json
+{
+    "actorSpecification": 1,
+    "defaultMemoryMbytes": 1000,
+    "name": "project-cheerio-crawler-javascript",
+    "title": "Project Cheerio Crawler JavaScript",
+    "description": "Crawlee and Cheerio project in JavaScript.",
+    "version": "0.0",
+    "meta": {
+        "templateId": "js-crawlee-cheerio",
+        "generatedBy": "Claude Code with Claude Sonnet 4.5"
+    },
+    "input": "./input_schema.json",
+    "output": "./output_schema.json",
+    "storages": {
+        "dataset": "./dataset_schema.json"
+    },
+    "dockerfile": "../Dockerfile"
+}
+```
+
+## Properties
+
+- `actorSpecification` (integer, required) - Version of Actor specification (currently 1)
+- `name` (string, required) - Actor identifier (lowercase, hyphens allowed)
+- `title` (string, required) - Human-readable title displayed in UI
+- `description` (string, optional) - Actor description for marketplace
+- `version` (string, required) - Semantic version number
+- `meta` (object, optional) - Metadata about Actor generation
+  - `templateId` (string) - ID of template used to create the Actor
+  - `generatedBy` (string) - Tool and model name that generated/modified the Actor (e.g., "Claude Code with Claude Sonnet 4.5")
+- `input` (string, optional) - Path to input schema file
+- `output` (string, optional) - Path to output schema file
+- `storages` (object, optional) - Storage schema references
+  - `dataset` (string) - Path to dataset schema file
+  - `keyValueStore` (string) - Path to key-value store schema file
+- `dockerfile` (string, optional) - Path to Dockerfile
+- defaultMemoryMbytes (integer, optional) - Set 1000 by default to keep cost low. Increase if the Actor requires complex workflow with 200+ sub Actors.
+
+**Important:** Always fill in the `generatedBy` property with the tool and model you're currently using (e.g., "Claude Code with Claude Sonnet 4.5") to help Apify improve documentation.

--- a/skills/apify-orchestrator-actor-development/references/actor-readme.md
+++ b/skills/apify-orchestrator-actor-development/references/actor-readme.md
@@ -1,0 +1,93 @@
+﻿# Actor README guidelines
+
+The README is the Actor's landing page on Apify Store. It serves as SEO content, first impression, usage guide, and support resource. **Always generate a README.md when creating or deploying an Actor.**
+
+## Required structure
+
+Write in Markdown. Use H2 (`##`) for main sections (these form the table of contents) and H3 (`###`) for subsections. Do not use H1 — the Actor name is automatically used as H1.
+
+### 1. What does [Actor name] do?
+
+- 1-2 sentences explaining what the Actor does and doesn't do
+- Include a link to the target website
+- Mention keywords like "API" (e.g., "Instagram API alternative")
+- Bold the most important terms
+
+### 2. Why use [Actor name]? / Why scrape [target site]?
+
+- Business use cases and benefits
+- List main features and capabilities
+- Highlight the Apify platform advantages: scheduling, API access, integrations, proxy rotation, and monitoring
+
+### 3. What data can [Actor name] extract?
+
+- Table showing main data fields the Actor outputs (field name, type, description)
+- Don't list every field — focus on the most useful and understandable ones
+
+### 4. How to scrape [target site]
+
+- Numbered step-by-step tutorial (Google may pick these up as rich snippets)
+- Include a link to blog tutorials if they exist
+
+### 5. How much will it cost to scrape [target site]?
+
+- Set pricing expectations based on the Actor's pricing model
+- For pay-per-result: mention free tier limits and what larger plans offer
+- For compute units: explain average data volume per dollar
+- Cost-related questions rank well in Google search
+
+### 6. Input
+
+- Reference the input tab: "See the input tab for full configuration options"
+- Explain any complex input fields or special formatting requirements
+- Screenshot of the input schema is optional but helpful
+
+### 7. Output
+
+- Include: "You can download the dataset in various formats such as JSON, HTML, CSV, or Excel"
+- Show a simplified JSON output example (2-3 items)
+- If output is complex, show separate examples for different data types
+
+### 8. Tips / Advanced options (if applicable)
+
+- How to limit compute unit usage
+- How to get more accurate results or improve speed
+
+### 9. FAQ, Disclaimers, and Support
+
+- Legal/scraping disclaimer (use this template and customize with the target site name):
+  > Our Actors are ethical and do not extract any private user data, such as email addresses, gender, or location. They only extract what the user has chosen to share publicly. We therefore believe that our Actors, when used for ethical purposes by Apify users, are safe. However, you should be aware that your results could contain personal data. Personal data is protected by the GDPR in the European Union and by other regulations around the world. You should not scrape personal data unless you have a legitimate reason to do so. If you're unsure whether your reason is legitimate, consult your lawyers.
+- Common troubleshooting tips
+- Mention the Issues tab for feedback
+- Link to API tab for programmatic access
+- Use cases for the extracted data
+
+## SEO best practices
+
+- Include keywords naturally in H2/H3 headings (e.g., "How to scrape Instagram" not just "How to use")
+- Target "People Also Ask" style questions as H3 headings
+- Aim for at least 300 words total
+- Embed a YouTube video URL if available (renders automatically as a player)
+- Make images clickable with links
+
+## Tone
+
+- Match the README tone to the target audience skill level
+- For no-code users: use plain language, avoid code blocks early on
+- For developers: include technical details, code examples, and API references
+- Be clear about what technical knowledge is needed to use the Actor
+
+## Reference Actors
+
+Before writing a README, review these top Actors on Apify Store for best practices on structure, tone, and content:
+
+- [Instagram Scraper](https://apify.com/apify/instagram-scraper)
+- [Google Maps Scraper](https://apify.com/compass/crawler-google-places)
+
+## Key rules
+
+- Always write the README as part of Actor development — do not skip this step
+- The first 25% of the README is what most visitors read — put the most important info there
+- Use emojis sparingly as bullet points to break up text
+- Keep images compressed but good quality
+- Use [Carbon](https://github.com/carbon-app/carbon) for code snippet screenshots if needed

--- a/skills/apify-orchestrator-actor-development/references/cost-tracking.md
+++ b/skills/apify-orchestrator-actor-development/references/cost-tracking.md
@@ -1,0 +1,158 @@
+# Cost tracking and per-run cost caps
+
+An orchestrator Actor's total cost is the parent Run's compute cost **plus** the sum of every child Run's cost. Without a cap, one badly-configured sub-Actor can burn through a user's Apify credits. The orchestrator is the right place to enforce a cost ceiling because it's the only actor that has visibility into all the child Runs.
+
+## The two Apify cost-cap primitives
+
+| Sub-Actor pricing model | Option to pass to `.call(name, input, options)` | What it does |
+|---|---|---|
+| **Pay-per-event** (most Apify Store Actors) | `maxTotalChargeUsd: <number>` | Hard USD cap. Apify aborts the Run when the charge would exceed this. |
+| **Pay-per-result** | `maxItems: <integer>` | Cap on the number of dataset items charged. |
+| **Rental / compute-unit** | *(neither)* — control cost via `memory` and `timeout` | No dollar cap available; use the Run's own timeout + memory instead. |
+
+Check each sub-Actor's pricing model on its Apify Store page (or via the MCP `fetch-actor-details` output — `pricingInfo` field) before picking which cap to pass.
+
+Type reference (from `apify-client`):
+
+```typescript
+interface ActorStartOptions {
+    memory?: number;
+    timeout?: number;
+    build?: string;
+    maxItems?: number;            // pay-per-result cap
+    maxTotalChargeUsd?: number;   // pay-per-event cap
+    // ...
+}
+```
+
+## Reading the orchestrator's own cap
+
+**`maxTotalChargeUsd` is a Run option, not an input schema field.** The caller sets it when starting the orchestrator — via the `maxTotalChargeUsd` query parameter on [`POST /v2/acts/{actorId}/runs`](https://docs.apify.com/api/v2/act-runs-post) (or the equivalent option in `apify-client`, Apify Console → Advanced → *Max total charge*, or a scheduled task). Do **not** duplicate it as a top-level input schema field.
+
+The orchestrator reads its own cap from its Run's `options`:
+
+```typescript
+import { Actor } from 'apify';
+
+const env = Actor.getEnv();
+let totalBudget = Number.POSITIVE_INFINITY;
+if (env.actorRunId) {
+    try {
+        const selfRun = await client.run(env.actorRunId).get();
+        const cap = selfRun?.options?.maxTotalChargeUsd;
+        if (typeof cap === 'number' && cap > 0) totalBudget = cap;
+    } catch (err) {
+        // Local `apify run` uses a synthetic Run ID that doesn't exist on the
+        // platform. Swallow the error and run uncapped.
+        log.debug(`Could not read self-Run options: ${(err as Error).message}`);
+    }
+}
+```
+
+`ActorRunOptions.maxTotalChargeUsd?: number` — the cap that was applied to this Run (may be undefined if the caller didn't set one, in which case the orchestrator has no dollar ceiling).
+
+## Splitting the cap: hard-code an even distribution
+
+The orchestrator divides `maxTotalChargeUsd` **evenly** across its sub-Actor steps at compile time. **Do not** expose a per-step budget field (`stepBudgets` or similar) in the input schema. The even split is the recommended default because:
+
+- It keeps the orchestrator input schema focused on the pipeline's real inputs, not on cost knobs the caller can already set via the Run option.
+- It removes a common footgun — a `stepBudgets` object whose three shares don't sum to the total, or that exceeds it.
+- It makes cost behavior predictable from the caller's perspective: "each step gets `maxTotalChargeUsd / n`," full stop.
+- If one step reliably dominates cost for a specific caller, they raise the Run-level cap so its slice is large enough; the surplus on cheaper steps is accepted overhead.
+
+Declare a `STEPS` tuple listing every step that spends money, and derive the share:
+
+```typescript
+const STEPS = ['crawl', 'summarize', 'classify'] as const;
+type Step = (typeof STEPS)[number];
+
+const perStepCap = totalBudget / STEPS.length;  // Infinity / N = Infinity, fine.
+```
+
+## Querying the current cost of any run
+
+Every Run object carries a running total:
+
+```typescript
+interface ActorRun {
+    id: string;
+    // ...
+    options: ActorRunOptions;         // includes maxTotalChargeUsd
+    usageTotalUsd?: number;           // running total charge in USD
+    usageUsd?: ActorRunUsage;         // per-resource breakdown (compute, storage, network)
+    chargedEventCounts?: Record<string, number>;  // pay-per-event only
+}
+```
+
+- After a sub-Actor call finishes, read `run.usageTotalUsd` from the returned object.
+- To poll a still-running child Run, use `client.run(runId).get()`.
+
+## The running-budget pattern
+
+Wrap each `client.actor(id).call(...)` with a helper that computes the step cap and updates the cumulative tally afterwards:
+
+```typescript
+let spent = 0;
+const remaining = (): number => totalBudget - spent;
+
+function planStepCap(step: Step): number | undefined {
+    const rem = remaining();
+    if (rem <= 0) {
+        throw new Error(`Cost cap $${totalBudget} reached before step "${step}"`);
+    }
+    // Uncapped run: return undefined so the caller doesn't pass maxTotalChargeUsd.
+    if (!Number.isFinite(perStepCap)) return undefined;
+    // Never ask a sub-Actor to spend more than we have left, even if the even
+    // share is larger (e.g. a prior step overshot its share).
+    return Math.min(perStepCap, rem);
+}
+
+function recordSpend(step: string, cost: number): void {
+    spent += cost;
+    log.info(`Step "${step}" spent $${cost.toFixed(4)}; cumulative $${spent.toFixed(4)}`);
+}
+
+// Usage:
+const cap = planStepCap('crawl');
+const run = await client
+    .actor('apify/website-content-crawler')
+    .call('crawl', input, cap != null ? { maxTotalChargeUsd: cap } : undefined);
+recordSpend('crawl', run.usageTotalUsd ?? 0);
+```
+
+The wrapper hands the sub-Actor a cap that never exceeds the remaining budget and updates the running tally. If cumulative spend ever exceeds `totalBudget`, the next `planStepCap` call throws before making the next Run — preventing runaway spend even if a sub-Actor overshot its individual cap.
+
+## LLM (Standby Actor) steps
+
+The Apify OpenRouter Actor and other Standby-mode Actors are called over HTTP, not via `.call()`, so **you can't hand them a `maxTotalChargeUsd`**. Their cost accrues to the parent Run's `usageTotalUsd` asynchronously and lags by seconds.
+
+Two practical mitigations:
+
+1. **Refuse to start the LLM step if the budget is already exhausted.** Call `planStepCap('llm')` up-front; if it throws, emit each candidate with `score: null` and a reasoning like `"Cost cap exhausted before LLM scoring"` rather than crashing the whole Run.
+2. **Estimate LLM cost per call and short-circuit mid-batch.** The OpenRouter response includes `json.usage.total_tokens`. Multiply by a rough per-token rate (e.g. `LLM_USD_PER_1K_TOKENS = 0.001` biased slightly high for `openai/gpt-4o-mini`) and track a running estimated cost. When the estimate crosses the LLM step's share, flip a `llmBudgetExhausted` flag; concurrent workers check it on entry and return null-scored placeholders. Add the final estimate to `spent` at the end of the step so downstream steps see the LLM cost too.
+
+Expect ±20% accuracy on the estimator — good enough for orchestration control flow, not for billing reconciliation.
+
+## Prompt the user for the budget
+
+During the interactive scaffolding flow, **do not ask** for per-step budgets. Instead, tell the user:
+
+- The total cap is `maxTotalChargeUsd`, set at Run start time (Apify Console → Advanced → *Max total charge*, or the API/SDK option).
+- The orchestrator splits that total evenly across all pay-spending steps.
+- If they want a specific step to have more budget, they should raise the Run cap enough that that step's slice is sufficient.
+
+If the caller expects to run the orchestrator uncapped for exploratory use, that's fine — just tell them scheduled Runs should always have a positive cap set.
+
+## Where to also declare the cap
+
+- **On the orchestrator Run itself** — the caller sets `maxTotalChargeUsd` when triggering the Run. This is the only surface for adjusting cost per Run.
+- **Not in the input schema** — do not add `maxCostUsd`, `stepBudgets`, or similar. Duplicating the cap creates two sources of truth that will diverge; the Run option is authoritative.
+
+## Gotchas
+
+1. **`maxTotalChargeUsd` only works on pay-per-event Actors.** Silently ignored on compute-unit Actors. Read the sub-Actor's pricing model before assuming the cap will bind.
+2. **`usageTotalUsd` lags slightly.** Apify updates it as the Run charges accumulate — it may be up to a few seconds stale. For orchestration control flow, that's fine; don't build sub-second cost logic on top of it.
+3. **Aborted-by-cap Runs still produce partial data.** When a sub-Actor is stopped mid-Run by hitting `maxTotalChargeUsd`, its dataset contains whatever it managed to write. Handle partial results (skip empty, retry, or degrade gracefully).
+4. **Compute unit runs need timeout + memory caps instead.** Set `timeout: 3600` (seconds) and `memory: 1024` on the `.call()` options — the product roughly bounds the compute-unit cost.
+5. **Don't double-count.** `usageTotalUsd` on the parent already excludes child Runs. Sum child Runs separately; add both totals to compute the true orchestrator cost.
+6. **Local `apify run` has no self-Run.** `env.actorRunId` points at a synthetic ID; `client.run(id).get()` returns an error. Catch it and fall back to `Infinity` (uncapped) so local runs still work.

--- a/skills/apify-orchestrator-actor-development/references/dataset-schema.md
+++ b/skills/apify-orchestrator-actor-development/references/dataset-schema.md
@@ -1,0 +1,171 @@
+﻿# Dataset schema reference
+
+The dataset schema defines how your Actor's output data is structured, transformed, and displayed in the Output tab in Apify Console.
+
+## Example (TypeScript)
+
+An orchestrator Actor typically forwards items from a child Run's dataset into its own:
+
+```typescript
+import { Actor } from 'apify';
+
+await Actor.init();
+
+await Actor.pushData({
+    numericField: 10,
+    pictureUrl: 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png',
+    linkUrl: 'https://google.com',
+    textField: 'Google',
+    booleanField: true,
+    dateField: new Date(),
+    arrayField: ['#hello', '#world'],
+    objectField: {},
+});
+
+await Actor.exit();
+```
+
+## Configuration
+
+To set up the Actor's output tab UI, reference a dataset schema file in `.actor/actor.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "name": "book-library-scraper",
+    "title": "Book Library Scraper",
+    "version": "1.0.0",
+    "storages": {
+        "dataset": "./dataset_schema.json"
+    }
+}
+```
+
+Then create the dataset schema in `.actor/dataset_schema.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "fields": {},
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "pictureUrl",
+                    "linkUrl",
+                    "textField",
+                    "booleanField",
+                    "arrayField",
+                    "objectField",
+                    "dateField",
+                    "numericField"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "pictureUrl": {
+                        "label": "Image",
+                        "format": "image"
+                    },
+                    "linkUrl": {
+                        "label": "Link",
+                        "format": "link"
+                    },
+                    "textField": {
+                        "label": "Text",
+                        "format": "text"
+                    },
+                    "booleanField": {
+                        "label": "Boolean",
+                        "format": "boolean"
+                    },
+                    "arrayField": {
+                        "label": "Array",
+                        "format": "array"
+                    },
+                    "objectField": {
+                        "label": "Object",
+                        "format": "object"
+                    },
+                    "dateField": {
+                        "label": "Date",
+                        "format": "date"
+                    },
+                    "numericField": {
+                        "label": "Number",
+                        "format": "number"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Structure
+
+```json
+{
+    "actorSpecification": 1,
+    "fields": {},
+    "views": {
+        "<VIEW_NAME>": {
+            "title": "string (required)",
+            "description": "string (optional)",
+            "transformation": {
+                "fields": ["string (required)"],
+                "unwind": ["string (optional)"],
+                "flatten": ["string (optional)"],
+                "omit": ["string (optional)"],
+                "limit": "integer (optional)",
+                "desc": "boolean (optional)"
+            },
+            "display": {
+                "component": "table (required)",
+                "properties": {
+                    "<FIELD_NAME>": {
+                        "label": "string (optional)",
+                        "format": "text|number|date|link|boolean|image|array|object (optional)"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Properties
+
+### Dataset schema properties
+
+- `actorSpecification` (integer, required) - Specifies the version of dataset schema structure document (currently only version 1)
+- `fields` (JSONSchema object, required) - Schema of one dataset object (use JsonSchema Draft 2020-12 or compatible)
+- `views` (DatasetView object, required) - Object with API and UI views description
+
+### DatasetView properties
+
+- `title` (string, required) - Visible in UI Output tab and API
+- `description` (string, optional) - Only available in API response
+- `transformation` (ViewTransformation object, required) - Data transformation applied when loading from Dataset API
+- `display` (ViewDisplay object, required) - Output tab UI visualization definition
+
+### ViewTransformation properties
+
+- `fields` (string[], required) - Fields to present in output (order matches column order)
+- `unwind` (string[], optional) - Deconstructs nested children into parent object
+- `flatten` (string[], optional) - Transforms nested object into flat structure
+- `omit` (string[], optional) - Removes specified fields from output
+- `limit` (integer, optional) - Maximum number of results (default: all)
+- `desc` (boolean, optional) - Sort order (true = newest first)
+
+### ViewDisplay properties
+
+- `component` (string, required) - Only `table` is available
+- `properties` (Object, optional) - Keys matching `transformation.fields` with ViewDisplayProperty values
+
+### ViewDisplayProperty properties
+
+- `label` (string, optional) - Table column header
+- `format` (string, optional) - One of: `text`, `number`, `date`, `link`, `boolean`, `image`, `array`, `object`

--- a/skills/apify-orchestrator-actor-development/references/input-schema.md
+++ b/skills/apify-orchestrator-actor-development/references/input-schema.md
@@ -1,0 +1,66 @@
+﻿# Input schema reference
+
+The input schema defines the input parameters for an Actor. It's a JSON object comprising various field types supported by the Apify platform.
+
+## Structure
+
+```json
+{
+    "title": "<INPUT-SCHEMA-TITLE>",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        /* define input fields here */
+    },
+    "required": []
+}
+```
+
+## Example
+
+```json
+{
+    "title": "E-commerce Product Scraper Input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "startUrls": {
+            "title": "Start URLs",
+            "type": "array",
+            "description": "URLs to start scraping from (category pages or product pages)",
+            "editor": "requestListSources",
+            "default": [{ "url": "https://example.com/category" }],
+            "prefill": [{ "url": "https://example.com/category" }]
+        },
+        "followVariants": {
+            "title": "Follow Product Variants",
+            "type": "boolean",
+            "description": "Whether to scrape product variants (different colors, sizes)",
+            "default": true
+        },
+        "maxRequestsPerCrawl": {
+            "title": "Max Requests per Crawl",
+            "type": "integer",
+            "description": "Maximum number of pages to scrape (0 = unlimited)",
+            "default": 1000,
+            "minimum": 0
+        },
+        "proxyConfiguration": {
+            "title": "Proxy Configuration",
+            "type": "object",
+            "description": "Proxy settings for anti-bot protection",
+            "editor": "proxy",
+            "default": { "useApifyProxy": false }
+        },
+        "locale": {
+            "title": "Locale",
+            "type": "string",
+            "description": "Language/country code for localized content",
+            "default": "cs",
+            "enum": ["cs", "en", "de", "sk"],
+            "enumTitles": ["Czech", "English", "German", "Slovak"]
+        }
+    },
+    "required": ["startUrls"]
+}
+```

--- a/skills/apify-orchestrator-actor-development/references/key-value-store-schema.md
+++ b/skills/apify-orchestrator-actor-development/references/key-value-store-schema.md
@@ -1,0 +1,94 @@
+﻿# Key-value store schema reference
+
+The key-value store schema organizes keys into logical groups called collections for easier data management.
+
+## Example (TypeScript)
+
+```typescript
+import { Actor } from 'apify';
+
+await Actor.init();
+
+await Actor.setValue('document-1', 'my text data', { contentType: 'text/plain' });
+await Actor.setValue(`image-${imageID}`, imageBuffer, { contentType: 'image/jpeg' });
+
+await Actor.exit();
+```
+
+## Configuration
+
+To configure the key-value store schema, reference a schema file in `.actor/actor.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "name": "data-collector",
+    "title": "Data Collector",
+    "version": "1.0.0",
+    "storages": {
+        "keyValueStore": "./key_value_store_schema.json"
+    }
+}
+```
+
+Then create the key-value store schema in `.actor/key_value_store_schema.json`:
+
+```json
+{
+    "actorKeyValueStoreSchemaVersion": 1,
+    "title": "Key-Value Store Schema",
+    "collections": {
+        "documents": {
+            "title": "Documents",
+            "description": "Text documents stored by the Actor",
+            "keyPrefix": "document-"
+        },
+        "images": {
+            "title": "Images",
+            "description": "Images stored by the Actor",
+            "keyPrefix": "image-",
+            "contentTypes": ["image/jpeg"]
+        }
+    }
+}
+```
+
+## Structure
+
+```json
+{
+    "actorKeyValueStoreSchemaVersion": 1,
+    "title": "string (required)",
+    "description": "string (optional)",
+    "collections": {
+        "<COLLECTION_NAME>": {
+            "title": "string (required)",
+            "description": "string (optional)",
+            "key": "string (conditional - use key OR keyPrefix)",
+            "keyPrefix": "string (conditional - use key OR keyPrefix)",
+            "contentTypes": ["string (optional)"],
+            "jsonSchema": "object (optional)"
+        }
+    }
+}
+```
+
+## Properties
+
+### Key-value store schema properties
+
+- `actorKeyValueStoreSchemaVersion` (integer, required) - Version of key-value store schema structure document (currently only version 1)
+- `title` (string, required) - Title of the schema
+- `description` (string, optional) - Description of the schema
+- `collections` (Object, required) - Object where each key is a collection ID and value is a Collection object
+
+### Collection properties
+
+- `title` (string, required) - Collection title shown in UI tabs
+- `description` (string, optional) - Description appearing in UI tooltips
+- `key` (string, conditional) - Single specific key for this collection
+- `keyPrefix` (string, conditional) - Prefix for keys included in this collection
+- `contentTypes` (string[], optional) - Allowed content types for validation
+- `jsonSchema` (object, optional) - JSON Schema Draft 07 format for `application/json` content type validation
+
+Either `key` or `keyPrefix` must be specified for each collection, but not both.

--- a/skills/apify-orchestrator-actor-development/references/logging.md
+++ b/skills/apify-orchestrator-actor-development/references/logging.md
@@ -1,0 +1,30 @@
+﻿# Actor logging reference
+
+**ALWAYS use the `apify/log` package for logging** — this package censors sensitive data (Apify tokens, API keys, credentials) and prevents accidental exposure in logs.
+
+## Available log levels in `apify/log`
+
+The Apify log package provides the following methods:
+
+- `log.debug()` — Debug level logs (detailed diagnostic information)
+- `log.info()` — Info level logs (general informational messages)
+- `log.warning()` — Warning level logs (potentially problematic situations)
+- `log.warningOnce()` — Warning logged only once for the same message
+- `log.error()` — Error level logs (failures)
+- `log.exception()` — Exception level logs (for exceptions with stack traces)
+- `log.perf()` — Performance metrics and timing information
+- `log.deprecated()` — Warnings about deprecated code
+- `log.softFail()` — Non-critical failures that don't stop execution (e.g., input validation errors, skipped items)
+- `log.internal()` — Internal/system messages
+
+## Best practices
+
+- Use `log.debug()` for detailed operation-level diagnostics
+- Use `log.info()` for general informational messages (API requests, successful operations)
+- Use `log.warning()` for potentially problematic situations (validation failures, unexpected states)
+- Use `log.error()` for actual errors and failures
+- Use `log.exception()` for caught exceptions with stack traces
+
+## In an orchestrator Actor
+
+Log each sub-Actor call with `log.info()` so the parent Run's log tells the story of the pipeline. The `apify-orchestrator` library also emits its own structured logs when `enableLogs: true` is passed to the `Orchestrator` constructor — you don't need to duplicate those.

--- a/skills/apify-orchestrator-actor-development/references/mcp-schema-discovery.md
+++ b/skills/apify-orchestrator-actor-development/references/mcp-schema-discovery.md
@@ -1,0 +1,76 @@
+# Apify MCP: sub-Actor schema discovery
+
+Before wiring a sub-Actor into an orchestrator, you need its input schema (what fields to send) and output shape (what fields the dataset contains). Use the Apify MCP server as the primary source; fall back to the REST API when MCP is unavailable.
+
+## MCP server
+
+- **Hosted URL:** `https://mcp.apify.com` (OAuth-based; supported by Claude.ai, VS Code, Cursor, and Claude Code)
+- **Scope with a query string:** `https://mcp.apify.com/?tools=actors,docs`
+- **Docs:** <https://docs.apify.com/platform/integrations/mcp>
+- **Repo:** <https://github.com/apify/apify-mcp-server>
+
+If the user has the Apify MCP server configured, its tools are already available. Otherwise, ask them to add it — or fall back to the REST route below.
+
+## Primary tool: `fetch-actor-details`
+
+Returns the input schema, output schema, README (summary or full), and pricing for a given Actor ID.
+
+**Call it once per sub-Actor** during the interactive creation flow. Example flow the agent should follow:
+
+1. User says "add `apify/website-content-crawler` as step 1".
+2. Agent calls `fetch-actor-details` with `actorId: "apify/website-content-crawler"`.
+3. Agent presents the input schema back to the user, highlighting `REQUIRED`-prefixed fields.
+4. Agent asks the user which input fields should be exposed as top-level orchestrator input, which should be hardcoded, and which should be derived from a previous step's output.
+
+## Supporting tools
+
+| Tool | Purpose |
+|---|---|
+| `search-actors` | Free-text search the Apify Store. Use when the user names a task ("summarize X") rather than an Actor ID. |
+| `call-actor` | Trigger a Run programmatically. Rarely needed from within an orchestrator (the orchestrator itself makes the runs), but useful during scaffolding to sanity-check inputs. |
+| `get-dataset-items` | Inspect a sample Run's dataset to understand the actual field shape (schemas can lie or be incomplete). |
+| `get-actor-run` / `abort-actor-run` | Ops-time inspection and cancellation. |
+
+## The truncation gotcha
+
+`fetch-actor-details` post-processes schemas before returning them:
+
+- Field **descriptions** are truncated to **500 chars**.
+- **Enum** lists are truncated (combined string length capped at **200 chars**).
+- **Required fields** get a `REQUIRED` prefix in their descriptions (because some MCP clients ignore JSON Schema `required`).
+
+For high-fidelity scaffolding — especially for Actors with long enum lists (locales, model names, etc.) — fetch the raw `INPUT_SCHEMA.json` directly:
+
+```bash
+# Public Actors usually have their source on GitHub
+curl https://raw.githubusercontent.com/<org>/<repo>/master/.actor/input_schema.json
+```
+
+Or via the Apify REST API (falls back if MCP is unavailable):
+
+```bash
+curl -s https://api.apify.com/v2/acts/apify~website-content-crawler \
+    -H "Authorization: Bearer $APIFY_TOKEN" | jq .data
+```
+
+Note the tilde (`~`) replacing the slash in the actor ID for the REST URL.
+
+## What to do with the schemas
+
+Once fetched, the agent should:
+
+1. **Generate a TypeScript `interface` for each sub-Actor's input** — this catches typos at build time. If the schema has an `enum`, translate it to a union of string literals.
+2. **Note required fields** — those `REQUIRED`-prefixed descriptions become the fields whose values the orchestrator's own input schema must expose or hardcode.
+3. **Skim the output schema (or a sample dataset)** — you need to know which output field(s) to read to feed the next step. If the output schema is missing, use `get-dataset-items` with `limit=1` on a public sample Run to peek.
+4. **Cite the source** — leave a comment in `src/main.ts` next to each `client.actor(id).call(...)` linking to the Actor's Apify Store page. Future maintainers will thank you.
+
+## Fallback: no MCP configured
+
+If the Apify MCP server is not available in the session, use `curl` (or `fetch()` from a scratch script) against the REST API:
+
+```
+GET https://api.apify.com/v2/acts/{userOrOrg}~{actorName}
+Authorization: Bearer $APIFY_TOKEN
+```
+
+Response body has `data.exampleRunInput`, `data.stats`, and enough metadata to guide scaffolding, though the input schema itself lives at `.actor/input_schema.json` inside the Actor's source and is best fetched from GitHub.

--- a/skills/apify-orchestrator-actor-development/references/openrouter.md
+++ b/skills/apify-orchestrator-actor-development/references/openrouter.md
@@ -1,0 +1,87 @@
+# LLM layer via the Apify OpenRouter Actor
+
+Adding an LLM transformation between two sub-Actors (or as a final formatting step) is a common orchestrator pattern. Use the [Apify OpenRouter Actor](https://apify.com/apify/openrouter) as the LLM gateway — it exposes 300+ models via a single OpenAI-compatible endpoint and is billed through your Apify account.
+
+> **The OpenRouter Actor is a Standby-mode Actor.** It exposes HTTP endpoints, not a start/wait Run cycle. **Do NOT** do `client.actor('apify/openrouter').call(...)` and expect a dataset — you'll get an empty dataset from the Standby container. Hit the HTTP URL directly with `fetch()`.
+
+## Endpoint at a glance
+
+- **Base URL:** `https://openrouter.apify.actor/api/v1`
+- **Auth header:** `Authorization: Bearer $APIFY_TOKEN` (your normal Apify token)
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/chat/completions` | OpenAI-format chat completions |
+| POST | `/messages` | Anthropic-format messages |
+| POST | `/embeddings` | Text embeddings |
+| GET | `/models` | List available models |
+| GET | `/providers` | List available providers |
+
+Billing = Apify Standby usage (small) + the model's own token cost. The Actor page on the Apify Store shows current per-model pricing.
+
+## Minimal TypeScript call
+
+```typescript
+import { log } from 'apify';
+
+interface OpenRouterMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+}
+
+async function callOpenRouter(messages: OpenRouterMessage[], model = 'openrouter/auto') {
+    const res = await fetch('https://openrouter.apify.actor/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            Authorization: `Bearer ${process.env.APIFY_TOKEN}`,
+        },
+        body: JSON.stringify({ model, messages }),
+    });
+    if (!res.ok) {
+        throw new Error(`OpenRouter ${res.status}: ${await res.text()}`);
+    }
+    const json = await res.json();
+    log.info('OpenRouter usage', json.usage);
+    return json.choices[0].message.content as string;
+}
+```
+
+Usage in an orchestrator step:
+
+```typescript
+const runA = await client.actor('apify/website-content-crawler').call('crawl', { ... });
+const items = await client.dataset(runA.defaultDatasetId).listItems({ skipEmpty: true });
+
+const summary = await callOpenRouter([
+    { role: 'system', content: 'You summarize scraped web pages in one paragraph.' },
+    { role: 'user', content: items.items.map(i => i.text).join('\n---\n').slice(0, 12000) },
+]);
+
+await Actor.pushData({ summary, source: items.items.map(i => i.url) });
+```
+
+## Model choice
+
+- `openrouter/auto` — router picks a model per request (cheapest reasonable choice).
+- `anthropic/claude-sonnet-4-5` — high-quality general.
+- `openai/gpt-4o-mini` — cheap and fast for classification/extraction.
+- `google/gemini-2.5-flash` — cheap with long context.
+- `GET /models` returns the full live list.
+
+## Streaming
+
+Add `stream: true` to the body. The response is Server-Sent Events (SSE). The final chunk carries the `usage` field.
+
+## Common orchestrator patterns
+
+- **Between steps** — Actor A scrapes, LLM classifies each item into buckets, Actor B is called once per bucket with different inputs.
+- **As final formatting** — After the last sub-Actor, run each dataset item through the LLM to normalize it (e.g., extract structured fields from free text).
+- **As a routing decision** — Ask the LLM which of N Actors to call next based on the user's original query.
+
+## Gotchas
+
+- **It's Standby, not Run.** Repeat: don't `client.actor('apify/openrouter').call(...)` — hit the HTTPS URL.
+- **Token lives in your env**, not the orchestrator library. On the Apify platform `APIFY_TOKEN` is populated automatically; locally you set it (or run `apify login` and export it manually for scripts that don't use the SDK).
+- **Rate limits & context windows** are per-model. Check the model's page on OpenRouter for the exact limit.
+- **Cost visibility** — track `json.usage.total_tokens` and log it. LLM steps can silently dominate the run's cost.

--- a/skills/apify-orchestrator-actor-development/references/orchestrator-library.md
+++ b/skills/apify-orchestrator-actor-development/references/orchestrator-library.md
@@ -1,0 +1,141 @@
+# apify-orchestrator library reference
+
+The [`apify-orchestrator`](https://github.com/apify-projects/apify-orchestrator) library is an opinionated TypeScript wrapper around `apify` + `apify-client` for coordinating **many external Actor Runs from within a single parent Run**. Unlike rigid parallel-runner patterns, it lets you spawn Runs from anywhere in your code at any time.
+
+> **Alpha release** — the library is at `0.x`. Pin the exact version in `package.json` and expect breaking changes on minor bumps.
+
+## Installation
+
+```bash
+npm install apify-orchestrator apify apify-client
+```
+
+`apify` and `apify-client` are peer dependencies. Install a matching version of each.
+
+## Core concepts
+
+### `Orchestrator`
+The singleton that owns the run scheduler, KVS persistence, log stream, and kill-switch behaviour.
+
+```typescript
+import { Orchestrator } from 'apify-orchestrator';
+
+const orchestrator = new Orchestrator({
+    enableLogs: true,                       // structured logs + periodic stats reports
+    persistenceSupport: 'kvs',              // 'kvs' | 'none' — enables Run resurrection
+    persistencePrefix: 'ORCH-',             // KVS record prefix
+    abortAllRunsOnGracefulAbort: true,      // parent gracefully aborts → all child Runs aborted
+    retryOnInsufficientResources: true,     // wait for memory/slots before launching
+    // fixedInput: { ... },                 // deep-merged into every child Run's input
+    // persistenceEncryptionKey: '...',     // optional at-rest encryption for persisted state
+    // hideSensitiveInformation: true,      // scrubs secrets from stats reports
+});
+```
+
+### `ExtendedApifyClient`
+An extended `ApifyClient` returned by `orchestrator.apifyClient()`. Same API surface as the standard client plus orchestrator-aware verbs.
+
+```typescript
+const client = await orchestrator.apifyClient({
+    name: 'MAIN',                           // clientName — persistence-critical (see gotchas)
+    token: process.env.APIFY_TOKEN,         // optional — SDK picks it up automatically on Apify
+});
+```
+
+## Verbs cheat sheet
+
+| Verb | Behaviour |
+|---|---|
+| `client.actor(id).enqueue(...)` | Register Run(s) in scheduler; start later when resources allow. Returns names. |
+| `client.actor(id).start(name, input?)` | Begin one Run; return `ActorRun` immediately (no wait). |
+| `client.actor(id).call(name, input?)` | Begin one Run and **await** finish. This is the default for sequential pipelines. |
+| `client.actor(id).callRuns(...requests)` | Begin multiple Runs in parallel, await all. Requests are `{ runName, input, options? }`. |
+| `client.actor(id).callBatch(prefix, sources, inputGen, splitRules?)` | Auto-shard `sources` into multiple Runs when input exceeds Apify's 9 MiB payload cap. **Slow** — prefer `callRuns` when you already know the shape. |
+| `client.dataset(id).iterate({ pageSize })` | Async generator over dataset items. **Required for large datasets** — plain `.listItems()` hits the V8 string cap. |
+| `orchestrator.mergeDatasets(...datasets)` | Combine child-Run datasets; call `.iterate()` on the result. Iteration is sequential (A drained fully before B). |
+| `client.abortAllRuns()` | Abort every tracked Run for this client. |
+
+## Canonical orchestrator pattern
+
+```typescript
+import { Actor, log } from 'apify';
+import { Orchestrator } from 'apify-orchestrator';
+
+await Actor.init();
+
+const orchestrator = new Orchestrator({
+    enableLogs: true,
+    persistenceSupport: 'kvs',
+    persistencePrefix: 'ORCH-',
+    abortAllRunsOnGracefulAbort: true,
+});
+const client = await orchestrator.apifyClient({ name: 'MAIN' });
+
+// Sequential: run A, then run B with A's output
+log.info('Starting step 1');
+const runA = await client.actor('apify/website-content-crawler').call('step-1', {
+    startUrls: [{ url: 'https://example.com' }],
+});
+
+log.info('Starting step 2');
+const items = await client.dataset(runA.defaultDatasetId).listItems({ skipEmpty: true });
+const runB = await client.actor('apify/rag-web-browser').call('step-2', {
+    query: items.items.map(i => i.text).join('\n').slice(0, 4000),
+});
+
+// Emit combined output
+for await (const item of client.dataset(runB.defaultDatasetId).iterate({ pageSize: 100 })) {
+    await Actor.pushData(item);
+}
+
+await Actor.exit();
+```
+
+## Parallel fan-out
+
+```typescript
+const record = await client.actor('apify/website-content-crawler').callRuns(
+    { runName: 'crawl-a', input: { startUrls: [{ url: 'https://a.com' }] } },
+    { runName: 'crawl-b', input: { startUrls: [{ url: 'https://b.com' }] } },
+);
+// record === { 'crawl-a': ActorRun, 'crawl-b': ActorRun }
+
+const merged = orchestrator.mergeDatasets(
+    ...Object.values(record).map(r => client.dataset(r.defaultDatasetId)),
+);
+for await (const item of merged.iterate({ pageSize: 100 })) {
+    await Actor.pushData(item);
+}
+```
+
+## Kill-switch across accounts (Children Run Killer)
+
+When you also control the child Actors' code, propagate the parent Run ID so a hard crash of the parent can still stop them:
+
+```typescript
+new Orchestrator({
+    fixedInput: {
+        __watched: {
+            parentRunId: Actor.getEnv().actorRunId,
+            apifyUserId: Actor.getEnv().userId,
+        },
+    },
+});
+```
+
+`abortAllRunsOnGracefulAbort` only fires on graceful abort. Hard timeouts and crashes orphan child Runs — the `fixedInput` pattern above is your only durable guarantee.
+
+## Gotchas
+
+1. **Alpha version** — pin the exact version, expect breakage on minor bumps.
+2. **`callBatch` is slow.** Its auto-split walks the input generator and probes sizes. If you already know a good shard shape, use `callRuns` with hand-authored `ActorRunRequest[]`.
+3. **Client name is persistence-critical.** The KVS record key is `${persistencePrefix}${clientName}-RUNS`. Change the name and resurrection reattaches to nothing.
+4. **`callBatch` name collision.** `namePrefix` is suffixed with `-1`, `-2`, etc. Don't reuse a prefix that also appears as a single-Run name in a `call`.
+5. **`abortAllRunsOnGracefulAbort` only fires on graceful abort.** Hard crashes leak child Runs.
+6. **`mergeDatasets` iterates sequentially.** Dataset A is drained fully before B begins. Not interleaved.
+7. **`iterate({ pageSize })` is required for large datasets.** Plain `listItems()` returns everything in one string and hits the V8 `0x1fffffe8`-char cap.
+
+## Sources
+
+- Repo: <https://github.com/apify-projects/apify-orchestrator>
+- Types: <https://raw.githubusercontent.com/apify-projects/apify-orchestrator/main/src/types.ts>

--- a/skills/apify-orchestrator-actor-development/references/orchestrator-template.md
+++ b/skills/apify-orchestrator-actor-development/references/orchestrator-template.md
@@ -1,0 +1,246 @@
+# Orchestrator Actor: canonical `src/main.ts` template
+
+This is the shape the agent should generate for the orchestrator's entry point. Fill in the placeholders (`<...>`) based on the sub-Actor schemas fetched during the interactive flow.
+
+## Template
+
+```typescript
+import { Actor, log } from 'apify';
+import { Orchestrator } from 'apify-orchestrator';
+
+// -------------------------------------------------------------------------
+// Input & sub-Actor input types
+// -------------------------------------------------------------------------
+
+// List every sub-Actor step that spends money. The total cap is divided
+// evenly across this tuple — see references/cost-tracking.md for the rationale.
+const STEPS = ['step1', 'step2'] as const;
+type Step = (typeof STEPS)[number];
+
+interface OrchestratorInput {
+    // Top-level fields exposed to the orchestrator's own input schema.
+    // Derive these from the sub-Actors' REQUIRED fields that shouldn't be hardcoded.
+    // Do NOT add a cost cap or stepBudgets field here — the TOTAL cap is the
+    // Run's own maxTotalChargeUsd option, and the split is the compile-time
+    // even distribution defined by STEPS above.
+    startUrls: { url: string }[];
+    maxItems?: number;
+}
+
+// One interface per sub-Actor, mirroring its input schema (from Apify MCP fetch-actor-details).
+interface StepOneInput {
+    startUrls: { url: string }[];
+    maxCrawlDepth?: number;
+}
+
+interface StepTwoInput {
+    query: string;
+    maxResults?: number;
+}
+
+// -------------------------------------------------------------------------
+// Actor entry
+// -------------------------------------------------------------------------
+
+await Actor.init();
+
+const input = await Actor.getInput<OrchestratorInput>();
+if (!input) throw new Error('Missing input');
+
+const orchestrator = new Orchestrator({
+    enableLogs: true,
+    persistenceSupport: 'kvs',
+    persistencePrefix: 'ORCH-',
+    abortAllRunsOnGracefulAbort: true,
+});
+
+const client = await orchestrator.apifyClient({ name: 'MAIN' });
+
+// -------------------------------------------------------------------------
+// Cost budget bookkeeping — see references/cost-tracking.md
+//   Total cap comes from THIS Run's own maxTotalChargeUsd option (set by
+//   the caller via API / Console / SDK, not via input schema). The
+//   orchestrator splits it evenly across STEPS at compile time — no
+//   stepBudgets input, no per-step config for the caller.
+// -------------------------------------------------------------------------
+
+const env = Actor.getEnv();
+let totalBudget = Number.POSITIVE_INFINITY;
+if (env.actorRunId) {
+    try {
+        const selfRun = await client.run(env.actorRunId).get();
+        const cap = selfRun?.options?.maxTotalChargeUsd;
+        if (typeof cap === 'number' && cap > 0) totalBudget = cap;
+    } catch (err) {
+        // Local `apify run` uses a synthetic Run ID that doesn't exist on
+        // the platform. Fall back to uncapped so local runs still work.
+        log.debug(`Could not read self-Run options: ${(err as Error).message}`);
+    }
+}
+const perStepCap = totalBudget / STEPS.length;   // Infinity / N = Infinity
+let spent = 0;
+
+log.info(
+    `Total cost cap: ${Number.isFinite(totalBudget) ? '$' + totalBudget.toFixed(4) : 'unlimited (caller did not set maxTotalChargeUsd)'}. ` +
+    `Per-step cap (even split across ${STEPS.length} steps): ${Number.isFinite(perStepCap) ? '$' + perStepCap.toFixed(4) : 'unlimited'}.`,
+);
+
+function planStepCap(step: Step): number | undefined {
+    const remaining = totalBudget - spent;
+    if (remaining <= 0) {
+        throw new Error(`Cost cap of $${totalBudget} reached before step "${step}"; refusing to launch`);
+    }
+    if (!Number.isFinite(perStepCap)) return undefined;   // uncapped → don't pass maxTotalChargeUsd
+    // Cap at whichever is smaller so an earlier overshoot can't leak into a later step.
+    return Math.min(perStepCap, remaining);
+}
+
+function record(stepName: string, run: { usageTotalUsd?: number }) {
+    const stepCost = run.usageTotalUsd ?? 0;
+    spent += stepCost;
+    log.info(`Step "${stepName}" spent $${stepCost.toFixed(4)}; cumulative $${spent.toFixed(4)}`);
+}
+
+// -------------------------------------------------------------------------
+// Step 1: <sub-actor-1-id>
+//   See: https://apify.com/<sub-actor-1-id>
+// -------------------------------------------------------------------------
+
+log.info('Step 1: launching <sub-actor-1-id>');
+const step1Input: StepOneInput = {
+    startUrls: input.startUrls,
+    // maxCrawlDepth: 2,  // hardcoded example
+};
+const step1Cap = planStepCap('step1');
+const run1 = await client
+    .actor('<sub-actor-1-id>')
+    .call('step-1', step1Input, step1Cap != null ? { maxTotalChargeUsd: step1Cap } : undefined);
+// For compute-unit sub-Actors, drop maxTotalChargeUsd and pass { memory, timeout } instead.
+record('step-1', run1);
+const step1Items = await client.dataset(run1.defaultDatasetId).listItems({ skipEmpty: true });
+log.info(`Step 1 finished: ${step1Items.items.length} items`);
+
+// -------------------------------------------------------------------------
+// (Optional) LLM transformation
+//   See references/openrouter.md for the full pattern.
+// -------------------------------------------------------------------------
+//
+// const summary = await callOpenRouter([
+//     { role: 'system', content: '...' },
+//     { role: 'user', content: JSON.stringify(step1Items.items).slice(0, 12000) },
+// ]);
+
+// -------------------------------------------------------------------------
+// Step 2: <sub-actor-2-id>
+//   Input derived from step-1 output.
+//   See: https://apify.com/<sub-actor-2-id>
+// -------------------------------------------------------------------------
+
+log.info('Step 2: launching <sub-actor-2-id>');
+const step2Input: StepTwoInput = {
+    query: step1Items.items.map(i => i.text as string).join('\n').slice(0, 4000),
+    maxResults: input.maxItems ?? 20,
+};
+const step2Cap = planStepCap('step2');
+const run2 = await client
+    .actor('<sub-actor-2-id>')
+    .call('step-2', step2Input, step2Cap != null ? { maxTotalChargeUsd: step2Cap } : undefined);
+record('step-2', run2);
+
+// -------------------------------------------------------------------------
+// Emit final dataset — iterate (not listItems) to survive large payloads
+// -------------------------------------------------------------------------
+
+log.info('Emitting final dataset');
+for await (const item of client.dataset(run2.defaultDatasetId).iterate({ pageSize: 100 })) {
+    await Actor.pushData(item);
+}
+
+// -------------------------------------------------------------------------
+// Surface sub-Actor dataset links so users can inspect upstream data.
+// Referenced from .actor/output_schema.json — see output-schema.md.
+// -------------------------------------------------------------------------
+
+const subDatasets = [
+    {
+        name: '<sub-actor-1-id>',
+        resultUrl: `https://console.apify.com/storage/datasets/${run1.defaultDatasetId}`,
+    },
+    {
+        name: '<sub-actor-2-id>',
+        resultUrl: `https://console.apify.com/storage/datasets/${run2.defaultDatasetId}`,
+    },
+];
+await Actor.setValue('SUB_DATASETS', subDatasets);
+
+await Actor.exit();
+```
+
+## Companion files
+
+`.actor/actor.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "defaultMemoryMbytes": 1000,
+    "name": "my-orchestrator",
+    "title": "My Orchestrator",
+    "version": "0.0",
+    "meta": {
+        "templateId": "ts_empty",
+        "generatedBy": "Claude Code with Claude Opus 4.7"
+    },
+    "input": "./input_schema.json",
+    "output": "./output_schema.json",
+    "storages": {
+        "dataset": "./dataset_schema.json"
+    },
+    "dockerfile": "../Dockerfile"
+}
+```
+
+`defaultMemoryMbytes: 1000` is a sane default for orchestrators — the parent Run spends most of its life awaiting child Runs, not doing heavy work. Bump it only if the workflow chains 200+ sub-Actors or streams very large datasets through in-memory transforms. See [actor-json.md](actor-json.md).
+
+`package.json` dependencies section (versions are indicative — check npm for latest):
+
+```json
+{
+    "dependencies": {
+        "apify": "^3.4.0",
+        "apify-client": "^2.10.0",
+        "apify-orchestrator": "0.x"
+    }
+}
+```
+
+Pin the exact `apify-orchestrator` version (it's alpha, minor bumps break API).
+
+## Surfacing sub-Actor dataset links
+
+Orchestrator users often want to inspect the raw data each sub-Actor produced — for debugging, spot-checking, or downloading the upstream dataset directly. Emit an array of `{ name, resultUrl }` records to a KVS key (canonically `SUB_DATASETS`), then reference that key from `.actor/output_schema.json` so it appears on the Run's Output tab.
+
+Construct URLs from each Run's `defaultDatasetId`:
+
+```typescript
+const subDatasets = [
+    { name: 'Google Search Scraper', resultUrl: `https://console.apify.com/storage/datasets/${googleRun.defaultDatasetId}` },
+    { name: 'Website Content Crawler', resultUrl: `https://console.apify.com/storage/datasets/${wccRun.defaultDatasetId}` },
+];
+await Actor.setValue('SUB_DATASETS', subDatasets);
+```
+
+Then in `.actor/output_schema.json` add a property pointing at the KVS record. See [output-schema.md](output-schema.md) for the exact template syntax.
+
+## Variations
+
+- **Parallel step**: replace `.call(name, input)` with `.callRuns(...requests)` and merge with `orchestrator.mergeDatasets(...)`. See `references/orchestrator-library.md`.
+- **Batch step** (very large inputs that would exceed 9 MiB): use `.callBatch(prefix, sources, inputGen, { respectApifyMaxPayloadSize: true })`.
+- **Kill-switch propagation**: pass `fixedInput.__watched` to the `Orchestrator` constructor (see `references/orchestrator-library.md`).
+- **LLM step**: inline a `callOpenRouter(...)` helper (see `references/openrouter.md`) between steps.
+
+## Testing locally
+
+1. `apify run --purge` — runs the orchestrator with the local `storage/key_value_stores/default/INPUT.json` as input.
+2. Local sub-Actor Runs execute **on the Apify platform** (they're real Runs, not simulated) — you need a valid `APIFY_TOKEN` in your environment. Watch the Apify Console → Runs list for the child Runs while the orchestrator runs locally.
+3. Local storage under `storage/` receives only the orchestrator's own dataset output, not the child Runs' data.

--- a/skills/apify-orchestrator-actor-development/references/output-schema.md
+++ b/skills/apify-orchestrator-actor-development/references/output-schema.md
@@ -1,0 +1,74 @@
+﻿# Output schema reference
+
+The Actor output schema builds upon the schemas for the dataset and key-value store. It specifies where an Actor stores its output and defines templates for accessing that output. Apify Console uses these output definitions to display run results.
+
+## Structure
+
+```json
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "<OUTPUT-SCHEMA-TITLE>",
+    "properties": {
+        /* define your outputs here */
+    }
+}
+```
+
+## Example
+
+```json
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Output schema of the files scraper",
+    "properties": {
+        "files": {
+            "type": "string",
+            "title": "Files",
+            "template": "{{links.apiDefaultKeyValueStoreUrl}}/keys"
+        },
+        "dataset": {
+            "type": "string",
+            "title": "Dataset",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}
+```
+
+## Orchestrator pattern: linking to sub-Actor datasets
+
+Orchestrator Actors typically surface links to each child Run's dataset so users can inspect upstream data. Write the array to a KVS record (see [orchestrator-template.md](orchestrator-template.md)), then expose it via the output schema:
+
+```json
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Orchestrator output",
+    "properties": {
+        "dataset": {
+            "type": "string",
+            "title": "Final dataset",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        },
+        "subDatasets": {
+            "type": "string",
+            "title": "Sub-Actor datasets",
+            "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/SUB_DATASETS"
+        }
+    }
+}
+```
+
+The `SUB_DATASETS` record contains the `[{ name, resultUrl }]` array the orchestrator wrote via `Actor.setValue('SUB_DATASETS', ...)`.
+
+## Output schema template variables
+
+- `links` (object) - Contains quick links to most commonly used URLs
+- `links.publicRunUrl` (string) - Public run url in format `https://console.apify.com/view/runs/:runId`
+- `links.consoleRunUrl` (string) - Console run url in format `https://console.apify.com/actors/runs/:runId`
+- `links.apiRunUrl` (string) - API run url in format `https://api.apify.com/v2/actor-runs/:runId`
+- `links.apiDefaultDatasetUrl` (string) - API url of default dataset in format `https://api.apify.com/v2/datasets/:defaultDatasetId`
+- `links.apiDefaultKeyValueStoreUrl` (string) - API url of default key-value store in format `https://api.apify.com/v2/key-value-stores/:defaultKeyValueStoreId`
+- `links.containerRunUrl` (string) - URL of a webserver running inside the run in format `https://<containerId>.runs.apify.net/`
+- `run` (object) - Contains information about the run same as it is returned from the `GET Run` API endpoint
+- `run.defaultDatasetId` (string) - ID of the default dataset
+- `run.defaultKeyValueStoreId` (string) - ID of the default key-value store


### PR DESCRIPTION
Build TypeScript Apify orchestrator Actors — coordinate a sequence of sub-Actors (optionally with an LLM step) using the apify-orchestrator library. Interactive scaffolding flow with Apify MCP schema discovery, per-step cost budgets via maxTotalChargeUsd, and OpenRouter LLM step.

## Skill

- **Name:** `apify-...`
- **What it does:** (one sentence — see also the `description` in your SKILL.md frontmatter)
- **Author:** (your name or handle)

## Checklist

- [ ] PR adds **one** skill in `skills/apify-<name>/` (no other file changes except `.claude-plugin/marketplace.json`)
- [ ] `SKILL.md` frontmatter has `name` (matches folder, `apify-` prefix) and `description` (≤ 1024 chars)
- [ ] Added entry to `.claude-plugin/marketplace.json`
- [ ] Tested the skill end-to-end at least once

## Notes

<!-- Optional: design decisions, links to similar skills, anything reviewers should know -->
