### PR TITLE
Add apify-zillow-real-estate-leads skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -207,6 +207,31 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-zillow-real-estate-leads",
+      "source": "./skills/apify-zillow-real-estate-leads",
+      "skills": "./",
+      "description": "Build real-estate agent and listing lead lists from Zillow — property details plus the listing agent's email, cell phone, brokerage and license — using a cost-ordered waterfall that starts from what the listing row already returned (phone 100%, email ~81% measured across 75 listings in three markets) and pays for web enrichment only on the remainder. Covers ZIP / search-URL / property-ID modes, the filters-are-ZIP-mode-only trap, and why a ZIP is searched as its city.",
+      "keywords": [
+        "zillow",
+        "real-estate",
+        "realtor",
+        "listing-agent",
+        "agent-email",
+        "property",
+        "leads",
+        "lead-generation",
+        "zip-code",
+        "zestimate",
+        "comps",
+        "for-sale",
+        "rental",
+        "brokerage",
+        "contact-enrichment"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -212,7 +212,7 @@
       "name": "apify-zillow-real-estate-leads",
       "source": "./skills/apify-zillow-real-estate-leads",
       "skills": "./",
-      "description": "Build real-estate agent and listing lead lists from Zillow — property details plus the listing agent's email, cell phone, brokerage and license — using a cost-ordered waterfall that starts from what the listing row already returned (phone 100%, email ~81% measured across 75 listings in three markets) and pays for web enrichment only on the remainder. Covers ZIP / search-URL / property-ID modes, the filters-are-ZIP-mode-only trap, and why a ZIP is searched as its city.",
+      "description": "Build real-estate agent and listing lead lists from Zillow — property details plus the listing agent's email, cell phone, brokerage and license — using a cost-ordered waterfall that starts from what the listing row already returned (phone 100%, email ~81% measured across 75 listings in three markets) and pays for web enrichment only on the remainder. Covers ZIP / search-URL / property-ID modes, the filters-are-ZIP-mode-only trap, and the per-ZIP cost cap.",
       "keywords": [
         "zillow",
         "real-estate",

--- a/skills/apify-zillow-real-estate-leads/SKILL.md
+++ b/skills/apify-zillow-real-estate-leads/SKILL.md
@@ -59,11 +59,11 @@ Every email in that sample carried `agentEmailSource: agent_profile_direct`.
 
 **Filters apply in ZIP mode only.** Passing `beds_min`, `price_max` or `status_type` alongside a `zillowUrl` does nothing — in URL mode the filtering already happened in the browser and lives inside the URL. In `zpid` mode filters are ignored too; you asked for specific properties.
 
-## Two things that surprise people
+## Two things worth knowing
 
-**A ZIP is searched as its city.** The upstream search resolves place names, not raw ZIP digits, so `78704` is searched as `Austin, TX` and the results span the metro. In the sample above, a 25-row run on `78704` returned listings across 15 different Austin ZIPs — **1 row was in 78704 itself**; `33139` returned 9 of 25 in-ZIP, `60614` 3 of 25. If the user asked for one ZIP, request a larger cap and **filter the output on the `zipcode` field**. If they asked for "the Austin market", you already have it.
+**The cap is per ZIP, so cost scales with the ZIP list.** `maxPropertiesPerZip` applies to each ZIP separately: 10 ZIPs at a cap of 5 returns up to 50 rows, and every row is billed. Multiply before you run, and confirm with the user before sweeping a long ZIP list.
 
-**The property cap covers a batch of ZIPs, not each ZIP.** ZIPs are searched in batches of up to five, and `maxPropertiesPerZip` bounds the batch. Three ZIPs with a cap of 10 returns 10 rows total — and the last city in the batch may return nothing at all. **To get N properties per ZIP, run one ZIP per call.**
+**A few ZIPs cannot be searched directly, and the run says so.** PO-box and business-district ZIPs — 3 of the 50 most-requested ones — are not searchable as regions on Zillow's side. For those the actor searches the surrounding city and keeps only listings inside the requested ZIP, dropping the rest before they are billed. Which ZIPs those were is in `RUN_SUMMARY.zipScope` and in the `USER_MESSAGE` record. In a dense metro that fallback often finds nothing, which is a real answer about the ZIP, not a failure to retry.
 
 ## Mapping (property row → lead row)
 
@@ -126,7 +126,6 @@ You can also call these Actors through the [Apify MCP connector](https://mcp.api
 
 - **Zero rows.** Read the run's `USER_MESSAGE` key-value record first — it names the cause for that specific run. In order of frequency: the search matched nothing (a PO-box or business-district ZIP has no residential listings by design, or `status_type` is wrong — asking for `ForSale` in a rentals area); the URL shape was not recognised in `url` mode; or the zpids were delisted. A ZIP that always returns data, for isolating the problem: `90210`, no filters.
 - **Emails come back like `j***@e***.com`.** That is the free plan masking them. Do not report masked strings as contacts — say the plan is the constraint.
-- **Rows are outside the ZIP the user asked for.** Expected; see *Two things that surprise people*. Filter on `zipcode`.
 - **Filters seem ignored.** Check the mode. Filters are ZIP-mode only.
-- **Fewer rows than the cap.** The cap covers a batch of up to five ZIPs, not each one. Run one ZIP per call.
+- **Fewer rows than the cap for one ZIP.** That ZIP has fewer matching listings than the cap — `RUN_SUMMARY` says whether a cap clipped the result or the search returned everything that matched.
 - **Cost control.** Every property enriched is billed, whether or not it carries an email, so cap the run before it starts rather than filtering afterwards. Confirm with the user before running an uncapped sweep across many ZIPs.

--- a/skills/apify-zillow-real-estate-leads/SKILL.md
+++ b/skills/apify-zillow-real-estate-leads/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: apify-zillow-real-estate-leads
+description: Build real-estate agent and listing lead lists from Zillow - property details plus the listing agent's email, cell phone, brokerage and license number - and fall through to web enrichment only for the rows Zillow leaves empty. Use when the user says things like "get real estate agent emails", "scrape Zillow listings", "find realtor contacts in a ZIP code", "build a list of listing agents", "Zillow lead generation", "pull homes for sale with agent contact", "recently sold comps", or "who is the listing agent". The agent's phone is in the listing row every time and the email about 4 times in 5, so this skill leads with what the property scrape already returned and only pays for contact-enrichment on the remainder - instead of routing every lead through a Google Maps email scraper, which costs more and matches the wrong business.
+author: afanasenkoa
+author_url: https://github.com/afanasenkoa
+---
+
+# Zillow property & agent lead builder
+
+Turn a ZIP code, a Zillow search URL, or a list of property IDs into a clean table of listings with the listing agent's contact details attached.
+
+## The key insight
+
+The listing agent's contact details are **already inside the property row**. `agentName`, `cellPhone`, `agentEmail`, `brokerName` and `agentLicenseNumber` come back with the listing itself, and `agentEmailSource` tells you which lookup produced the email — so you can tell a real address from a guess without re-checking.
+
+Measured on 2026-07-29, 75 for-sale listings across three markets:
+
+| Market | Listings | `cellPhone` | `agentEmail` |
+|---|---|---|---|
+| Austin, TX | 25 | 25 (100%) | 23 (92%) |
+| Chicago, IL | 25 | 25 (100%) | 21 (84%) |
+| Miami Beach, FL | 25 | 25 (100%) | 17 (68%) |
+| **Total** | **75** | **75 (100%)** | **61 (81%)** |
+
+Every email in that sample carried `agentEmailSource: agent_profile_direct`.
+
+**So use a waterfall.** Take what the listing scrape returned, and spend on enrichment only for the ~1 row in 5 with no email. Never open with a Google Maps email extractor: it costs more per lead, and for a listing agent it frequently resolves to the brokerage's front desk rather than the person.
+
+| Tier | Source | Gets | Fires when |
+|------|--------|------|-----------|
+| 1 | Zillow listing row | agent name, cell phone, email, brokerage, license | always — already scraped |
+| 2 | Google Search (agent + brokerage name) | a candidate brokerage **website** | row still has no email |
+| 3 | Contact scraper on that website | email / phone / socials | row has a website but still no email |
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## Workflow
+
+1. **Pick the mode first.** This is the single most common mistake — see *Mode routing* below. ZIP code = discover listings; Zillow URL = the user already filtered in their browser; property IDs (`zpid`) = enrich listings they already have.
+2. **Collect inputs.** Location (ZIP / URL / zpid list), for-sale vs for-rent vs recently-sold (`status_type`), any price / beds / baths filters, and how many properties to cap the run at.
+3. **Tier 1 — scrape the listings.** Run the Zillow actor. Build one lead row per property from the fields in *Mapping* below. Rows with `agentEmail` set are done; mark them `contactSource: zillow-listing`.
+4. **Tier 2 — find a website (only rows still missing an email).** Run `apify/google-search-scraper` with one query per row: `"<agentName>" "<brokerName>" real estate`. Take the first `organicResults[].url` that is not zillow.com, realtor.com, redfin.com, or a social network.
+5. **Tier 3 — scrape that website (only rows with a website but no email).** Run `vdrmota/contact-info-scraper` on the candidate URLs. Mark filled rows `contactSource: website-contact`. Cap this tier — it is the expensive one, and it runs on the smallest slice.
+6. **Deliver.** One row per property. Report the row count, the share with an email, and the `contactSource` breakdown. Rows still without an email keep `cellPhone` and `hdpUrl`, which are enough to reach the agent.
+
+## Mode routing
+
+| User wants | Mode | Key input |
+|---|---|---|
+| Every listing in an area | `zip` | `zipCodes: ["78704"]` |
+| The exact search they configured on zillow.com | `url` | `zillowUrl` — the full address-bar URL, including `searchQueryState=` |
+| Details for properties they already identified | `zpid` | `zpids: ["119617641"]` |
+
+**Filters apply in ZIP mode only.** Passing `beds_min`, `price_max` or `status_type` alongside a `zillowUrl` does nothing — in URL mode the filtering already happened in the browser and lives inside the URL. In `zpid` mode filters are ignored too; you asked for specific properties.
+
+## Two things that surprise people
+
+**A ZIP is searched as its city.** The upstream search resolves place names, not raw ZIP digits, so `78704` is searched as `Austin, TX` and the results span the metro. In the sample above, a 25-row run on `78704` returned listings across 15 different Austin ZIPs — **1 row was in 78704 itself**; `33139` returned 9 of 25 in-ZIP, `60614` 3 of 25. If the user asked for one ZIP, request a larger cap and **filter the output on the `zipcode` field**. If they asked for "the Austin market", you already have it.
+
+**The property cap covers a batch of ZIPs, not each ZIP.** ZIPs are searched in batches of up to five, and `maxPropertiesPerZip` bounds the batch. Three ZIPs with a cap of 10 returns 10 rows total — and the last city in the batch may return nothing at all. **To get N properties per ZIP, run one ZIP per call.**
+
+## Mapping (property row → lead row)
+
+| Output column | Source field |
+|---|---|
+| `address`, `city`, `state`, `zipcode`, `county` | `streetAddress`, `city`, `state`, `zipcode`, `county` |
+| `price`, `zestimate`, `pricePerSqft`, `status` | `price`, `zestimate`, `pricePerSqft`, `status` |
+| `beds`, `baths`, `sqft`, `yearBuilt` | `bedrooms`, `bathrooms`, `livingArea`, `yearBuilt` |
+| `agentName`, `phone`, `email` | `agentName`, `cellPhone`, `agentEmail` |
+| `brokerage`, `license` | `brokerName`, `agentLicenseNumber` |
+| `emailProvenance` | `agentEmailSource` — `property_details` \| `agent_profile_direct` \| `agent_search_fallback` \| `not_found` |
+| `listingUrl` | `hdpUrl` |
+| `contactSource` | `zillow-listing` \| `website-contact` \| `none` |
+
+Put `agentName`, `phone` and `email` immediately after the address columns — that is the order a user scans a lead list in.
+
+Always return `hdpUrl`, `daysOnZillow` and `priceChange` for every row. They are the three signals that let a user rank which agent to call first without reopening Zillow.
+
+## Actor routing
+
+| Waterfall tier | Actor ID | Maintainer | Best for |
+|---|---|---|---|
+| 1 — listings + agent contacts, all three modes | `afanasenko/zillow-property-agent-data-scraper` | community | **Primary.** ZIP / URL / zpid in one actor, agent contact attached to every row |
+| 1 — ZIP only, simpler input | `afanasenko/zillow-zip-search` | community | When the user gives nothing but ZIP codes |
+| 1 — search URL only | `afanasenko/zillow-url-search` | community | When the user pastes a zillow.com search link |
+| 2 — discover a website | `apify/google-search-scraper` | apify | Finding the agent's or brokerage's site when the listing has no email |
+| 3 — extract from the website | `vdrmota/contact-info-scraper` | community | Deterministic email / phone / social extraction |
+
+Prefer `apify`-maintained Actors where available.
+
+## Calling Actors — Apify CLI
+
+    apify actors call "afanasenko/zillow-property-agent-data-scraper" \
+      -i '{"mode":"zip","zipCodes":["78704"],"maxPropertiesPerZip":25,"status_type":"ForSale"}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-zillow-real-estate-leads \
+      2>/dev/null
+
+Fetch the input schema before building a call, so filter names come from the actor rather than from memory:
+
+    apify actors info "afanasenko/zillow-property-agent-data-scraper" --input --json \
+      --user-agent apify-awesome-skills/apify-zillow-real-estate-leads \
+      2>/dev/null
+
+Read the rows:
+
+    apify datasets get-items DATASET_ID --format json \
+      --user-agent apify-awesome-skills/apify-zillow-real-estate-leads \
+      2>/dev/null
+
+| Flag | Why |
+|------|-----|
+| `--json` | Stable machine-readable output |
+| `--user-agent` | Apify telemetry attribution |
+| `2>/dev/null` | Suppress progress messages that break JSON |
+
+You can also call these Actors through the [Apify MCP connector](https://mcp.apify.com) or any MCP client — cross-tool compatibility is your responsibility.
+
+## Troubleshooting
+
+- **Zero rows.** Read the run's `USER_MESSAGE` key-value record first — it names the cause for that specific run. In order of frequency: the search matched nothing (a PO-box or business-district ZIP has no residential listings by design, or `status_type` is wrong — asking for `ForSale` in a rentals area); the URL shape was not recognised in `url` mode; or the zpids were delisted. A ZIP that always returns data, for isolating the problem: `90210`, no filters.
+- **Emails come back like `j***@e***.com`.** That is the free plan masking them. Do not report masked strings as contacts — say the plan is the constraint.
+- **Rows are outside the ZIP the user asked for.** Expected; see *Two things that surprise people*. Filter on `zipcode`.
+- **Filters seem ignored.** Check the mode. Filters are ZIP-mode only.
+- **Fewer rows than the cap.** The cap covers a batch of up to five ZIPs, not each one. Run one ZIP per call.
+- **Cost control.** Every property enriched is billed, whether or not it carries an email, so cap the run before it starts rather than filtering afterwards. Confirm with the user before running an uncapped sweep across many ZIPs.


### PR DESCRIPTION
## Skill

- **Name:** `apify-zillow-real-estate-leads`
- **What it does:** Builds real-estate agent and listing lead lists from Zillow, starting from the contact details the listing scrape already returned and paying for web enrichment only on the rows Zillow leaves empty.
- **Author:** [@afanasenkoa](https://github.com/afanasenkoa)

## Checklist

- [x] PR adds **one** skill in `skills/apify-<name>/` (no other file changes except `.claude-plugin/marketplace.json`)
- [x] `SKILL.md` frontmatter has `name` (matches folder, `apify-` prefix) and `description` (838 chars)
- [x] Added entry to `.claude-plugin/marketplace.json`
- [x] Tested the skill end-to-end at least once

## Notes

**Why this niche.** Neither this repo nor `apify/agent-skills` mentions Zillow anywhere today — the real-estate routing table in `apify-ultimate-scraper` covers Redfin and an aggregator only. This fills that gap rather than competing with an existing skill.

**The insight it leads with is measured, not estimated.** 75 for-sale listings across three markets on 2026-07-29:

| Market | Listings | `cellPhone` | `agentEmail` |
|---|---|---|---|
| Austin, TX | 25 | 25 (100%) | 23 (92%) |
| Chicago, IL | 25 | 25 (100%) | 21 (84%) |
| Miami Beach, FL | 25 | 25 (100%) | 17 (68%) |
| **Total** | **75** | **75 (100%)** | **61 (81%)** |

Because the agent's contact is already in the listing row, the skill treats Google Search + a contact scraper as tiers 2 and 3 for the ~19% remainder, rather than routing every lead through a Maps email extractor. It also documents three things that are easy to get wrong: input filters apply in ZIP mode only, a ZIP is searched as its city so results span the metro, and the property cap covers a batch of up to five ZIPs rather than each one.

**Heads-up on CI, unrelated to this PR.** `scripts/generate_agents.py` currently fails on a clean `main`:

```
Validation failed:
  - Skill 'apify-x402-agentic-wallet' at 'skills/apify-x402-agentic-wallet' is missing from .claude-plugin/marketplace.json
```

`skills/apify-x402-agentic-wallet/` landed in #59 without its `marketplace.json` entry. I verified this by stashing my changes and re-running the validator on pristine `main`, so it is not introduced here — but it will likely make this PR's check red too. I left it alone to keep this PR to one skill; happy to open a separate one-line PR adding the missing entry if that would help.

`bash scripts/lint_telemetry.sh` passes.
