### PR TITLE
Add apify-google-street-view-api skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,21 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-google-street-view-api",
+      "source": "./skills/apify-google-street-view-api",
+      "skills": "./",
+      "description": "A google maps street view api you call with a business name instead of coordinates, returning the 360 panoramas attached to that place as structured rows.",
+      "keywords": [
+        "apify",
+        "street-view",
+        "google-maps",
+        "panorama",
+        "mcp"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-google-street-view-api/SKILL.md
+++ b/skills/apify-google-street-view-api/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: apify-google-street-view-api
+description: Pull Street View and 360 panoramas for a place by name with a google maps street view api built on the Apify Google Maps Photos API Actor (johnvc/google-maps-photos-api). The official Street View Static endpoint wants a latitude, longitude and heading and returns one rendered tile; this returns a listing of the panoramas actually attached to a business, addressed by its name or its Google Maps URL, as rows with the full-size image url, a thumbnail, gallery position and a stable photo id. Set the category to street_view for panoramas or videos for clips. Use when the user wants a street view api, google street view images for a business, 360 photos of a location, exterior or frontage imagery for site surveys, real estate, insurance or field-service work, without geocoding first. Pay per image returned, MCP-ready for Claude and other AI agents.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# Street View and 360 Panoramas, Addressed by Place Name
+
+A Street View API you can call with a business name instead of coordinates, returning the panoramas attached to that place as rows.
+
+## When to use this skill
+
+- The user wants a "street view api" or "google street view images" for a specific business.
+- They need 360 panoramas or exterior frontage shots for site surveys, real estate, insurance, or field-service prep.
+- They have a place name or a Google Maps URL and do not want to geocode and pick a heading first.
+- They want the video clips attached to a place rather than still photos.
+
+Not for: bulk gallery download across a whole category (use the companion apify-google-maps-photo-download skill) or routing and drive times (`johnvc/google-maps-directions-api`). See `references/actor-index.md`.
+
+## Why this is not the official Street View endpoint
+
+Street View Static renders one tile from a latitude, longitude, heading, pitch, and field of view you supply. Getting from "this restaurant" to "the right panorama facing the right way" is a geocoding and aiming problem you own. This skill instead lists the panoramas Google already associates with the place, so the aiming is already done and the input is a name.
+
+## What you get
+
+One dataset row per image. `result_type` separates the row kinds:
+
+- `image` (full-size URL) and `thumbnail`
+- `position` in the gallery section
+- `photo_id`, stable across runs
+- `data_id` and `place_title`
+- `category_id`, echoing the filter that was applied
+- one `place_summary` row per place with `photos_returned` and `place_categories`
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/google-maps-photos-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/google-maps-photos-api`
+- Pricing: pay per event; see the cost section below and `references/gotchas.md` for live-price commands.
+
+## Run it with the Apify CLI
+
+Street View and 360 panoramas for one place:
+
+```bash
+apify actors call "johnvc/google-maps-photos-api" -i '{"searchTerm":"Mozart Coffee Roasters, Austin TX","maxPlacesPerSearch":1,"photoCategory":"street_view","maxPhotosPerPlace":20}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-street-view-api \
+  2>/dev/null
+```
+
+Panoramas for a list of sites you already hold URLs for:
+
+```bash
+apify actors call "johnvc/google-maps-photos-api" -i '{"placeUrls":["https://www.google.com/maps/place/..."],"photoCategory":"street_view"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-street-view-api \
+  2>/dev/null
+```
+
+Video clips instead of stills:
+
+```bash
+apify actors call "johnvc/google-maps-photos-api" -i '{"searchTerm":"Mozart Coffee Roasters, Austin TX","maxPlacesPerSearch":1,"photoCategory":"videos"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-street-view-api \
+  2>/dev/null
+```
+
+Confirm live pricing and the input schema before a large batch:
+
+```bash
+apify actors info "johnvc/google-maps-photos-api" --json \
+  --user-agent apify-awesome-skills/apify-google-street-view-api \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-google-street-view-api`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/google-maps-photos-api`
+
+Then ask, for example: "Get the Street View panoramas for this address and tell me whether the entrance looks step-free." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Identify the place by name plus city, or by its Google Maps URL. A URL costs nothing to resolve; a search adds one charge.
+2. Set `photoCategory` to `street_view` for panoramas, or `videos` for clips.
+3. Keep `maxPlacesPerSearch` at 1 when you mean one specific site, so a loose name does not sweep neighbours.
+4. Read the rows; check `photos_returned` on the summary row before concluding a place has no coverage.
+5. Re-host anything you plan to display or archive.
+
+## Inputs
+
+- `searchTerm` (string): a place name, ideally with city and state
+- `placeUrls` (array): Google Maps URLs, parsed locally at no API cost
+- `dataId` / `dataIds` (string, array): place identifiers you already hold
+- `photoCategory` (enum, use `street_view` here, or `videos` for clips)
+- `maxPlacesPerSearch` (integer, default 3, max 20): keep at 1 for a single site
+- `maxPhotosPerPlace` (integer, default 20, max 1000)
+- `hl` (string, default `en`): interface language
+
+## Cost
+
+Billing is pay per event, plus a negligible platform fee per dataset row. Prices below are the BRONZE tier at the time of writing; confirm live prices with the info command above.
+
+- About $0.0015 per image returned.
+- About $0.012 per search term, and nothing when you pass URLs or identifiers instead.
+- About $0.001 to start a run.
+- Checking 50 sites by URL, a few panoramas each, is well under $1.
+
+Suggested confirmation thresholds: warn the user over about $5; get explicit confirmation over about $20. Present cost as "around $X", never a guarantee.
+
+## Honest limits
+
+- Street View coverage is uneven. Rural addresses, interior units, and new construction often have none, and an empty result is a real answer rather than a failure.
+- The panoramas are whatever Google associates with the place. You cannot request a specific heading, pitch, or field of view the way the Static endpoint lets you.
+- No capture dates, so there is no way to tell how old a panorama is or to request an older one.
+- Image URLs are Google-hosted and can rotate, so hotlinking them long term is unreliable.
+
+## Troubleshooting
+
+- Empty result for `street_view`: that place has no panoramas attached. Read `place_categories` on the summary row to see which sections do exist.
+- Wrong building: the name matched a neighbour. Pass the Google Maps URL instead of a search term.
+- Several places came back when you wanted one: set `maxPlacesPerSearch` to 1.
+- An `error` row: clean failure, stated plainly; retry once before investigating.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Google Maps Places API: https://apify.com/johnvc/google-maps-places-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Maps Directions API: https://apify.com/johnvc/google-maps-directions-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Maps Contributor Reviews API: https://apify.com/johnvc/google-maps-contributor-reviews-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Apple Maps API: https://apify.com/johnvc/apple-maps-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-google-street-view-api/references/actor-index.md
+++ b/skills/apify-google-street-view-api/references/actor-index.md
@@ -1,0 +1,24 @@
+# Actor index: Google Maps Photos API
+
+The primary Actor for this skill, plus the Actors worth chaining for adjacent intents. The agent reads this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| Google Maps Photos API | google maps street view api | `johnvc/google-maps-photos-api` | community | Pay per event: `photo_returned` about $0.0015 per image, `place_search` about $0.012 per search term, `actor_start` about $0.001 per run. |
+
+## Chain with adjacent Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Find the places first | `johnvc/google-maps-places-api` | Names, ratings, hours, and the identifiers you can feed straight back in. |
+| Reviews for a place | `johnvc/google-maps-contributor-reviews-api` | Review text and ratings by contributor. |
+| Routes and drive times | `johnvc/google-maps-directions-api` | Point to point, with distance and duration. |
+| Hotel imagery and reviews | `johnvc/google-hotels-search-scraper` | Hotel search including photos. |
+| Same places, second source | `johnvc/apple-maps-api` | Apple Maps place data for cross-checking. |
+
+## How to extend
+
+1. Fetch the input schema: `apify actors info "johnvc/google-maps-photos-api" --input --json --user-agent apify-awesome-skills/apify-google-street-view-api 2>/dev/null`
+2. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-google-street-view-api/references/gotchas.md
+++ b/skills/apify-google-street-view-api/references/gotchas.md
@@ -1,0 +1,48 @@
+# Gotchas: Google Maps Photos API (`johnvc/google-maps-photos-api`)
+
+Cost guardrails, error recovery, and input quirks. The agent reads this on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event, plus a platform fee of about $0.00001 per dataset row. Charge events:
+
+- `photo_returned`: about $0.0015 per image returned (BRONZE tier at the time of writing).
+- `place_search`: about $0.012 per search term, and not charged at all when you pass `placeUrls` or `dataIds`.
+- `actor_start`: about $0.001 per run.
+
+Confirm the live price before a large batch:
+
+```bash
+apify actors info "johnvc/google-maps-photos-api" --json \
+  --user-agent apify-awesome-skills/apify-google-street-view-api \
+  2>/dev/null
+```
+
+Worked estimates for this skill:
+
+- One site checked by URL, a few panoramas, is a few tenths of a cent.
+- Fifty sites passed as URLs is well under $1.
+- Fifty sites found by name instead adds about $0.60 in search charges, so hold identifiers where you can.
+
+Suggested confirmation thresholds:
+
+- Rough estimate over $5: warn the user.
+- Rough estimate over $20: get explicit confirmation before running.
+- Always present cost as "around $X", not a guarantee.
+
+## Actor-specific notes
+
+- Set `photoCategory` to `street_view` for panoramas or `videos` for clips. Both are universal categories that work on any place.
+- Keep `maxPlacesPerSearch` at 1 for a single site; the default of 3 will sweep neighbouring businesses on a loose name.
+- Coverage is genuinely uneven. Rural addresses, interior units, and new construction often have no panoramas, and an empty result is a real answer.
+- You cannot request a heading, pitch, or field of view. This lists what is attached to the place rather than rendering a tile.
+- No capture dates are returned, so panorama age is unknowable from the data.
+- Read `place_categories` on the `place_summary` row to confirm which sections a place actually offers before concluding coverage is missing.
+
+## Error recovery
+
+- An empty `street_view` result means no panoramas are attached, not that the run failed. Check `photos_returned` on the summary row.
+- Wrong building: the name matched a neighbour. Pass the Google Maps URL instead of a search term.
+- Transient upstream failures: retry once before changing inputs.
+- Input rejections happen before any charge; fix the named field and re-run.
+- Image URLs are Google-hosted and can rotate. Re-host anything you intend to archive.


### PR DESCRIPTION
Adds one skill, `apify-google-street-view-api`, targeting **google maps street view api**, built on the public Store Actor [`johnvc/google-maps-photos-api`](https://apify.com/johnvc/google-maps-photos-api).

Returns the Street View and 360 panoramas attached to a place, addressed by business name rather than latitude, longitude, and heading. Includes a section on why this is not the official Street View Static endpoint, and states plainly that coverage is uneven and an empty result is a real answer.

**Contents (4 files):**
- `skills/apify-google-street-view-api/SKILL.md`
- `skills/apify-google-street-view-api/references/actor-index.md`
- `skills/apify-google-street-view-api/references/gotchas.md`
- one new entry in `.claude-plugin/marketplace.json`

**Checks:**
- `bash scripts/lint_telemetry.sh` passes; every `apify` call carries `--user-agent apify-awesome-skills/apify-google-street-view-api`, `--json`, and `2>/dev/null`.
- `uv run scripts/generate_agents.py` fails on `apify-x402-agentic-wallet` being present in `skills/` but absent from `marketplace.json`. That failure reproduces on a clean checkout of upstream `main` with no changes applied, so it is pre-existing and unrelated to this PR. Happy to rebase once it is reconciled.
- One skill per PR; this branch touches only the four files listed above.