### PR TITLE
Add apify-lead-scoring-enrichment skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -278,6 +278,29 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-lead-scoring-enrichment",
+      "source": "./skills/apify-lead-scoring-enrichment",
+      "skills": "./",
+      "description": "Score and enrich a CSV of B2B leads. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech), Website Content Crawler (content), and Contact Info Scraper (company metadata) for scoring; enriches with department contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper -> AI Web Scraper -> Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column. Use when user asks to score leads, enrich lead lists, detect tech stack for outreach, find marketing/sales/engineering contacts, hunt blog copywriters for guest posts, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
+      "keywords": [
+        "lead-scoring",
+        "lead-enrichment",
+        "outreach",
+        "cold-email",
+        "personalization",
+        "tech-stack",
+        "builtwith",
+        "email-finder",
+        "copywriter-discovery",
+        "guest-post",
+        "prospecting",
+        "b2b",
+        "csv-workflow"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-lead-scoring-enrichment/.gitignore
+++ b/skills/apify-lead-scoring-enrichment/.gitignore
@@ -1,0 +1,21 @@
+# Local secrets and env
+.env
+.ENV
+.env.*
+
+# Node
+scripts/node_modules/
+scripts/package-lock.json
+
+# Runtime artifacts produced by the workflow
+scoring.json
+scored.json
+enrichment.json
+enrichment_*.json
+qualified_leads.csv
+leads.enriched.csv
+
+# User-supplied data (should stay local, never committed)
+leads.csv
+leads.*.csv
+!examples/leads.example.csv

--- a/skills/apify-lead-scoring-enrichment/SKILL.md
+++ b/skills/apify-lead-scoring-enrichment/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: apify-lead-scoring-enrichment
+description: Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper → AI Web Scraper → Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. "uses Shopify → send Shopify install guide"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.
+author: Fabian Maume
+author_url: https://github.com/fmaume
+---
+
+# Lead Scoring & Enrichment
+
+Turn a CSV of company URLs into a scored, contact-enriched pitch list. The
+agent asks the user for scoring rules in plain English ("+10 if using Shopify",
+"-5 if company size <10"), picks an enrichment path (departments or
+copywriters), and orchestrates six Apify Actors through four helper scripts.
+
+## Prerequisites
+
+- Apify account with an active `APIFY_TOKEN` ([Console → Settings → Integrations](https://console.apify.com/settings/integrations))
+- Node.js 20.6+ (needed for native `--env-file` support)
+- A `.env` file at the skill root containing `APIFY_TOKEN=apify_api_...`
+- One-time inside `scripts/`: `npm install` (installs `csv-parse`, `csv-stringify`)
+
+Optional but recommended: the Apify CLI (`npm i -g apify-cli`) for ad-hoc Actor
+calls. The helper scripts hit the REST API directly and do not need the CLI.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+Task Progress:
+- [ ] Step 1: Collect CSV path and validate required column (company_url)
+- [ ] Step 2: Collect scoring rules per source (tech / content / metadata)
+- [ ] Step 3: Collect enrichment path (departments OR copywriters)
+- [ ] Step 4: Run scoring Actors (writes scoring.json)
+- [ ] Step 5: Apply scoring rules per lead → assign per-source scores + outreach_hook (writes scored.json)
+- [ ] Step 5b: Compute theoretical min/max score, ask user for qualification threshold, filter leads → qualified_leads.csv
+- [ ] Step 6: Run enrichment path against qualified_leads.csv (writes enrichment.json)
+- [ ] Step 7: Merge scoring + enrichment onto the ORIGINAL CSV → leads.enriched.csv (qualified column marks who made the cut)
+```
+
+### Step 1: CSV intake
+
+Ask the user for the CSV path. Required column: `company_url`. Recognized
+optional columns pass through untouched: `company_name`, `first_name`,
+`last_name`, `role`, `department`. Reject the run if `company_url` is
+missing. Trim to a bare domain (strip trailing slash, `www.` optional) when
+feeding downstream Actors that expect a domain.
+
+### Step 2: Scoring rules (per source)
+
+Ask **one question per source** so it's obvious to the user (and to you at
+Step 5) which data each rule tests. Ask only for the sources the user
+wants to fetch — each source has a matching `--enable-*` flag in Step 4.
+
+**2a. Tech-stack rules** — applied against
+`scoring.json[url].tech` (BuiltWith output). Only ask if the user wants
+`--enable-tech`. Example rules to show:
+
+- *+10 if the company uses Shopify or WooCommerce (we sell a Shopify integration).*
+- *+5 if the tech stack includes HubSpot, Marketo, or Segment (marketing-ops ICP).*
+- *-3 if no analytics or CDP is detected (likely too early-stage).*
+
+**2b. Website-content rules** — applied against
+`scoring.json[url].content` (Website Content Crawler markdown/text). Only
+ask if the user wants `--enable-content`. Also ask for `maxCrawlDepth`
+here (default `0` = homepage only; higher = more $). Example rules:
+
+- *+8 if the homepage describes a SaaS or platform business.*
+- *-5 if the homepage describes a services agency (not our ICP).*
+- *+3 if the homepage mentions "developers" or "API" (technical buyer).*
+
+**2c. Company-metadata rules** — applied against
+`scoring.json[url].metadata` (Contact Info Scraper metadata). Only ask if
+the user wants `--enable-metadata`. Example rules:
+
+- *+3 if industry is e-commerce, retail, or B2C.*
+- *-3 if company size is under 10 employees (too small to buy).*
+- *+5 if the company has a LinkedIn presence (bigger operation).*
+
+Store each rule block verbatim, tagged with its source. If the user
+folds a metadata rule into the tech block (e.g. "+3 if size >50" under
+tech), re-file it to the correct block before Step 5 and tell them why.
+
+Any source the user has no rules for should also be dropped from the
+Step 4 `--enable-*` flags — no point paying for a signal you won't
+score on. Full example rule sets: [examples/scoring-rules.example.md](examples/scoring-rules.example.md).
+
+### Step 3: Enrichment path (pick one)
+
+Ask: *"Which enrichment path?*
+- *(A) Department contacts — find named people (with title + email) in a specific team at each company. Uses Contact Info Scraper's "Business leads enrichment" add-on, falls back to Bulk Email Finder for any lead without a discovered email.*
+- *(B) Copywriter hunt — for each domain, Google-search `site:{domain} blog`, extract author names from top posts, find their emails. Good for guest-post outreach."*
+
+For **Path A**, collect two more inputs:
+
+1. **Department(s)** — one or more from this enum (comma-separated):
+   `c_suite`, `product`, `engineering_technical`, `design`, `education`,
+   `finance`, `human_resources`, `information_technology`, `legal`,
+   `marketing`, `medical_health`, `operations`, `sales`, `consulting`.
+   Example: `marketing,sales`.
+2. **Max leads per domain** — integer. Recommend 3–5 for typical SDR work.
+   ⚠️ This is a **cost multiplier**: 5 leads × 500 domains = up to 2500
+   billed leads. Apify only charges for leads successfully found. Warn
+   the user before running if `max_leads × domain_count > 500`.
+
+For **Path B** no additional input is needed.
+
+### Step 4: Run scoring Actors
+
+```bash
+node --env-file=.env scripts/run_scoring.js \
+  --input leads.csv \
+  --output scoring.json \
+  --enable-tech --enable-content --enable-metadata \
+  --content-crawl-depth 0
+```
+
+`run_scoring.js` batches all URLs into a single call per enabled Actor (not
+one call per lead), then reshapes the datasets into a per-URL sidecar so the
+agent can look up every signal by `company_url`. Actors that weren't
+`--enable-*`'d are skipped. Read the resulting `scoring.json` — its shape
+is `{ "https://acme.com": { "tech": {...}, "content": {...}, "metadata": {...} }, ... }`.
+
+### Step 5: Apply scoring rules (per source, then sum)
+
+For each lead in `scoring.json`, run **one pass per source** using only
+that source's rules from Step 2. This keeps the score auditable — if
+`content_score = -5` on a lead the user expected to convert, you can
+inspect exactly which content rule fired without re-deriving the whole
+computation.
+
+Produce five fields per lead:
+
+- `tech_score` (number, or `null` if `--enable-tech` was off) — sum of
+  Step 2a rule deltas against `scoring.json[url].tech`.
+- `content_score` (number, or `null` if `--enable-content` was off) —
+  sum of Step 2b rule deltas against `scoring.json[url].content`.
+- `metadata_score` (number, or `null` if `--enable-metadata` was off) —
+  sum of Step 2c rule deltas against `scoring.json[url].metadata`.
+- `score` (number) — sum of the three above, treating `null` as `0`.
+- `outreach_hook` (string, one sentence) — the single most-personalizable
+  signal across **all** sources: a specific CMS ("uses Shopify"), a
+  named analytics tool, an industry match, a hiring signal in the copy
+  — whatever a human sales rep would open the email with.
+
+The `null` vs `0` distinction matters: a source that wasn't fetched must
+not be conflated with a source that was fetched and simply scored zero.
+Downstream CSV columns render `null` as blank, `0` as `"0"`.
+
+Store scored rows as an intermediate `scored.json` (agent writes it
+directly, keyed by canonical `https://domain`), then pass it to
+`filter_qualified.js` at Step 5b and to `merge_output.js` at Step 7.
+
+### Step 5b: Qualification threshold gate
+
+Enrichment is the expensive part — running it on unqualified leads
+burns credits with no ROI. Gate it with a user-set threshold before you
+call any enrichment Actor.
+
+1. **Compute the theoretical score range** from the Step 2 rules the
+   user gave. For each source's rule set, sum every positive delta into
+   `max_source` and every negative delta into `min_source`. Then
+   `min_total = min_tech + min_content + min_metadata` and same for
+   `max_total`. This is a hard bound: no lead can score outside it.
+2. **Also compute the observed range** from `scored.json` — the actual
+   minimum and maximum `score` values across all leads. Often the
+   observed range is much narrower than the theoretical one.
+3. **Present both to the user, plus a rough tiering suggestion:**
+
+   > *"Theoretical range: **{min_total} to {max_total}**. Observed range
+   > in your list: **{observed_min} to {observed_max}** across
+   > **{n_leads}** leads. Distribution: {count above 75th percentile} /
+   > {count above 50th percentile} / {count above 25th percentile} at
+   > those thresholds. What threshold do you want? Leads scoring at or
+   > above the threshold move to enrichment; everything below is
+   > flagged in the final CSV as `qualified=false` and skipped."*
+
+   Recommend the 75th-percentile score as a starting point if the user
+   is unsure — enrichment cost drops ~75% while keeping the top of the
+   funnel. Warn if their chosen threshold would qualify 0 leads or
+   qualify all of them (no filtering).
+
+4. **Mark `qualified: true|false`** on every row in `scored.json` based
+   on the chosen threshold (write it back), then run:
+
+   ```bash
+   node scripts/filter_qualified.js \
+     --leads leads.csv \
+     --scores scored.json \
+     --output qualified_leads.csv
+   ```
+
+   `filter_qualified.js` is a pure-Node CSV filter — it reads
+   `scored.json`, keeps only rows where `qualified === true`, and
+   writes them to `qualified_leads.csv` preserving all original columns.
+   The full lead list (including unqualified rows) still lives in the
+   original `leads.csv` — Step 7's merge uses that as the join base.
+
+### Step 6: Run enrichment path (qualified leads only)
+
+Feed **`qualified_leads.csv`** from Step 5b into the enrichment scripts,
+not the original `leads.csv`. This is where the threshold gate pays for
+itself.
+
+**Path A — Department contacts:**
+
+```bash
+node --env-file=.env scripts/enrich_departments.js \
+  --input qualified_leads.csv \
+  --department marketing,sales \
+  --max-leads 5 \
+  --output enrichment.json
+```
+
+Add `--verify-emails` to also validate every returned email (small extra
+charge per verified/invalid/disposable result; catch-all and unknown are
+free per the Actor docs).
+
+**Path B — Copywriter hunt:**
+
+```bash
+node --env-file=.env scripts/enrich_copywriters.js \
+  --input qualified_leads.csv \
+  --output enrichment.json
+```
+
+Path A calls `vdrmota/contact-info-scraper` with the **Business leads
+enrichment** add-on enabled (`maximumLeadsEnrichmentRecords` +
+`leadsEnrichmentDepartments`) so the Actor returns actual people
+per domain — name, title, work email, LinkedIn. For any lead that comes
+back without a resolved email, the script calls
+`scalelist/bulk-email-finder-dep` on the `(firstName, lastName, domain)`
+triple as a fallback. Path B chains
+`apify/google-search-scraper` → `apify/ai-web-scraper` (with the
+[`get-author-name-from-blog-post`](https://apify.com/apify/ai-web-scraper/examples/get-author-name-from-blog-post)
+example input) → `scalelist/bulk-email-finder-dep`.
+
+### Step 7: Merge
+
+```bash
+node scripts/merge_output.js \
+  --leads leads.csv \
+  --scoring scoring.json \
+  --enrichment enrichment.json \
+  --scores scored.json \
+  --output leads.enriched.csv
+```
+
+Note that `--leads` is the **original** `leads.csv`, not
+`qualified_leads.csv`. That way every input lead appears in the final
+CSV — unqualified ones simply have blank enrichment columns and
+`qualified=false`. This preserves the audit trail: you can see which
+leads got scored below threshold and why.
+
+`merge_output.js` is pure Node (no Actor calls). It left-joins on
+`company_url` and emits `leads.enriched.csv` with the original columns plus:
+`tech_summary`, `content_summary`, `company_size`, `industry`,
+`tech_score`, `content_score`, `metadata_score`, `score` (sum),
+`qualified` (`true` / `false` — matches Step 5b threshold), `outreach_hook`,
+`leads` (full JSON of the per-domain people found via Path A),
+`lead_names` and `lead_titles` (semicolon-separated summaries for CSV
+readability), `emails` (semicolon-separated), and `authors` (Path B).
+
+## Actor routing
+
+| User intent | Actor | Tier | Notes |
+|---|---|---|---|
+| Detect tech stack | [`builtwith/builtwith-official-technology-scraper`](https://apify.com/builtwith/builtwith-official-technology-scraper) | community | Input: `{ "startDomains": ["acme.com", ...] }` (bare domains, no protocol). CMS, analytics, hosting drive outreach hooks. |
+| Website content classification | [`apify/website-content-crawler`](https://apify.com/apify/website-content-crawler) | apify | Set `maxCrawlDepth: 0` for homepage only; higher = more $. |
+| Company metadata (scoring path) | [`vdrmota/contact-info-scraper`](https://apify.com/vdrmota/contact-info-scraper) | community | Add-on **OFF**. Returns emails/phones/socials + company metadata from About/Contact pages. |
+| Dept-specific leads (Path A enrichment) | [`vdrmota/contact-info-scraper`](https://apify.com/vdrmota/contact-info-scraper) | community | Add-on **ON** via `maximumLeadsEnrichmentRecords` + `leadsEnrichmentDepartments` (enum). Returns actual people: name, title, work email, LinkedIn. |
+| Blog discovery | [`apify/google-search-scraper`](https://apify.com/apify/google-search-scraper) | apify | Query `site:{domain} blog`, `resultsPerPage: 5`. |
+| Blog author extraction | [`apify/ai-web-scraper`](https://apify.com/apify/ai-web-scraper) | apify | Use example `get-author-name-from-blog-post`. |
+| Email finder fallback | [`scalelist/bulk-email-finder-dep`](https://apify.com/scalelist/bulk-email-finder-dep) | community | Input: `{ "leads": [{ "first_name", "last_name", "company_domain" }] }`. Called only for leads with a name but no email. |
+
+Full input schemas and quirks: [references/actor-index.md](references/actor-index.md).
+
+## Calling Actors — the CLI recipe
+
+Every `apify` CLI call must carry three flags (CI-enforced):
+
+```bash
+apify actors call ACTOR_ID \
+  -i 'JSON_INPUT' \
+  --user-agent apify-awesome-skills/apify-lead-scoring-enrichment \
+  --json 2>/dev/null
+```
+
+```bash
+apify actors info ACTOR_ID --input \
+  --user-agent apify-awesome-skills/apify-lead-scoring-enrichment \
+  --json 2>/dev/null
+```
+
+```bash
+apify datasets get-items DATASET_ID \
+  --user-agent apify-awesome-skills/apify-lead-scoring-enrichment \
+  --format json 2>/dev/null
+```
+
+The helper scripts use the REST API directly and set the same
+`apify-awesome-skills/apify-lead-scoring-enrichment` user-agent header on
+every request, so attribution is consistent whether you drive by CLI or by
+script.
+
+## Alternative interfaces
+
+- **Apify MCP connector** — <https://mcp.apify.com> ([docs](https://docs.apify.com/platform/integrations/mcp)). Skip the helper scripts; the agent calls Actors as MCP tools.
+- **mcpc** — standalone MCP client, <https://github.com/apify/mcpc>.
+
+If you skip the helper scripts, you still need to apply the Step 5 scoring
+logic yourself and produce the final CSV.
+
+## Troubleshooting
+
+- **`APIFY_TOKEN not set`** — the scripts read it from `.env` via `node --env-file=.env`. Ensure `.env` is at the directory you `cd`'d into, not in the skill dir. Absolute paths help: `node --env-file=/abs/path/.env scripts/...`.
+- **`fetch failed` on Node <20.6** — `--env-file` requires 20.6+. Check `node --version`. Upgrade or export `APIFY_TOKEN` manually in the shell.
+- **BuiltWith returned empty for a URL** — the domain is unreachable, WAF-blocked, or new (no historical detections). Feed the bare domain (`acme.com`) not the full URL, and retry the failed rows only.
+- **Contact Info Scraper returned 0 leads for a domain** — the domain is filtered out by the Actor's built-in exclusion list (large chains, social platforms, retail giants, food-delivery services), or the site has no discoverable employees in the requested department. Try broader departments (e.g. add `c_suite` alongside `marketing`) or fall back to the copywriter path for that segment.
+- **Lead has a name but no email** — the Business-Leads add-on couldn't resolve one. Path A auto-falls-back to `scalelist/bulk-email-finder-dep` on `(firstName, lastName, domain)`. If the fallback also returns nothing, the person's email is genuinely not in Scalelist's index — try LinkedIn Sales Navigator manually or drop the row.
+- **Copywriter path returns 0 authors for a domain** — the domain has no blog, or blog posts don't expose an author byline. Skip the row; guest-post outreach isn't the right play for that domain.
+- **Ran out of Apify credits mid-run** — no partial recovery in `run_scoring.js` v1. Re-run against a smaller CSV slice. See [references/gotchas.md](references/gotchas.md) for cost estimates per Actor.

--- a/skills/apify-lead-scoring-enrichment/SKILL.md
+++ b/skills/apify-lead-scoring-enrichment/SKILL.md
@@ -229,11 +229,11 @@ enrichment** add-on enabled (`maximumLeadsEnrichmentRecords` +
 `leadsEnrichmentDepartments`) so the Actor returns actual people
 per domain — name, title, work email, LinkedIn. For any lead that comes
 back without a resolved email, the script calls
-`scalelist/bulk-email-finder-dep` on the `(firstName, lastName, domain)`
+`scalelist/email-finder` on the `(firstName, lastName, domain)`
 triple as a fallback. Path B chains
 `apify/google-search-scraper` → `apify/ai-web-scraper` (with the
 [`get-author-name-from-blog-post`](https://apify.com/apify/ai-web-scraper/examples/get-author-name-from-blog-post)
-example input) → `scalelist/bulk-email-finder-dep`.
+example input) → `scalelist/email-finder`.
 
 ### Step 7: Merge
 
@@ -271,7 +271,7 @@ readability), `emails` (semicolon-separated), and `authors` (Path B).
 | Dept-specific leads (Path A enrichment) | [`vdrmota/contact-info-scraper`](https://apify.com/vdrmota/contact-info-scraper) | community | Add-on **ON** via `maximumLeadsEnrichmentRecords` + `leadsEnrichmentDepartments` (enum). Returns actual people: name, title, work email, LinkedIn. |
 | Blog discovery | [`apify/google-search-scraper`](https://apify.com/apify/google-search-scraper) | apify | Query `site:{domain} blog`, `resultsPerPage: 5`. |
 | Blog author extraction | [`apify/ai-web-scraper`](https://apify.com/apify/ai-web-scraper) | apify | Use example `get-author-name-from-blog-post`. |
-| Email finder fallback | [`scalelist/bulk-email-finder-dep`](https://apify.com/scalelist/bulk-email-finder-dep) | community | Input: `{ "leads": [{ "first_name", "last_name", "company_domain" }] }`. Called only for leads with a name but no email. |
+| Email finder fallback | [`scalelist/email-finder`](https://apify.com/scalelist/email-finder) | community | Input: `{ "leads": [{ "first_name", "last_name", "company_domain" }] }`. Called only for leads with a name but no email. |
 
 Full input schemas and quirks: [references/actor-index.md](references/actor-index.md).
 
@@ -317,6 +317,6 @@ logic yourself and produce the final CSV.
 - **`fetch failed` on Node <20.6** — `--env-file` requires 20.6+. Check `node --version`. Upgrade or export `APIFY_TOKEN` manually in the shell.
 - **BuiltWith returned empty for a URL** — the domain is unreachable, WAF-blocked, or new (no historical detections). Feed the bare domain (`acme.com`) not the full URL, and retry the failed rows only.
 - **Contact Info Scraper returned 0 leads for a domain** — the domain is filtered out by the Actor's built-in exclusion list (large chains, social platforms, retail giants, food-delivery services), or the site has no discoverable employees in the requested department. Try broader departments (e.g. add `c_suite` alongside `marketing`) or fall back to the copywriter path for that segment.
-- **Lead has a name but no email** — the Business-Leads add-on couldn't resolve one. Path A auto-falls-back to `scalelist/bulk-email-finder-dep` on `(firstName, lastName, domain)`. If the fallback also returns nothing, the person's email is genuinely not in Scalelist's index — try LinkedIn Sales Navigator manually or drop the row.
+- **Lead has a name but no email** — the Business-Leads add-on couldn't resolve one. Path A auto-falls-back to `scalelist/email-finder` on `(firstName, lastName, domain)`. If the fallback also returns nothing, the person's email is genuinely not in Scalelist's index — try LinkedIn Sales Navigator manually or drop the row.
 - **Copywriter path returns 0 authors for a domain** — the domain has no blog, or blog posts don't expose an author byline. Skip the row; guest-post outreach isn't the right play for that domain.
 - **Ran out of Apify credits mid-run** — no partial recovery in `run_scoring.js` v1. Re-run against a smaller CSV slice. See [references/gotchas.md](references/gotchas.md) for cost estimates per Actor.

--- a/skills/apify-lead-scoring-enrichment/examples/leads.example.csv
+++ b/skills/apify-lead-scoring-enrichment/examples/leads.example.csv
@@ -1,0 +1,4 @@
+company_url,company_name
+https://apify.com,Apify
+https://vercel.com,Vercel
+https://shopify.com,Shopify

--- a/skills/apify-lead-scoring-enrichment/examples/scoring-rules.example.md
+++ b/skills/apify-lead-scoring-enrichment/examples/scoring-rules.example.md
@@ -1,0 +1,39 @@
+# Example scoring rules — split per source
+
+Paste one block per source when the agent asks in Step 2. Only supply
+blocks for sources you actually want to fetch — each block corresponds to
+a `--enable-*` flag in Step 4. Keep each rule pointed at its own source
+so the resulting `tech_score` / `content_score` / `metadata_score`
+columns stay auditable.
+
+## Tech-stack rules — evaluated against `scoring.json[url].tech`
+
+```
++10 if the company uses Shopify or WooCommerce (we sell a Shopify integration).
++5  if the tech stack includes HubSpot, Marketo, or Segment (marketing-ops ICP).
++3  if the site uses a modern framework (Next.js, Nuxt, SvelteKit) → likely product-led.
+-3  if no analytics or CDP is detected (likely too early-stage).
+```
+
+## Website-content rules — evaluated against `scoring.json[url].content`
+
+```
++8 if the homepage describes a SaaS or platform business.
++3 if the homepage mentions "developers", "API", or "SDK" (technical buyer).
+-5 if the homepage describes a services agency or consultancy (not our ICP).
+-3 if the homepage is only in a language we don't sell in.
+```
+
+## Company-metadata rules — evaluated against `scoring.json[url].metadata`
+
+```
++3 if industry is e-commerce, retail, or B2C.
++5 if the company has a LinkedIn presence (bigger operation).
+-3 if company size is under 10 employees (too small to buy).
+-5 if the domain is a personal blog or portfolio site.
+```
+
+Once the agent produces `tech_score`, `content_score`, `metadata_score`,
+`score` (sum), and `outreach_hook` per lead, `merge_output.js` joins them
+onto the enriched CSV. Sort descending by `score` and pitch the top of
+the list first; scan the three sub-scores when a row surprises you.

--- a/skills/apify-lead-scoring-enrichment/references/actor-index.md
+++ b/skills/apify-lead-scoring-enrichment/references/actor-index.md
@@ -121,7 +121,7 @@ field-name variants defensively.
 
 ## Enrichment Actors
 
-### `scalelist/bulk-email-finder-dep` (community)
+### `scalelist/email-finder` (community)
 
 **Intent:** Given a first name, last name, and company domain, return a
 verified business email. This skill uses it **only as a fallback** — when

--- a/skills/apify-lead-scoring-enrichment/references/actor-index.md
+++ b/skills/apify-lead-scoring-enrichment/references/actor-index.md
@@ -1,0 +1,211 @@
+# Actor index — apify-lead-scoring-enrichment
+
+Full routing table with the input shape each script sends. All six Actors
+are drivable by CLI, MCP, or the raw REST API — pick your interface. Refer
+to each Actor's live schema (`apify actors info <id> --input --json 2>/dev/null`)
+if you change any input beyond what's captured here.
+
+## Scoring Actors
+
+### `builtwith/builtwith-official-technology-scraper` (community)
+
+**Intent:** "What technologies does this company use?"
+**Cost:** pay-per-result (usually cents per domain).
+**Input shape used by `run_scoring.js`:**
+
+```json
+{ "startDomains": ["acme.com", "foo.com"] }
+```
+
+Bare domains, no protocol. Passing `urls` (or full URLs) makes the Actor
+succeed with zero-item output — the sidecar then attaches no `tech` block
+to any lead.
+
+**Output shape:** dataset item per domain with a `technologies` array (name +
+category). Field names vary; `merge_output.js` collapses the top 8 into a
+comma-separated `tech_summary` column.
+
+**Common outreach hooks derived from tech:**
+- CMS detected (Shopify, WordPress, Webflow) → link a platform-specific integration guide
+- Analytics stack (GA4, Segment, Amplitude) → pitch a data-add-on
+- CDP or MAP (HubSpot, Marketo) → pitch marketing ops
+- No detected framework → likely a static/agency site; low value for tech-heavy products
+
+### `apify/website-content-crawler` (apify)
+
+**Intent:** "What does this company actually say they do?"
+**Cost:** pay-per-page; homepage-only (`maxCrawlDepth: 0`) is cheapest.
+**Input shape:**
+
+```json
+{
+  "startUrls": [{"url": "https://acme.com"}],
+  "maxCrawlDepth": 0,
+  "maxCrawlPages": 1,
+  "crawlerType": "playwright:firefox",
+  "saveMarkdown": true
+}
+```
+
+**Output shape:** `{ url, markdown, text, metadata }` per crawled page.
+
+**Use for content-based scoring rules:** the agent reads
+`content_summary` (first 240 chars of markdown) and applies user rules like
+*"+5 if the site describes a SaaS business"*. Increase `maxCrawlDepth` when
+homepage content is thin (e.g. marketing sites with everything on `/product`).
+
+### `vdrmota/contact-info-scraper` (community)
+
+**Intent:** Two very different jobs depending on whether the "Business leads
+enrichment" add-on is enabled.
+
+- **Scoring path (add-on OFF):** page-level emails/phones/socials + company
+  metadata scraped from About and Contact pages. Fed to `merge_output.js`
+  as the `metadata` sidecar.
+- **Enrichment Path A (add-on ON):** returns actual **people** (name, title,
+  work email, department, LinkedIn) working at each domain. Requires
+  `maximumLeadsEnrichmentRecords > 0` and `leadsEnrichmentDepartments`.
+
+**Cost:** pay-per-result. With the add-on, cost multiplies:
+`max_leads × domains`, and Apify only charges for leads actually found.
+
+**Input shape — scoring (add-on OFF), used by `run_scoring.js`:**
+
+```json
+{ "startUrls": [{"url": "https://acme.com"}], "maxDepth": 2, "maxRequests": 10 }
+```
+
+**Input shape — Path A enrichment (add-on ON), used by `enrich_departments.js`:**
+
+```json
+{
+  "startUrls": [{"url": "https://acme.com"}],
+  "maxRequestsPerStartUrl": 1,
+  "mergeContacts": true,
+  "maxDepth": 0,
+  "maximumLeadsEnrichmentRecords": 5,
+  "leadsEnrichmentDepartments": ["marketing", "sales"],
+  "verifyLeadsEnrichmentEmails": false
+}
+```
+
+**`leadsEnrichmentDepartments` enum** — pick one or more:
+
+| Value | Label |
+|---|---|
+| `c_suite` | C-Suite |
+| `product` | Product |
+| `engineering_technical` | Engineering & Technical |
+| `design` | Design |
+| `education` | Education |
+| `finance` | Finance |
+| `human_resources` | Human Resources |
+| `information_technology` | Information Technology |
+| `legal` | Legal |
+| `marketing` | Marketing |
+| `medical_health` | Medical & Health |
+| `operations` | Operations |
+| `sales` | Sales |
+| `consulting` | Consulting |
+
+**Setup recommendations (from the Actor's own docs):**
+- For leads only → `maxRequestsPerStartUrl: 1`
+- For leads + maximum contact discovery → `maxRequestsPerStartUrl: 3`
+
+**Output (add-on ON):** one item per start URL with a `leadsEnrichment`
+(also seen as `leads` / `businessLeads` across Actor versions) array of
+people, each with `firstName`, `lastName`, `email` (optional),
+`emailVerification` (when `verifyLeadsEnrichmentEmails: true`), `title`,
+`department`, and `linkedin`. `enrich_departments.js` handles all three
+field-name variants defensively.
+
+## Enrichment Actors
+
+### `scalelist/bulk-email-finder-dep` (community)
+
+**Intent:** Given a first name, last name, and company domain, return a
+verified business email. This skill uses it **only as a fallback** — when
+`vdrmota/contact-info-scraper` (Path A) or the copywriter chain (Path B)
+returns a lead whose name is known but whose email wasn't discovered.
+**Cost:** pay-per-found-email.
+**Input shape (single required key `leads`):**
+
+```json
+{
+  "leads": [
+    {
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "company_domain": "acme.com",
+      "company_name": "Acme Corp"
+    }
+  ]
+}
+```
+
+Field names are **snake_case** and the required per-lead fields are
+`first_name` + `last_name`. `company_domain` is preferred over
+`company_name` for better match rate (per the Actor's own schema
+description). Do not send the pluralized flat-array shapes seen in
+older skills — this Actor rejects them.
+
+**Output:** dataset item per input lead with `email` (or `null` when
+unresolved), plus echoes of the input identifiers. Field names in the
+output can be either snake_case or camelCase depending on Actor
+version; `enrich_departments.js` and `enrich_copywriters.js` read both.
+
+**When to run the fallback:** only for leads with a first+last name and
+no email. Do **not** call this Actor to enumerate contacts at a domain —
+that's `vdrmota/contact-info-scraper`'s job (with the
+Business-leads-enrichment add-on enabled).
+
+### `apify/google-search-scraper` (apify)
+
+**Intent:** Discover blog posts on a domain via `site:{domain} blog`.
+**Cost:** pay-per-search-page.
+**Input shape:**
+
+```json
+{
+  "queries": "site:acme.com blog\nsite:foo.com blog",
+  "resultsPerPage": 5,
+  "maxPagesPerQuery": 1,
+  "countryCode": "us",
+  "languageCode": "en"
+}
+```
+
+**Output:** one bucket per query with an `organicResults` array. `enrich_copywriters.js`
+re-attaches each bucket to its domain by regex-matching `site:...` in the
+query.
+
+### `apify/ai-web-scraper` (apify)
+
+**Intent:** LLM-driven structured extraction from arbitrary URLs. This skill
+uses the [`get-author-name-from-blog-post`](https://apify.com/apify/ai-web-scraper/examples/get-author-name-from-blog-post)
+example input shape.
+**Cost:** LLM tokens per URL + fetch cost.
+**Input shape:**
+
+```json
+{
+  "startUrls": [{"url": "https://acme.com/blog/post-1"}],
+  "prompt": "Extract the author name of this blog post. Return the full name only.",
+  "schema": {"type": "object", "properties": {"author": {"type": "string"}}, "required": ["author"]},
+  "proxyConfiguration": {"useApifyProxy": true}
+}
+```
+
+**Output:** `{ url, author }` per crawled URL, or `author: null` if no byline
+was found. `enrich_copywriters.js` drops null/single-word authors before the
+email-finder step.
+
+## How to extend
+
+If you want to swap an Actor (e.g. use a different email finder), keep the
+same three-flag CLI recipe from the SKILL and update `run_scoring.js` /
+`enrich_*.js` accordingly.
+
+1. Search candidates: `apify actors search "KEYWORDS" --user-agent apify-awesome-skills/apify-lead-scoring-enrichment --json --limit 10 2>/dev/null`
+2. Fetch schema: `apify actors info "ACTOR_ID" --input --user-agent apify-awesome-skills/apify-lead-scoring-enrichment --json 2>/dev/null`
+3. Wire it into the matching helper script.

--- a/skills/apify-lead-scoring-enrichment/references/gotchas.md
+++ b/skills/apify-lead-scoring-enrichment/references/gotchas.md
@@ -13,7 +13,7 @@ with all three scoring Actors + Path A enrichment:
 | `apify/website-content-crawler` (depth 0) | $0.20 – $1 | Homepage-only. Higher depth multiplies. |
 | `vdrmota/contact-info-scraper` (scoring, add-on OFF) | $2 – $5 | Fetches multiple pages per domain. |
 | `vdrmota/contact-info-scraper` (Path A, add-on ON) | **`max_leads × domains × ~$0.03–$0.10`** | Multiplier. 5 leads × 100 domains ≈ $15–$50, charged only for leads actually found. |
-| `scalelist/bulk-email-finder-dep` | $1 – $4 (fallback only) | Only invoked for leads with a name but no email. |
+| `scalelist/email-finder` | $1 – $4 (fallback only) | Only invoked for leads with a name but no email. |
 | `apify/google-search-scraper` | $0.30 – $1 | 5 results × 100 domains. |
 | `apify/ai-web-scraper` | $2 – $8 | LLM cost dominates; scales with blog-post count. |
 
@@ -73,14 +73,14 @@ The Actor scrapes visible page text; it doesn't crack:
 - Contact forms with no fallback mailto.
 - Emails hidden behind "click to reveal" buttons.
 
-Path A's fallback to `scalelist/bulk-email-finder-dep` covers most of
+Path A's fallback to `scalelist/email-finder` covers most of
 these. If a domain still returns 0 emails after fallback, the company is
 probably filtering all inbound — mark the lead as "phone-only" or "form
 submission required" in your outreach plan.
 
 ## Bulk Email Finder input shape
 
-`scalelist/bulk-email-finder-dep` takes a single required key `leads`
+`scalelist/email-finder` takes a single required key `leads`
 holding an array of snake_case objects:
 
 ```json
@@ -95,7 +95,7 @@ Common wrong shapes (all reject):
 If a call 400s, re-fetch the schema before guessing:
 
 ```bash
-apify actors info scalelist/bulk-email-finder-dep --input \
+apify actors info scalelist/email-finder --input \
   --user-agent apify-awesome-skills/apify-lead-scoring-enrichment \
   --json 2>/dev/null
 ```

--- a/skills/apify-lead-scoring-enrichment/references/gotchas.md
+++ b/skills/apify-lead-scoring-enrichment/references/gotchas.md
@@ -1,0 +1,129 @@
+# Gotchas — apify-lead-scoring-enrichment
+
+Cost guardrails and per-Actor traps to look for before you kick off a run.
+
+## Cost guardrails
+
+Total run cost scales with (leads × Actors enabled). For a 100-lead CSV
+with all three scoring Actors + Path A enrichment:
+
+| Actor | Rough $ per 100 URLs | Notes |
+|---|---|---|
+| `builtwith/builtwith-official-technology-scraper` | $0.50 – $2 | Pay-per-result; cheapest of the three. |
+| `apify/website-content-crawler` (depth 0) | $0.20 – $1 | Homepage-only. Higher depth multiplies. |
+| `vdrmota/contact-info-scraper` (scoring, add-on OFF) | $2 – $5 | Fetches multiple pages per domain. |
+| `vdrmota/contact-info-scraper` (Path A, add-on ON) | **`max_leads × domains × ~$0.03–$0.10`** | Multiplier. 5 leads × 100 domains ≈ $15–$50, charged only for leads actually found. |
+| `scalelist/bulk-email-finder-dep` | $1 – $4 (fallback only) | Only invoked for leads with a name but no email. |
+| `apify/google-search-scraper` | $0.30 – $1 | 5 results × 100 domains. |
+| `apify/ai-web-scraper` | $2 – $8 | LLM cost dominates; scales with blog-post count. |
+
+**Confirmation thresholds** — surface these to the user before running:
+- Estimated cost **>$5** → warn.
+- Estimated cost **>$20** → require explicit confirmation.
+- Always frame as "roughly $X" not a guaranteed number.
+
+**Rule of thumb:** for CSVs over ~500 leads, do a 10-row dry run first,
+inspect the sidecars, then commit to the full run. Apify credit is
+non-refundable once spent.
+
+## Content Crawler depth trap
+
+`maxCrawlDepth: 0` = homepage only. `maxCrawlDepth: 1` = homepage + every
+same-origin link found on it, which can be **50-100 pages** for a
+marketing site. Multiply by the lead count and it's easy to spend $50+
+without meaning to.
+
+Set `maxCrawlPages` explicitly as a safety cap (`run_scoring.js` sets it
+to `urls.length * (depth + 1)`, which is conservative but not zero risk).
+
+## BuiltWith empty-result rows
+
+Domains with no historical Wappalyzer-style detection return an empty
+technologies array — not an error. Common causes:
+- Brand-new domains not yet indexed.
+- Sites behind Cloudflare full-page challenge.
+- Non-web domains (e.g. `mail.company.com`).
+
+Feed the bare apex domain (`company.com`, not `blog.company.com`) when
+possible. Retry only the empty rows with a longer timeout before deciding
+the domain is un-fingerprintable.
+
+## Business-Leads-Enrichment cost multiplier
+
+`vdrmota/contact-info-scraper` has an opt-in add-on activated by setting
+`maximumLeadsEnrichmentRecords > 0`. This is what Path A enrichment uses to
+return actual named people per domain.
+
+The gotcha: `maximumLeadsEnrichmentRecords` is **per domain**. Setting it to
+`10` on a CSV of 500 leads attempts up to **5,000** leads. Apify only bills
+for leads successfully found, but the ceiling is real and easy to blow past.
+
+Recommended defaults:
+- SDR-style top-of-funnel prospecting: `max_leads = 3–5`
+- ABM deep dive for a shortlist: `max_leads = 10–20`, but keep the CSV under 50 rows
+
+The Actor also silently filters out large chains, social media, retail
+giants, and food-delivery domains from its lead index. Enterprise B2B ICPs
+are usually fine; consumer/agency ICPs may return 0 leads for many rows.
+
+## Contact Info Scraper missing emails
+
+The Actor scrapes visible page text; it doesn't crack:
+- Cloudflare email obfuscation (the `.email-decode` class → JS-decoded on page load).
+- Contact forms with no fallback mailto.
+- Emails hidden behind "click to reveal" buttons.
+
+Path A's fallback to `scalelist/bulk-email-finder-dep` covers most of
+these. If a domain still returns 0 emails after fallback, the company is
+probably filtering all inbound — mark the lead as "phone-only" or "form
+submission required" in your outreach plan.
+
+## Bulk Email Finder input shape
+
+`scalelist/bulk-email-finder-dep` takes a single required key `leads`
+holding an array of snake_case objects:
+
+```json
+{ "leads": [{ "first_name": "Jane", "last_name": "Doe", "company_domain": "acme.com" }] }
+```
+
+Common wrong shapes (all reject):
+- `{ "people": [...] }` — wrong outer key.
+- `{ "firstNames": [], "lastNames": [], "domains": [] }` — flat pluralized arrays.
+- Per-lead objects with `firstName` / `lastName` — camelCase is rejected.
+
+If a call 400s, re-fetch the schema before guessing:
+
+```bash
+apify actors info scalelist/bulk-email-finder-dep --input \
+  --user-agent apify-awesome-skills/apify-lead-scoring-enrichment \
+  --json 2>/dev/null
+```
+
+## Google Search Scraper query-attribution bug
+
+Multiple `site:X` queries in one `queries` string return separate result
+buckets — but the bucket's `searchQuery` field can be reformatted by the
+Actor (e.g. URL-encoded, quoted). `enrich_copywriters.js` matches on the
+`site:` regex which is robust to those reformattings. If a domain is
+losing results, log `bucket.searchQuery` and confirm the regex still
+matches.
+
+## AI Web Scraper — null authors
+
+Not every blog post has a byline. Sites that use:
+- A single company account
+- "Team" or "Editors" as the author
+- No author metadata at all
+
+...will return `author: null` (or a single word). The copywriter path
+filters these out before the email-finder step, so the run doesn't waste
+credits looking up "Team" at `acme.com`.
+
+## Windows path gotcha
+
+`node --env-file=.env` resolves the path relative to the current working
+directory. On Windows Git Bash, `cd`-ing into the skill directory and
+running the command works; running it from the repo root looks for
+`./.env` at the repo root and fails silently (no error, just no token
+loaded). Prefer absolute paths in scripted runs.

--- a/skills/apify-lead-scoring-enrichment/scripts/apify_client.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/apify_client.js
@@ -1,0 +1,110 @@
+// Thin Apify REST-API wrapper shared by all lead-scoring-enrichment scripts.
+// No SDK dependency — uses global fetch (Node 18+).
+
+export const USER_AGENT = 'apify-awesome-skills/apify-lead-scoring-enrichment';
+
+function getToken() {
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN is not set. Load via `node --env-file=.env ...` or export it.');
+        process.exit(1);
+    }
+    return token;
+}
+
+function sleep(ms) {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+// Start an Actor run, poll until it terminates, return {status, runData}.
+export async function runActor(actorId, input, { timeoutSec = 900, pollIntervalSec = 5, sourceTag = 'run' } = {}) {
+    const token = getToken();
+    const slug = actorId.replace('/', '~');
+    const startUrl = `https://api.apify.com/v2/acts/${slug}/runs?token=${encodeURIComponent(token)}`;
+
+    const startResp = await fetch(startUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': `${USER_AGENT}/${sourceTag}`,
+        },
+        body: JSON.stringify(input),
+    });
+    if (!startResp.ok) {
+        const text = await startResp.text();
+        throw new Error(`Failed to start ${actorId}: ${startResp.status} ${text}`);
+    }
+    const { data: runStart } = await startResp.json();
+    const runId = runStart.id;
+    console.error(`Started ${actorId} run ${runId}`);
+
+    const runUrl = `https://api.apify.com/v2/actor-runs/${runId}?token=${encodeURIComponent(token)}`;
+    const start = Date.now();
+    let lastStatus = null;
+    while (true) {
+        const resp = await fetch(runUrl, {
+            headers: { 'User-Agent': `${USER_AGENT}/${sourceTag}_poll` },
+        });
+        if (!resp.ok) {
+            const text = await resp.text();
+            throw new Error(`Failed to poll run ${runId}: ${resp.status} ${text}`);
+        }
+        const { data } = await resp.json();
+        if (data.status !== lastStatus) {
+            console.error(`  ${actorId} → ${data.status}`);
+            lastStatus = data.status;
+        }
+        if (['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT'].includes(data.status)) {
+            return { status: data.status, runData: data };
+        }
+        if ((Date.now() - start) / 1000 > timeoutSec) {
+            console.error(`Warning: client-side wait timed out after ${timeoutSec}s. Run may still finish on Apify.`);
+            console.error(`  Check: https://console.apify.com/actors/runs/${runId}`);
+            return { status: 'TIMED-OUT', runData: data };
+        }
+        await sleep(pollIntervalSec * 1000);
+    }
+}
+
+// Fetch all items from a dataset as parsed JSON.
+export async function fetchDatasetItems(datasetId, { sourceTag = 'fetch' } = {}) {
+    const token = getToken();
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
+    const resp = await fetch(url, {
+        headers: { 'User-Agent': `${USER_AGENT}/${sourceTag}` },
+    });
+    if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(`Failed to fetch dataset ${datasetId}: ${resp.status} ${text}`);
+    }
+    return resp.json();
+}
+
+// Run an Actor and return its default-dataset items in one call.
+export async function runActorAndGetItems(actorId, input, opts = {}) {
+    const { status, runData } = await runActor(actorId, input, opts);
+    if (status !== 'SUCCEEDED') {
+        console.error(`Warning: ${actorId} ended with status=${status}. Attempting to fetch dataset anyway.`);
+    }
+    if (!runData.defaultDatasetId) {
+        console.error(`Warning: ${actorId} run ${runData.id} has no default dataset.`);
+        return [];
+    }
+    return fetchDatasetItems(runData.defaultDatasetId, { sourceTag: `${opts.sourceTag || 'run'}_items` });
+}
+
+// Normalize a URL to a bare hostname (lowercase, no scheme, no www, no path).
+export function toDomain(url) {
+    if (!url) return '';
+    let s = String(url).trim().toLowerCase();
+    s = s.replace(/^https?:\/\//, '');
+    s = s.replace(/^www\./, '');
+    s = s.split('/')[0].split('?')[0];
+    return s;
+}
+
+// Normalize a URL to a canonical https://domain form for keying sidecars.
+export function toCanonicalUrl(url) {
+    const d = toDomain(url);
+    return d ? `https://${d}` : '';
+}

--- a/skills/apify-lead-scoring-enrichment/scripts/enrich_copywriters.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/enrich_copywriters.js
@@ -3,7 +3,7 @@
 //   1. Google-search site:{domain} blog → apify/google-search-scraper
 //   2. Extract author names from top blog posts → apify/ai-web-scraper
 //      (with the get-author-name-from-blog-post example input)
-//   3. Deduplicate authors, then resolve emails → scalelist/bulk-email-finder-dep
+//   3. Deduplicate authors, then resolve emails → scalelist/email-finder
 //
 // Usage:
 //   node --env-file=.env scripts/enrich_copywriters.js \
@@ -154,11 +154,11 @@ if (!finderPairs.length) {
 }
 
 // ---- Step 3: email finder on (first_name, last_name, company_domain) triples.
-console.error(`→ Running scalelist/bulk-email-finder-dep for ${finderPairs.length} authors…`);
+console.error(`→ Running scalelist/email-finder for ${finderPairs.length} authors…`);
 let finderItems = [];
 try {
     finderItems = await runActorAndGetItems(
-        'scalelist/bulk-email-finder-dep',
+        'scalelist/email-finder',
         {
             leads: finderPairs.map(({ firstName, lastName, domain }) => ({
                 first_name: firstName,
@@ -169,7 +169,7 @@ try {
         { sourceTag: 'copywriters_email', timeoutSec: 1200 },
     );
 } catch (e) {
-    console.error(`  bulk-email-finder-dep failed: ${e.message}. Continuing with no emails.`);
+    console.error(`  email-finder failed: ${e.message}. Continuing with no emails.`);
 }
 console.error(`  email-finder: ${finderItems.length} items back.`);
 

--- a/skills/apify-lead-scoring-enrichment/scripts/enrich_copywriters.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/enrich_copywriters.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// For each lead URL:
+//   1. Google-search site:{domain} blog → apify/google-search-scraper
+//   2. Extract author names from top blog posts → apify/ai-web-scraper
+//      (with the get-author-name-from-blog-post example input)
+//   3. Deduplicate authors, then resolve emails → scalelist/bulk-email-finder-dep
+//
+// Usage:
+//   node --env-file=.env scripts/enrich_copywriters.js \
+//     --input leads.csv --output enrichment.json \
+//     [--results-per-domain 5]
+
+import { parseArgs } from 'node:util';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import { runActorAndGetItems, toCanonicalUrl, toDomain } from './apify_client.js';
+
+const { values } = parseArgs({
+    options: {
+        input: { type: 'string' },
+        output: { type: 'string' },
+        'results-per-domain': { type: 'string', default: '5' },
+    },
+});
+
+if (!values.input || !values.output) {
+    console.error('Usage: enrich_copywriters.js --input <leads.csv> --output <enrichment.json>');
+    process.exit(1);
+}
+
+const csvText = readFileSync(values.input, 'utf8');
+const rows = parse(csvText, { columns: true, skip_empty_lines: true, trim: true });
+if (!rows.length || !('company_url' in rows[0])) {
+    console.error('Error: input CSV needs a "company_url" column.');
+    process.exit(1);
+}
+
+const urls = [...new Set(rows.map((r) => toCanonicalUrl(r.company_url)).filter(Boolean))];
+const perDomain = parseInt(values['results-per-domain'], 10) || 5;
+console.error(`Copywriter hunt across ${urls.length} URLs, top ${perDomain} blog posts each.`);
+
+const sidecar = Object.fromEntries(urls.map((u) => [u, { authors: [], blogPosts: [], emails: [] }]));
+
+// ---- Step 1: Google search for blog posts on each domain.
+console.error('→ Running apify/google-search-scraper for site:{domain} blog…');
+const gssItems = await runActorAndGetItems(
+    'apify/google-search-scraper',
+    {
+        queries: urls.map((u) => `site:${toDomain(u)} blog`).join('\n'),
+        resultsPerPage: perDomain,
+        maxPagesPerQuery: 1,
+        countryCode: 'us',
+        languageCode: 'en',
+    },
+    { sourceTag: 'copywriters_search', timeoutSec: 1200 },
+);
+console.error(`  google-search: ${gssItems.length} result buckets back.`);
+
+// Map results back to their originating domain by matching the query.
+const blogUrlsByDomain = {};
+for (const bucket of gssItems) {
+    const query = bucket.searchQuery?.term || bucket.searchQuery || '';
+    const m = /site:([^\s]+)/i.exec(query);
+    if (!m) continue;
+    const domain = m[1].toLowerCase();
+    const canon = toCanonicalUrl(domain);
+    if (!canon || !(canon in sidecar)) continue;
+    const results = bucket.organicResults || bucket.results || [];
+    const links = results.map((r) => r.url).filter(Boolean).slice(0, perDomain);
+    blogUrlsByDomain[canon] = links;
+    sidecar[canon].blogPosts = links;
+}
+
+const allBlogUrls = Object.values(blogUrlsByDomain).flat();
+if (!allBlogUrls.length) {
+    console.error('No blog posts discovered — skipping author extraction and email lookup.');
+    writeFileSync(values.output, JSON.stringify(sidecar, null, 2));
+    process.exit(0);
+}
+
+// ---- Step 2: extract author names from blog posts.
+console.error(`→ Running apify/ai-web-scraper on ${allBlogUrls.length} blog URLs…`);
+const authorItems = await runActorAndGetItems(
+    'apify/ai-web-scraper',
+    {
+        // Matches https://apify.com/apify/ai-web-scraper/examples/get-author-name-from-blog-post
+        startUrls: allBlogUrls.map((u) => ({ url: u })),
+        prompt: 'Extract the author name of this blog post. Return the full name only, no title or role. If no author is listed, return null.',
+        schema: {
+            type: 'object',
+            properties: { author: { type: 'string' } },
+            required: ['author'],
+        },
+        proxyConfiguration: { useApifyProxy: true },
+    },
+    { sourceTag: 'copywriters_author', timeoutSec: 1800 },
+);
+console.error(`  ai-web-scraper: ${authorItems.length} items back.`);
+
+// apify/ai-web-scraper returns extracted values in `item.data` (array of
+// strings or {name}-shaped objects), NOT `item.author`. Flatten to a list
+// of candidate names per item, then keep only entries that look like a
+// real first+last human name (drops "Session zero", "Login", single-word
+// nav labels, etc.).
+const looksLikeHumanName = (s) => {
+    if (typeof s !== 'string') return false;
+    const trimmed = s.trim();
+    if (trimmed.length < 3 || trimmed.length > 60) return false;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) return false;
+    return parts.every((p) => /^[A-Z][A-Za-z''`\-.]{0,29}$/.test(p));
+};
+const authorsByDomain = {};
+for (const item of authorItems) {
+    const sourceUrl = item.url || item.startUrl;
+    if (!sourceUrl) continue;
+    const raw = item.data ?? item.author ?? item.result?.author ?? [];
+    const candidates = (Array.isArray(raw) ? raw : [raw])
+        .map((v) => (typeof v === 'string' ? v : v && (v.name || v.author)))
+        .filter(Boolean)
+        .map((s) => s.trim())
+        .filter(looksLikeHumanName);
+    if (!candidates.length) continue;
+    for (const [canon, links] of Object.entries(blogUrlsByDomain)) {
+        if (links.includes(sourceUrl)) {
+            const set = (authorsByDomain[canon] = authorsByDomain[canon] || new Set());
+            for (const name of candidates) {
+                set.add(name);
+                sidecar[canon].authors.push({ name, sourceUrl });
+            }
+            break;
+        }
+    }
+}
+
+const finderPairs = [];
+for (const [canon, set] of Object.entries(authorsByDomain)) {
+    for (const fullName of set) {
+        const parts = fullName.split(/\s+/);
+        if (parts.length < 2) continue;
+        finderPairs.push({
+            canon,
+            firstName: parts[0],
+            lastName: parts.slice(1).join(' '),
+            domain: toDomain(canon),
+        });
+    }
+}
+
+if (!finderPairs.length) {
+    console.error('No authors extracted with a first+last name — skipping email lookup.');
+    writeFileSync(values.output, JSON.stringify(sidecar, null, 2));
+    process.exit(0);
+}
+
+// ---- Step 3: email finder on (first_name, last_name, company_domain) triples.
+console.error(`→ Running scalelist/bulk-email-finder-dep for ${finderPairs.length} authors…`);
+let finderItems = [];
+try {
+    finderItems = await runActorAndGetItems(
+        'scalelist/bulk-email-finder-dep',
+        {
+            leads: finderPairs.map(({ firstName, lastName, domain }) => ({
+                first_name: firstName,
+                last_name: lastName,
+                company_domain: domain,
+            })),
+        },
+        { sourceTag: 'copywriters_email', timeoutSec: 1200 },
+    );
+} catch (e) {
+    console.error(`  bulk-email-finder-dep failed: ${e.message}. Continuing with no emails.`);
+}
+console.error(`  email-finder: ${finderItems.length} items back.`);
+
+for (const item of finderItems) {
+    const email = item.email || item.emailAddress;
+    if (!email) continue;
+    const domain = (item.company_domain || item.domain || '').toLowerCase();
+    const first = (item.first_name || item.firstName || '').toLowerCase();
+    const last = (item.last_name || item.lastName || '').toLowerCase();
+    const match = finderPairs.find((p) => p.domain === domain && p.firstName.toLowerCase() === first && p.lastName.toLowerCase() === last);
+    if (!match) continue;
+    sidecar[match.canon].emails.push(email);
+    const author = sidecar[match.canon].authors.find((a) => a.name.toLowerCase() === `${first} ${last}`);
+    if (author) author.email = email;
+}
+
+for (const canon of Object.keys(sidecar)) {
+    sidecar[canon].emails = [...new Set(sidecar[canon].emails)];
+}
+
+writeFileSync(values.output, JSON.stringify(sidecar, null, 2));
+console.error(`Wrote ${values.output}. ${Object.values(sidecar).filter((v) => v.emails.length).length}/${urls.length} URLs have ≥1 copywriter email.`);

--- a/skills/apify-lead-scoring-enrichment/scripts/enrich_departments.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/enrich_departments.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Calls vdrmota/contact-info-scraper with its "Business leads enrichment"
+// add-on enabled (maximumLeadsEnrichmentRecords + leadsEnrichmentDepartments)
+// to return actual people per domain. For any lead that comes back without a
+// resolved email, falls back to scalelist/bulk-email-finder-dep on the
+// (firstName, lastName, domain) triple.
+//
+// Usage:
+//   node --env-file=.env scripts/enrich_departments.js \
+//     --input leads.csv \
+//     --department marketing,sales \
+//     --max-leads 5 \
+//     [--verify-emails] \
+//     --output enrichment.json
+//
+// --department accepts one or more of the Actor's enum values (comma-separated):
+//   c_suite, product, engineering_technical, design, education, finance,
+//   human_resources, information_technology, legal, marketing, medical_health,
+//   operations, sales, consulting
+
+import { parseArgs } from 'node:util';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import { runActorAndGetItems, toCanonicalUrl, toDomain } from './apify_client.js';
+
+const VALID_DEPARTMENTS = new Set([
+    'c_suite', 'product', 'engineering_technical', 'design', 'education',
+    'finance', 'human_resources', 'information_technology', 'legal',
+    'marketing', 'medical_health', 'operations', 'sales', 'consulting',
+]);
+
+const { values } = parseArgs({
+    options: {
+        input: { type: 'string' },
+        output: { type: 'string' },
+        department: { type: 'string' },
+        'max-leads': { type: 'string', default: '5' },
+        'verify-emails': { type: 'boolean', default: false },
+    },
+});
+
+if (!values.input || !values.output || !values.department) {
+    console.error('Usage: enrich_departments.js --input <leads.csv> --department <dept[,dept...]> --max-leads N [--verify-emails] --output <enrichment.json>');
+    console.error(`Valid departments: ${[...VALID_DEPARTMENTS].join(', ')}`);
+    process.exit(1);
+}
+
+const departments = values.department.split(',').map((s) => s.trim()).filter(Boolean);
+const invalid = departments.filter((d) => !VALID_DEPARTMENTS.has(d));
+if (invalid.length) {
+    console.error(`Error: invalid department(s): ${invalid.join(', ')}`);
+    console.error(`Valid: ${[...VALID_DEPARTMENTS].join(', ')}`);
+    process.exit(1);
+}
+
+const maxLeads = parseInt(values['max-leads'], 10);
+if (!Number.isFinite(maxLeads) || maxLeads < 1) {
+    console.error('Error: --max-leads must be a positive integer.');
+    process.exit(1);
+}
+
+const csvText = readFileSync(values.input, 'utf8');
+const rows = parse(csvText, { columns: true, skip_empty_lines: true, trim: true });
+if (!rows.length || !('company_url' in rows[0])) {
+    console.error('Error: input CSV needs a "company_url" column.');
+    process.exit(1);
+}
+
+const urls = [...new Set(rows.map((r) => toCanonicalUrl(r.company_url)).filter(Boolean))];
+console.error(`Enriching ${urls.length} unique URLs — departments: ${departments.join(', ')}, max leads/domain: ${maxLeads}`);
+console.error(`Estimated cost: up to ${urls.length * maxLeads} leads (charged only for leads successfully found).`);
+
+const sidecar = Object.fromEntries(urls.map((u) => [u, { leads: [], emails: [], source: null }]));
+
+// ---- Primary call: contact-info-scraper with Business leads enrichment on.
+console.error('→ Running vdrmota/contact-info-scraper (Business leads enrichment ON)…');
+const contactItems = await runActorAndGetItems(
+    'vdrmota/contact-info-scraper',
+    {
+        startUrls: urls.map((u) => ({ url: u })),
+        maxRequestsPerStartUrl: 1,
+        mergeContacts: true,
+        maxDepth: 0,
+        maximumLeadsEnrichmentRecords: maxLeads,
+        leadsEnrichmentDepartments: departments,
+        verifyLeadsEnrichmentEmails: values['verify-emails'],
+    },
+    { sourceTag: 'departments_primary', timeoutSec: 1800 },
+);
+console.error(`  contact-info: ${contactItems.length} items back.`);
+
+// Output item is one row per start URL (mergeContacts=true). Leads live under
+// `leadsEnrichment` / `leads` / `businessLeads` depending on Actor version.
+function extractLeads(item) {
+    return item.leadsEnrichment
+        || item.leads
+        || item.businessLeads
+        || item.employees
+        || [];
+}
+
+for (const item of contactItems) {
+    const canon = toCanonicalUrl(item.url || item.startUrl || item.domain);
+    if (!canon || !(canon in sidecar)) continue;
+
+    const rawLeads = extractLeads(item);
+    for (const lead of rawLeads) {
+        const email = lead.email || lead.workEmail || lead.emailAddress || null;
+        const first = lead.firstName || lead.first_name || (lead.name || '').split(/\s+/)[0] || '';
+        const last = lead.lastName || lead.last_name || (lead.name || '').split(/\s+/).slice(1).join(' ') || '';
+        const person = {
+            firstName: first,
+            lastName: last,
+            fullName: lead.name || `${first} ${last}`.trim(),
+            title: lead.title || lead.jobTitle || lead.role || '',
+            department: lead.department || departments[0] || '',
+            email,
+            emailVerification: lead.emailVerification || null,
+            linkedin: lead.linkedin || lead.linkedInUrl || lead.linkedIn || null,
+            phone: lead.phone || null,
+            source: 'contact-info-scraper',
+        };
+        sidecar[canon].leads.push(person);
+        if (email) sidecar[canon].emails.push(email);
+    }
+    if (rawLeads.length && !sidecar[canon].source) sidecar[canon].source = 'contact-info-scraper';
+}
+
+// Dedup emails per URL.
+for (const canon of Object.keys(sidecar)) {
+    sidecar[canon].emails = [...new Set(sidecar[canon].emails)];
+}
+
+// ---- Fallback: leads with a first+last name but no email → bulk-email-finder-dep.
+const noEmailLeads = [];
+for (const [canon, entry] of Object.entries(sidecar)) {
+    for (const lead of entry.leads) {
+        if (!lead.email && lead.firstName && lead.lastName) {
+            noEmailLeads.push({ canon, lead, domain: toDomain(canon) });
+        }
+    }
+}
+
+if (noEmailLeads.length) {
+    console.error(`→ Fallback: ${noEmailLeads.length} leads have no email → scalelist/bulk-email-finder-dep…`);
+    let finderItems = [];
+    try {
+        finderItems = await runActorAndGetItems(
+            'scalelist/bulk-email-finder-dep',
+            {
+                leads: noEmailLeads.map(({ lead, domain }) => ({
+                    first_name: lead.firstName,
+                    last_name: lead.lastName,
+                    company_domain: domain,
+                })),
+            },
+            { sourceTag: 'departments_fallback', timeoutSec: 900 },
+        );
+    } catch (e) {
+        console.error(`  bulk-email-finder-dep failed: ${e.message}. Continuing without fallback data.`);
+    }
+    console.error(`  email-finder: ${finderItems.length} items back.`);
+
+    for (const item of finderItems) {
+        const email = item.email || item.emailAddress;
+        if (!email) continue;
+        const domain = (item.company_domain || item.domain || '').toLowerCase();
+        const first = (item.first_name || item.firstName || '').toLowerCase();
+        const last = (item.last_name || item.lastName || '').toLowerCase();
+        const match = noEmailLeads.find(({ lead, domain: d }) =>
+            d === domain
+            && lead.firstName.toLowerCase() === first
+            && lead.lastName.toLowerCase() === last);
+        if (!match) continue;
+        match.lead.email = email;
+        match.lead.source = 'bulk-email-finder-dep';
+        sidecar[match.canon].emails.push(email);
+    }
+
+    for (const canon of Object.keys(sidecar)) {
+        sidecar[canon].emails = [...new Set(sidecar[canon].emails)];
+    }
+}
+
+writeFileSync(values.output, JSON.stringify(sidecar, null, 2));
+const withPeople = Object.values(sidecar).filter((v) => v.leads.length).length;
+const withEmails = Object.values(sidecar).filter((v) => v.emails.length).length;
+console.error(`Wrote ${values.output}. ${withPeople}/${urls.length} URLs have ≥1 lead; ${withEmails}/${urls.length} have ≥1 email.`);

--- a/skills/apify-lead-scoring-enrichment/scripts/enrich_departments.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/enrich_departments.js
@@ -2,7 +2,7 @@
 // Calls vdrmota/contact-info-scraper with its "Business leads enrichment"
 // add-on enabled (maximumLeadsEnrichmentRecords + leadsEnrichmentDepartments)
 // to return actual people per domain. For any lead that comes back without a
-// resolved email, falls back to scalelist/bulk-email-finder-dep on the
+// resolved email, falls back to scalelist/email-finder on the
 // (firstName, lastName, domain) triple.
 //
 // Usage:
@@ -131,7 +131,7 @@ for (const canon of Object.keys(sidecar)) {
     sidecar[canon].emails = [...new Set(sidecar[canon].emails)];
 }
 
-// ---- Fallback: leads with a first+last name but no email → bulk-email-finder-dep.
+// ---- Fallback: leads with a first+last name but no email → email-finder.
 const noEmailLeads = [];
 for (const [canon, entry] of Object.entries(sidecar)) {
     for (const lead of entry.leads) {
@@ -142,11 +142,11 @@ for (const [canon, entry] of Object.entries(sidecar)) {
 }
 
 if (noEmailLeads.length) {
-    console.error(`→ Fallback: ${noEmailLeads.length} leads have no email → scalelist/bulk-email-finder-dep…`);
+    console.error(`→ Fallback: ${noEmailLeads.length} leads have no email → scalelist/email-finder…`);
     let finderItems = [];
     try {
         finderItems = await runActorAndGetItems(
-            'scalelist/bulk-email-finder-dep',
+            'scalelist/email-finder',
             {
                 leads: noEmailLeads.map(({ lead, domain }) => ({
                     first_name: lead.firstName,
@@ -157,7 +157,7 @@ if (noEmailLeads.length) {
             { sourceTag: 'departments_fallback', timeoutSec: 900 },
         );
     } catch (e) {
-        console.error(`  bulk-email-finder-dep failed: ${e.message}. Continuing without fallback data.`);
+        console.error(`  email-finder failed: ${e.message}. Continuing without fallback data.`);
     }
     console.error(`  email-finder: ${finderItems.length} items back.`);
 
@@ -173,7 +173,7 @@ if (noEmailLeads.length) {
             && lead.lastName.toLowerCase() === last);
         if (!match) continue;
         match.lead.email = email;
-        match.lead.source = 'bulk-email-finder-dep';
+        match.lead.source = 'email-finder';
         sidecar[match.canon].emails.push(email);
     }
 

--- a/skills/apify-lead-scoring-enrichment/scripts/filter_qualified.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/filter_qualified.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Filter leads.csv to only the rows the agent marked qualified in scored.json.
+// Pure Node — no Actor calls. The agent must have written `qualified: true`
+// (or `qualified: false`) on each row of scored.json before running this.
+//
+// Usage:
+//   node scripts/filter_qualified.js \
+//     --leads leads.csv \
+//     --scores scored.json \
+//     --output qualified_leads.csv
+
+import { parseArgs } from 'node:util';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import { toCanonicalUrl } from './apify_client.js';
+
+const { values } = parseArgs({
+    options: {
+        leads: { type: 'string' },
+        scores: { type: 'string' },
+        output: { type: 'string' },
+    },
+});
+
+if (!values.leads || !values.scores || !values.output) {
+    console.error('Usage: filter_qualified.js --leads <leads.csv> --scores <scored.json> --output <qualified_leads.csv>');
+    process.exit(1);
+}
+
+const rows = parse(readFileSync(values.leads, 'utf8'), { columns: true, skip_empty_lines: true, trim: true });
+const scored = JSON.parse(readFileSync(values.scores, 'utf8'));
+
+const qualified = rows.filter((row) => {
+    const canon = toCanonicalUrl(row.company_url);
+    const entry = scored[canon];
+    return entry && entry.qualified === true;
+});
+
+if (!rows.length) {
+    console.error('Error: leads.csv is empty.');
+    process.exit(1);
+}
+if (!qualified.length) {
+    console.error('Warning: 0 leads qualified. Enrichment would be a no-op — lower your threshold or fix your rules.');
+}
+
+const columns = Object.keys(rows[0]);
+writeFileSync(values.output, stringify(qualified, { header: true, columns }));
+console.error(`Wrote ${values.output} — ${qualified.length}/${rows.length} leads qualified (${((qualified.length / rows.length) * 100).toFixed(0)}%).`);

--- a/skills/apify-lead-scoring-enrichment/scripts/merge_output.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/merge_output.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Pure-Node merge: joins scoring.json + enrichment.json (+ optional scored.json
+// from the agent) onto the input CSV keyed by canonical https://domain and
+// writes leads.enriched.csv.
+//
+// Usage:
+//   node scripts/merge_output.js \
+//     --leads leads.csv \
+//     --scoring scoring.json \
+//     --enrichment enrichment.json \
+//     [--scores scored.json] \
+//     --output leads.enriched.csv
+
+import { parseArgs } from 'node:util';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import { toCanonicalUrl } from './apify_client.js';
+
+const { values } = parseArgs({
+    options: {
+        leads: { type: 'string' },
+        scoring: { type: 'string' },
+        enrichment: { type: 'string' },
+        scores: { type: 'string' },
+        output: { type: 'string' },
+    },
+});
+
+if (!values.leads || !values.output) {
+    console.error('Usage: merge_output.js --leads <leads.csv> [--scoring scoring.json] [--enrichment enrichment.json] [--scores scored.json] --output <leads.enriched.csv>');
+    process.exit(1);
+}
+
+const rows = parse(readFileSync(values.leads, 'utf8'), { columns: true, skip_empty_lines: true, trim: true });
+
+function loadJson(path) {
+    if (!path) return {};
+    if (!existsSync(path)) {
+        console.error(`Warning: ${path} not found — skipping.`);
+        return {};
+    }
+    return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+const scoring = loadJson(values.scoring);
+const enrichment = loadJson(values.enrichment);
+const scores = loadJson(values.scores);
+
+function techSummary(t) {
+    if (!t) return '';
+    // BuiltWith outputs vary; try common shapes.
+    const groups = t.techs || t.technologies || t.techStack || t.Results?.[0]?.Result?.Paths?.[0]?.Technologies || [];
+    if (Array.isArray(groups) && groups.length) {
+        return groups.slice(0, 8).map((g) => g.name || g.Name || g).filter(Boolean).join(', ');
+    }
+    return '';
+}
+
+function contentSummary(c) {
+    if (!c) return '';
+    const text = c.markdown || c.text || c.pageContent || '';
+    return text ? text.replace(/\s+/g, ' ').slice(0, 240) : '';
+}
+
+function metaField(m, ...keys) {
+    if (!m) return '';
+    for (const k of keys) {
+        if (m[k]) return m[k];
+    }
+    return '';
+}
+
+const enrichedRows = rows.map((row) => {
+    const canon = toCanonicalUrl(row.company_url);
+    const sc = scoring[canon] || {};
+    const en = enrichment[canon] || {};
+    const scored = scores[canon] || {};
+
+    return {
+        ...row,
+        tech_summary: techSummary(sc.tech),
+        content_summary: contentSummary(sc.content),
+        company_size: metaField(sc.metadata, 'companySize', 'size', 'employees'),
+        industry: metaField(sc.metadata, 'industry', 'category'),
+        tech_score: scored.tech_score ?? '',
+        content_score: scored.content_score ?? '',
+        metadata_score: scored.metadata_score ?? '',
+        score: scored.score ?? '',
+        qualified: typeof scored.qualified === 'boolean' ? String(scored.qualified) : '',
+        outreach_hook: scored.outreach_hook ?? '',
+        leads: Array.isArray(en.leads) && en.leads.length ? JSON.stringify(en.leads) : '',
+        lead_names: Array.isArray(en.leads) ? en.leads.map((l) => l.fullName).filter(Boolean).join(';') : '',
+        lead_titles: Array.isArray(en.leads) ? en.leads.map((l) => l.title).filter(Boolean).join(';') : '',
+        emails: Array.isArray(en.emails) ? en.emails.join(';') : '',
+        authors: Array.isArray(en.authors) ? en.authors.map((a) => a.name).join(';') : '',
+    };
+});
+
+const columns = Object.keys(enrichedRows[0] || {});
+writeFileSync(values.output, stringify(enrichedRows, { header: true, columns }));
+console.error(`Wrote ${values.output} — ${enrichedRows.length} rows, ${columns.length} columns.`);

--- a/skills/apify-lead-scoring-enrichment/scripts/package.json
+++ b/skills/apify-lead-scoring-enrichment/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "apify-lead-scoring-enrichment-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Helper scripts for the apify-lead-scoring-enrichment skill",
+  "dependencies": {
+    "csv-parse": "^5.5.6",
+    "csv-stringify": "^6.5.1"
+  }
+}

--- a/skills/apify-lead-scoring-enrichment/scripts/run_scoring.js
+++ b/skills/apify-lead-scoring-enrichment/scripts/run_scoring.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Batches all lead URLs into per-Actor calls (tech, content, metadata) and
+// writes a per-URL sidecar keyed by canonical https://domain.
+//
+// Usage:
+//   node --env-file=.env scripts/run_scoring.js \
+//     --input leads.csv --output scoring.json \
+//     [--enable-tech] [--enable-content] [--enable-metadata] \
+//     [--content-crawl-depth 0]
+//
+// At least one --enable-* flag must be set.
+
+import { parseArgs } from 'node:util';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import { runActorAndGetItems, toCanonicalUrl, toDomain } from './apify_client.js';
+
+const { values } = parseArgs({
+    options: {
+        input: { type: 'string' },
+        output: { type: 'string' },
+        'enable-tech': { type: 'boolean', default: false },
+        'enable-content': { type: 'boolean', default: false },
+        'enable-metadata': { type: 'boolean', default: false },
+        'content-crawl-depth': { type: 'string', default: '0' },
+    },
+});
+
+if (!values.input || !values.output) {
+    console.error('Usage: run_scoring.js --input <leads.csv> --output <scoring.json> [--enable-tech] [--enable-content] [--enable-metadata]');
+    process.exit(1);
+}
+if (!values['enable-tech'] && !values['enable-content'] && !values['enable-metadata']) {
+    console.error('Error: at least one of --enable-tech, --enable-content, --enable-metadata is required.');
+    process.exit(1);
+}
+
+const csvText = readFileSync(values.input, 'utf8');
+const rows = parse(csvText, { columns: true, skip_empty_lines: true, trim: true });
+if (!rows.length) {
+    console.error(`Error: no rows in ${values.input}`);
+    process.exit(1);
+}
+if (!('company_url' in rows[0])) {
+    console.error(`Error: input CSV is missing the required "company_url" column. Found: ${Object.keys(rows[0]).join(', ')}`);
+    process.exit(1);
+}
+
+const urls = [...new Set(rows.map((r) => toCanonicalUrl(r.company_url)).filter(Boolean))];
+const domains = [...new Set(urls.map(toDomain))];
+console.error(`Loaded ${rows.length} leads → ${urls.length} unique URLs.`);
+
+const sidecar = Object.fromEntries(urls.map((u) => [u, {}]));
+
+function upsertByUrl(actorItems, urlPicker, key) {
+    for (const item of actorItems || []) {
+        const raw = urlPicker(item);
+        const canon = toCanonicalUrl(raw);
+        if (!canon || !(canon in sidecar)) continue;
+        sidecar[canon][key] = item;
+    }
+}
+
+if (values['enable-tech']) {
+    console.error(`→ Running builtwith/builtwith-official-technology-scraper for ${domains.length} domains…`);
+    const items = await runActorAndGetItems(
+        'builtwith/builtwith-official-technology-scraper',
+        { startDomains: domains },
+        { sourceTag: 'tech', timeoutSec: 900 },
+    );
+    upsertByUrl(items, (it) => it.url || it.domain || it.website || it.startDomain, 'tech');
+    console.error(`  tech: ${items.length} items back.`);
+}
+
+if (values['enable-content']) {
+    const depth = parseInt(values['content-crawl-depth'], 10);
+    console.error(`→ Running apify/website-content-crawler (maxCrawlDepth=${depth})…`);
+    const items = await runActorAndGetItems(
+        'apify/website-content-crawler',
+        {
+            startUrls: urls.map((u) => ({ url: u })),
+            maxCrawlDepth: depth,
+            maxCrawlPages: Math.max(urls.length, urls.length * (depth + 1)),
+            crawlerType: 'playwright:firefox',
+            saveMarkdown: true,
+        },
+        { sourceTag: 'content', timeoutSec: 1800 },
+    );
+    upsertByUrl(items, (it) => it.url || it.loadedUrl, 'content');
+    console.error(`  content: ${items.length} items back.`);
+}
+
+if (values['enable-metadata']) {
+    console.error(`→ Running vdrmota/contact-info-scraper for ${urls.length} URLs…`);
+    const items = await runActorAndGetItems(
+        'vdrmota/contact-info-scraper',
+        {
+            startUrls: urls.map((u) => ({ url: u })),
+            maxDepth: 1,
+            maxRequests: urls.length * 2,
+        },
+        { sourceTag: 'metadata', timeoutSec: 1800 },
+    );
+    upsertByUrl(items, (it) => it.url || it.domain, 'metadata');
+    console.error(`  metadata: ${items.length} items back.`);
+}
+
+writeFileSync(values.output, JSON.stringify(sidecar, null, 2));
+console.error(`Wrote ${values.output} (${Object.keys(sidecar).length} URLs).`);


### PR DESCRIPTION
## Summary

Adds a new community skill, `apify-lead-scoring-enrichment`, that walks an AI agent through the full lead-scoring + enrichment loop for B2B outbound:

1. Ingest a CSV whose only required column is `company_url`.
2. Collect scoring rules from the user **per data source** (tech stack / website content / company metadata) so each rule's provenance is auditable.
3. Score every lead by running one call per enabled Actor:
   - `builtwith/builtwith-official-technology-scraper` for tech stack.
   - `apify/website-content-crawler` for homepage/deeper content.
   - `vdrmota/contact-info-scraper` (add-on OFF) for company metadata.
4. Compute theoretical + observed score ranges, ask the user for a qualification threshold, filter to `qualified_leads.csv`.
5. Enrich **only qualified leads** on one of two paths:
   - **Path A (departments)** — `vdrmota/contact-info-scraper` with the Business-leads-enrichment add-on returning named people (with `first_name`, `last_name`, `title`, `email`, LinkedIn) filtered to selected `leadsEnrichmentDepartments`. Any lead with a name but no email falls back to `scalelist/email-finder`.
   - **Path B (copywriters)** — `apify/google-search-scraper` for `site:{domain} blog` → `apify/ai-web-scraper` (`get-author-name-from-blog-post` example) → `scalelist/email-finder`.
6. Merge back onto the **original** CSV so unqualified rows are preserved with `qualified=false` and blank enrichment columns.

## What's in the PR

- `skills/apify-lead-scoring-enrichment/SKILL.md` — 7-step workflow with per-source rules, threshold-gate, and full CLI recipes.
- `scripts/` — seven Node.js helpers (`run_scoring`, `filter_qualified`, `enrich_departments`, `enrich_copywriters`, `merge_output`, `apify_client`, `package.json`). Uses Node 20.6+ `--env-file` for `APIFY_TOKEN` loading; no Apify SDK dep, just `fetch` + `csv-parse`/`csv-stringify`.
- `references/actor-index.md` — schema-verified input shapes for all six Actors, including the `vdrmota` Business-leads-enrichment add-on (`maximumLeadsEnrichmentRecords` + the 14-value `leadsEnrichmentDepartments` enum) and the `scalelist` snake_case `leads` array.
- `references/gotchas.md` — cost guardrails, add-on multiplier warnings, per-Actor traps.
- `examples/` — 3-row sample CSV and per-source example rules.
- `.claude-plugin/marketplace.json` — one new `plugins[]` entry.
- Skill-level `.gitignore` — keeps `.env`, `node_modules`, and runtime artifacts out of the tree.

## Maintainer review

One blocker was found and fixed in b738d98 (pushed to this branch by a maintainer):

- **`scalelist/bulk-email-finder-dep` does not exist** — the Apify API 404s on it. Both enrichment paths would have failed at runtime on the email-fallback hop, and it broke the "publicly available Actors only" rule in CONTRIBUTING.md. Replaced with **`scalelist/email-finder`** ("Bulk Email Finder with Email Verification"), which takes the identical `{leads:[{first_name, last_name, company_domain}]}` payload the scripts already build. Swapped across `SKILL.md`, both `references/`, `enrich_departments.js`, `enrich_copywriters.js`, and the dead store link.

Non-blocking follow-up, worth a separate PR: `scripts/apify_client.js` passes `APIFY_TOKEN` as a `?token=` query parameter on every call. It works, but tokens in URLs leak into tracebacks, proxy logs and shell history — one unhandled error surfaced the full token in a stack trace during testing. The `Authorization: Bearer` header avoids that.

## Test plan

- [x] `npm install` inside `scripts/` — clean install, no vulnerabilities.
- [x] `node --check` on every script.
- [x] `bash scripts/lint_telemetry.sh` from repo root — passes.
- [x] Dry-run of `filter_qualified.js` and `merge_output.js` with hand-crafted `scored.json` (mixed qualified / unqualified rows) — filter emits the right subset, merge preserves all input rows with the `qualified` column set correctly.
- [x] Live end-to-end run against a real `APIFY_TOKEN` on the 3-row `examples/leads.example.csv`:
  - `run_scoring.js --enable-tech --enable-metadata` — `builtwith` run `Anrvf74lTYFwV0fmF` returned tech stacks for 3/3 domains, `vdrmota/contact-info-scraper` run `YozM3K4qQnvtfxpaT` returned metadata for 2/3; `scoring.json` written with both sources keyed per canonical URL.
  - `filter_qualified.js` at a threshold of 8 — 2/3 leads qualified, original columns preserved.
  - `enrich_departments.js --department marketing --max-leads 2` — `vdrmota/contact-info-scraper` run `BxqsNrTLnf1dCguYH`, 2/2 URLs returned ≥1 named lead and ≥1 email.
  - The corrected `scalelist/email-finder` verified directly (run `X18nziaChrre8Da2n`) because the enrichment hop resolved every email itself and never triggered the fallback: the Actor accepts the payload the script builds and returns `first_name` / `last_name` / `company_domain` / `email` / `email_status` / `found`, the exact keys the merge-back logic reads.

Total smoke-test spend: ~$0.05.

## Author

Fabian Maume ([@fmaume](https://github.com/fmaume)) — Product Marketing Manager @ Apify, focused on the universe cluster (Web Content Crawler, RAG Web Browser, Cheerio/Puppeteer Scraper) and community creator support.