### PR TITLE
Add apify-google-maps-photo-download skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,21 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-google-maps-photo-download",
+      "source": "./skills/apify-google-maps-photo-download",
+      "skills": "./",
+      "description": "Bulk google maps photo download for a place or a whole neighbourhood, returning one row per photo with the full-size image URL, thumbnail, gallery position and a stable photo ID.",
+      "keywords": [
+        "apify",
+        "google-maps",
+        "photos",
+        "images",
+        "mcp"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-google-maps-photo-download/SKILL.md
+++ b/skills/apify-google-maps-photo-download/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: apify-google-maps-photo-download
+description: Bulk google maps photo download with the Apify Google Maps Photos API Actor (johnvc/google-maps-photos-api). Name a place, paste a Google Maps URL, or search a category and city, and get one row per photo with the full-size image url, a thumbnail, its gallery position, and a stable photo id you can de-duplicate on across runs. One run sweeps up to 20 places, so a whole neighbourhood of businesses comes back in a single pass instead of one right-click at a time. Filter to a gallery section when you only want menus, interiors, or owner uploads. Use when the user wants to download google maps photos, bulk place images, a google maps images api, place photos api access, or imagery for a directory, listings site, or dataset. Pay per photo returned, MCP-ready for Claude and other AI agents.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# Bulk Google Maps Photo Download, One Row Per Photo
+
+Every photo a place has on Google Maps, as structured rows: full-size URL, thumbnail, gallery position, and a stable ID you can dedupe on.
+
+## When to use this skill
+
+- The user wants to "download google maps photos" for a business, or for many businesses at once.
+- They need imagery for a directory, listings site, travel app, or training dataset.
+- They want a "google maps images api" or "place photos api" they can call from code.
+- They already have Google Maps URLs or place identifiers and want the galleries behind them.
+
+Not for: Street View and 360 panoramas (use the companion apify-google-street-view-api skill), place details like ratings and hours (`johnvc/google-maps-places-api`), or review text (`johnvc/google-maps-contributor-reviews-api`). See `references/actor-index.md`.
+
+## What you get
+
+One dataset row per photo. `result_type` separates the row kinds:
+
+- `image` (full-size URL) and `thumbnail` (smaller preview of the same shot)
+- `position`, where it sits in the place's gallery
+- `photo_id`, stable across runs, which is what makes scheduled refreshes cheap
+- `data_id` and `place_title`, the place the photo belongs to
+- `category_id` when a gallery filter was applied
+- one `place_summary` row per place with `photos_returned`, `pages_fetched`, and `place_categories`
+
+It does not return captions, EXIF, contributor names, or upload dates.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/google-maps-photos-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/google-maps-photos-api`
+- Pricing: pay per event; see the cost section below and `references/gotchas.md` for live-price commands.
+
+## Run it with the Apify CLI
+
+One place by name:
+
+```bash
+apify actors call "johnvc/google-maps-photos-api" -i '{"searchTerm":"Mozart Coffee Roasters, Austin TX","maxPlacesPerSearch":1,"maxPhotosPerPlace":20}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-maps-photo-download \
+  2>/dev/null
+```
+
+Sweep a category across a city:
+
+```bash
+apify actors call "johnvc/google-maps-photos-api" -i '{"searchTerm":"coffee shops in Austin, TX","maxPlacesPerSearch":10,"maxPhotosPerPlace":20}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-maps-photo-download \
+  2>/dev/null
+```
+
+Skip the search charge with URLs you already hold:
+
+```bash
+apify actors call "johnvc/google-maps-photos-api" -i '{"placeUrls":["https://www.google.com/maps/place/..."],"maxPhotosPerPlace":40}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-maps-photo-download \
+  2>/dev/null
+```
+
+Confirm live pricing and the input schema before a large batch:
+
+```bash
+apify actors info "johnvc/google-maps-photos-api" --json \
+  --user-agent apify-awesome-skills/apify-google-maps-photo-download \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-google-maps-photo-download`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/google-maps-photos-api`
+
+Then ask, for example: "Download every photo for the three highest-rated ramen places in Austin and list the full-size URLs." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Pick the cheapest way in. A Google Maps URL or a place identifier costs nothing to resolve; a `searchTerm` adds one search charge.
+2. Bound the sweep with `maxPlacesPerSearch` (default 3, max 20) and the depth with `maxPhotosPerPlace` (default 20).
+3. Run, then split rows on `result_type`: `photo`, `place_summary`, `error`.
+4. Store `photo_id` alongside each image. On the next run, skip IDs you already hold.
+5. Re-host anything you plan to display; the Google-hosted URLs can rotate.
+
+## Inputs
+
+- `searchTerm` (string): a place name, or a category plus a city
+- `searchTerms` (array): several searches in one run
+- `placeUrls` (array): Google Maps URLs, parsed locally at no API cost
+- `dataId` / `dataIds` (string, array): place identifiers you already hold
+- `maxPlacesPerSearch` (integer, default 3, max 20): how wide a search sweeps
+- `maxPhotosPerPlace` (integer, default 20, max 1000): how deep per place
+- `photoCategory` (enum `all`, `latest`, `videos`, `by_owner`, `street_view`, `menu`, `food_and_drink`, `vibe`, default `all`)
+- `categoryId` (string): a venue-specific section ID taken from a `place_summary` row
+- `hl` (string, default `en`): interface language
+
+## Cost
+
+Billing is pay per event, plus a negligible platform fee per dataset row. Prices below are the BRONZE tier at the time of writing; confirm live prices with the info command above.
+
+- About $0.0015 per photo returned.
+- About $0.012 per search term, and nothing when you pass URLs or identifiers instead.
+- About $0.001 to start a run.
+- A 10-place sweep at 20 photos each is about $0.32.
+
+Suggested confirmation thresholds: warn the user over about $5; get explicit confirmation over about $20. Present cost as "around $X", never a guarantee.
+
+## Honest limits
+
+- Gallery size varies enormously, from a handful at a small office to several hundred at a busy restaurant. Photos arrive in blocks of twenty.
+- `menu`, `food_and_drink`, and `vibe` exist only on food and drink venues; the other five categories work anywhere.
+- No captions, EXIF, contributor names, or upload dates, so there is no way to filter by when a photo was taken.
+- No historical imagery. This returns the current gallery, not what the place looked like years ago.
+- Image URLs are Google-hosted and can rotate, so hotlinking them long term is unreliable.
+
+## Troubleshooting
+
+- Fewer photos than `maxPhotosPerPlace`: the place has that many, and `photos_returned` on the summary row confirms it.
+- A category returns nothing: it is probably food-venue only. Read `place_categories` on the summary row to see what that place actually offers.
+- Search matched the wrong place: add the city and state to `searchTerm`, or pass the Google Maps URL directly.
+- An `error` row: clean failure, stated plainly; retry once before investigating.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Google Maps Places API: https://apify.com/johnvc/google-maps-places-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Maps Contributor Reviews API: https://apify.com/johnvc/google-maps-contributor-reviews-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Maps Directions API: https://apify.com/johnvc/google-maps-directions-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Apple Maps API: https://apify.com/johnvc/apple-maps-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-google-maps-photo-download/references/actor-index.md
+++ b/skills/apify-google-maps-photo-download/references/actor-index.md
@@ -1,0 +1,24 @@
+# Actor index: Google Maps Photos API
+
+The primary Actor for this skill, plus the Actors worth chaining for adjacent intents. The agent reads this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| Google Maps Photos API | google maps photo download | `johnvc/google-maps-photos-api` | community | Pay per event: `photo_returned` about $0.0015 per photo, `place_search` about $0.012 per search term, `actor_start` about $0.001 per run. |
+
+## Chain with adjacent Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Find the places first | `johnvc/google-maps-places-api` | Names, ratings, hours, and the identifiers you can feed straight back in. |
+| Reviews for a place | `johnvc/google-maps-contributor-reviews-api` | Review text and ratings by contributor. |
+| Routes and drive times | `johnvc/google-maps-directions-api` | Point to point, with distance and duration. |
+| Hotel imagery and reviews | `johnvc/google-hotels-search-scraper` | Hotel search including photos. |
+| Same places, second source | `johnvc/apple-maps-api` | Apple Maps place data for cross-checking. |
+
+## How to extend
+
+1. Fetch the input schema: `apify actors info "johnvc/google-maps-photos-api" --input --json --user-agent apify-awesome-skills/apify-google-maps-photo-download 2>/dev/null`
+2. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-google-maps-photo-download/references/gotchas.md
+++ b/skills/apify-google-maps-photo-download/references/gotchas.md
@@ -1,0 +1,49 @@
+# Gotchas: Google Maps Photos API (`johnvc/google-maps-photos-api`)
+
+Cost guardrails, error recovery, and input quirks. The agent reads this on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event, plus a platform fee of about $0.00001 per dataset row. Charge events:
+
+- `photo_returned`: about $0.0015 per photo returned (BRONZE tier at the time of writing).
+- `place_search`: about $0.012 per search term, and not charged at all when you pass `placeUrls` or `dataIds`.
+- `actor_start`: about $0.001 per run.
+
+Confirm the live price before a large batch:
+
+```bash
+apify actors info "johnvc/google-maps-photos-api" --json \
+  --user-agent apify-awesome-skills/apify-google-maps-photo-download \
+  2>/dev/null
+```
+
+Worked estimates for this skill:
+
+- One place at 20 photos, found by search, is about $0.043.
+- A 10-place sweep at 20 photos each is about $0.32.
+- The same 10 places passed as URLs instead of a search is about $0.30, and scales better the more you run it.
+
+Suggested confirmation thresholds:
+
+- Rough estimate over $5: warn the user.
+- Rough estimate over $20: get explicit confirmation before running.
+- Always present cost as "around $X", not a guarantee.
+
+## Actor-specific notes
+
+- Billing is per photo delivered, so a place with a small gallery costs less; there is no per-page charge.
+- `placeUrls` and `dataIds` are parsed locally and skip the search charge entirely. This is the single biggest cost lever.
+- `maxPlacesPerSearch` defaults to 3 and caps at 20, so a bare category search sweeps more than one place unless you set it.
+- Photos arrive from the source in blocks of twenty; `maxPhotosPerPlace` is the cap, not a guarantee.
+- `menu`, `food_and_drink`, and `vibe` categories exist only on food and drink venues. `all`, `latest`, `videos`, `by_owner`, and `street_view` work anywhere.
+- The `place_summary` row is not billed as a photo and carries `place_categories`, the venue's own gallery sections with their filter IDs.
+- `photo_id` is stable across runs, which is what makes a scheduled refresh cheap: dedupe on it and only pay for new images.
+
+## Error recovery
+
+- A failed place emits an `error` row explaining the failure in plain terms; photos that never arrived are not charged.
+- Transient upstream failures: retry once before changing inputs.
+- Input rejections happen before any charge; fix the named field and re-run.
+- If a run stops early at your budget limit, rows already delivered are kept and billed; raise the limit or narrow the input.
+- Image URLs are Google-hosted and can rotate. Re-host anything you intend to display long term.


### PR DESCRIPTION
Adds one skill, `apify-google-maps-photo-download`, targeting **google maps photo download**, built on the public Store Actor [`johnvc/google-maps-photos-api`](https://apify.com/johnvc/google-maps-photos-api).

Bulk-downloads a place's whole photo gallery, or every business in an area, as one row per photo with the full-size URL, thumbnail, gallery position, and a stable photo ID for de-duplicating across runs. Documents the cost lever honestly: passing a Google Maps URL or place identifier skips the per-search charge entirely.

**Contents (4 files):**
- `skills/apify-google-maps-photo-download/SKILL.md`
- `skills/apify-google-maps-photo-download/references/actor-index.md`
- `skills/apify-google-maps-photo-download/references/gotchas.md`
- one new entry in `.claude-plugin/marketplace.json`

**Checks:**
- `bash scripts/lint_telemetry.sh` passes; every `apify` call carries `--user-agent apify-awesome-skills/apify-google-maps-photo-download`, `--json`, and `2>/dev/null`.
- `uv run scripts/generate_agents.py` fails on `apify-x402-agentic-wallet` being present in `skills/` but absent from `marketplace.json`. That failure reproduces on a clean checkout of upstream `main` with no changes applied, so it is pre-existing and unrelated to this PR. Happy to rebase once it is reconciled.
- One skill per PR; this branch touches only the four files listed above.