### PR TITLE
Add apify-google-flights-tracking skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,21 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-google-flights-tracking",
+      "source": "./skills/apify-google-flights-tracking",
+      "skills": "./",
+      "description": "Build your own fare history for google flights tracking by scheduling the deals feed, with a typical-price baseline attached to every observation.",
+      "keywords": [
+        "apify",
+        "flights",
+        "price-tracking",
+        "travel",
+        "mcp"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-google-flights-tracking/SKILL.md
+++ b/skills/apify-google-flights-tracking/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: apify-google-flights-tracking
+description: Build your own fare history for google flights tracking with the Apify Google Flights Deals API Actor (johnvc/google-flights-deals-api). Run it on a schedule against one or several home airports and every row arrives with the fare, what that route typically costs, the gap between them, exact dates, airline and a booking link, so successive runs accumulate into a price record you own and can query. This is the data layer under a price-alert product, not the alerting itself. The Actor takes a snapshot and keeps no history and sends no notifications, so the repeated observation is yours to store and the notify rule is yours to write, and a baseline in every row means that rule can be below typical instead of a threshold you guessed. Use when the user wants flight price tracking, airfare monitoring, fare data with a reference price, or the source feed behind flight price alerts. Pay per deal returned, MCP-ready for Claude and other AI agents.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# Google Flights Tracking: Your Own Fare History, With a Baseline in Every Row
+
+Schedule the deals feed, store the rows, and you own a fare record where every observation already knows what that route normally costs.
+
+## When to use this skill
+
+- The user wants "flight price tracking" or airfare monitoring from their own data.
+- They are building a price-alert product and need a source feed to sit under it.
+- They want fare data where each row carries a reference price, not just a number.
+- They want to watch several home airports on one schedule.
+
+Not for: a one-shot look at today's bargains (use the companion apify-google-flights-deals skill) or pricing a specific route you have already picked (`johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search`). See `references/actor-index.md`.
+
+## What this does and does not do
+
+An alert is two pieces: a repeated observation, and a rule about when to notify. This Actor is the observation half. It returns a snapshot each run, keeps no history, and sends nothing. You schedule it, you store the rows, and you write the rule. Any copy or agent response that implies this Actor notifies the user is wrong.
+
+The payoff for doing it this way is `average_price`. Because every observation arrives with what that route typically costs, your notify rule can be "below typical" rather than a fixed threshold you guessed at.
+
+## What you get
+
+One dataset row per destination, per run. `result_type` separates `deal` rows from `error` rows:
+
+- `price` and `average_price`, the observation and its reference
+- `savings`, `savings_percent`, `is_below_typical`
+- `route`, `departure_airport_code`, `arrival_airport_code`
+- `outbound_date` and `return_date` for the exact itinerary priced
+- `airline`, `stops`, `flight_duration` in minutes, `flight_link`
+- `name`, `country`, `description`, `thumbnail` for the destination
+
+Key your storage on departure, arrival, and travel date, and add the run timestamp yourself.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/google-flights-deals-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/google-flights-deals-api`
+- Pricing: pay per event; see the cost section below and `references/gotchas.md` for live-price commands.
+
+## Run it with the Apify CLI
+
+One observation across three home airports:
+
+```bash
+apify actors call "johnvc/google-flights-deals-api" -i '{"departureIds":["JFK","EWR","LGA"],"maxDealsPerAirport":30,"currency":"USD"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-flights-tracking \
+  2>/dev/null
+```
+
+Pin the shape you want to track so successive runs stay comparable:
+
+```bash
+apify actors call "johnvc/google-flights-deals-api" -i '{"departureId":"SFO","maxStops":"nonstop","travelClass":"economy","maxDealsPerAirport":30}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-google-flights-tracking \
+  2>/dev/null
+```
+
+Confirm live pricing and the input schema before scheduling a sweep:
+
+```bash
+apify actors info "johnvc/google-flights-deals-api" --json \
+  --user-agent apify-awesome-skills/apify-google-flights-tracking \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-google-flights-tracking`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/google-flights-deals-api`
+
+Then ask, for example: "Take today's reading for my three New York airports and tell me which routes are below their typical price." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Decide the shape you are tracking: airports, cabin, and stops. Keep it fixed so readings stay comparable.
+2. Save it as an Apify task, then attach a schedule. Daily is enough for most fare movement.
+3. Append each run's rows to your own store, keyed on departure, arrival, and travel date, stamped with the run time.
+4. Write the notify rule against `is_below_typical` or a `savings_percent` floor you choose.
+5. Watch `average_price` too, not just `price`. A baseline that drifts down means the route repriced, which is different from a sale.
+
+## Inputs
+
+- `departureId` (string) or `departureIds` (array): the airports you watch
+- `maxDealsPerAirport` (integer, default 30, max 30)
+- `travelClass` (enum `economy`, `premium_economy`, `business`, `first`, default `economy`)
+- `maxStops` (enum `any`, `nonstop`, `one_stop`, `two_stops`, default `any`)
+- `travelDuration` (enum `any`, `one_week`, `weekend`, `two_weeks`, default `any`)
+- `tripType` (enum `round_trip`, `one_way`, default `round_trip`)
+- `outboundDate` / `returnDate` (string): leave blank so the feed keeps finding cheap dates
+- `maxPrice` (integer), `includeAirlines` / `excludeAirlines` (string)
+- `currency` (default `USD`), `hl` (default `en`), `gl` (string)
+
+## Cost
+
+Billing is pay per event, plus a negligible platform fee per dataset row. Prices below are the BRONZE tier at the time of writing; confirm live prices with the info command above.
+
+- About $0.0025 per deal returned.
+- About $0.001 to start a run.
+- One airport at thirty deals is about $0.08 per reading, so roughly $2.30 a month daily.
+- Three airports daily is roughly $7 a month.
+
+Suggested confirmation thresholds: warn the user over about $5; get explicit confirmation over about $20. Present cost as "around $X", never a guarantee. Scheduled tracking is recurring spend, so state the monthly figure, not just the per-run one.
+
+## Honest limits
+
+- No history and no alerts inside the Actor. Both are yours to build, and copy must not claim otherwise.
+- The destination set can change between runs, since it is the cheapest thirty rather than a fixed watchlist. A route can drop out because it got expensive.
+- With dates left blank the itinerary moves between runs, so you are tracking the cheapest available trip, not one fixed departure.
+- `maxDurationMinutes` switches off the baseline and with it `savings` and `is_below_typical`. Never set it on a tracking schedule.
+- Thirty destinations per airport is a hard ceiling.
+
+## Troubleshooting
+
+- A route vanished between runs: it left the cheapest thirty. Treat absence as missing data, not a price of zero.
+- The baseline disappeared: `maxDurationMinutes` is set. Remove it and re-run.
+- Readings look noisy: the itinerary is floating because dates are blank. Pin `outboundDate` if you need one fixed departure.
+- Costs climbing faster than expected: count airports times deals times runs per month before widening a schedule.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Google Flights Data Scraper: https://apify.com/johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Travel Explore API: https://apify.com/johnvc/google-travel-explore-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Hotels Search Scraper: https://apify.com/johnvc/google-hotels-search-scraper?fpr=9n7kx3&fp_sid=awesomeskills
+- Google Maps Photos API: https://apify.com/johnvc/google-maps-photos-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-google-flights-tracking/references/actor-index.md
+++ b/skills/apify-google-flights-tracking/references/actor-index.md
@@ -1,0 +1,23 @@
+# Actor index: Google Flights Deals API
+
+The primary Actor for this skill, plus the Actors worth chaining for adjacent intents. The agent reads this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| Google Flights Deals API | google flights tracking | `johnvc/google-flights-deals-api` | community | Pay per event: `deal_returned` about $0.0025 per destination, `actor_start` about $0.001 per run. Scheduled use is recurring spend. |
+
+## Chain with adjacent Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Price a chosen route | `johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search` | Point to point search when the destination is known. |
+| Destination ideas with hotels | `johnvc/google-travel-explore-api` | Inspiration including nightly hotel prices. |
+| Hotels at the destination | `johnvc/google-hotels-search-scraper` | Hotel search, photos, and reviews. |
+| Imagery of where you land | `johnvc/google-maps-photos-api` | Real photos for places at the destination. |
+
+## How to extend
+
+1. Fetch the input schema: `apify actors info "johnvc/google-flights-deals-api" --input --json --user-agent apify-awesome-skills/apify-google-flights-tracking 2>/dev/null`
+2. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-google-flights-tracking/references/gotchas.md
+++ b/skills/apify-google-flights-tracking/references/gotchas.md
@@ -1,0 +1,48 @@
+# Gotchas: Google Flights Deals API (`johnvc/google-flights-deals-api`)
+
+Cost guardrails, error recovery, and input quirks. The agent reads this on demand when building inputs or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event, plus a platform fee of about $0.00001 per dataset row. Charge events:
+
+- `deal_returned`: about $0.0025 per destination returned (BRONZE tier at the time of writing).
+- `actor_start`: about $0.001 per run.
+
+Confirm the live price before a large batch:
+
+```bash
+apify actors info "johnvc/google-flights-deals-api" --json \
+  --user-agent apify-awesome-skills/apify-google-flights-tracking \
+  2>/dev/null
+```
+
+Worked estimates for this skill:
+
+- One airport at thirty deals is about $0.08 per reading.
+- Daily for a month, one airport, is roughly $2.30.
+- Daily for a month, three airports, is roughly $7. Always quote the monthly figure for a schedule, not the per-run one.
+
+Suggested confirmation thresholds:
+
+- Rough estimate over $5: warn the user.
+- Rough estimate over $20: get explicit confirmation before running.
+- Always present cost as "around $X", not a guarantee.
+
+## Actor-specific notes
+
+- The Actor keeps no history and sends no alerts. Storing the readings and writing the notify rule are the caller's job, and copy must not imply otherwise.
+- `average_price` is what makes the record useful: each observation arrives with its own reference price, so a rule can be 'below typical' rather than a guessed threshold.
+- The destination set changes between runs because it is the cheapest thirty, not a fixed watchlist. A route can drop out because it got expensive; treat absence as missing data, never as a zero.
+- With dates blank the itinerary floats between runs, so you track the cheapest available trip rather than one fixed departure. Pin `outboundDate` if you need a fixed one.
+- Never set `maxDurationMinutes` on a tracking schedule: it removes the baseline and with it the whole point of the record.
+- Keep the input shape fixed across runs, cabin and stops included, or readings stop being comparable.
+- Key stored rows on departure, arrival, and travel date, and stamp the run time yourself; the Actor does not add one.
+
+## Error recovery
+
+- An `error` row explains the failure in plain terms; deals that never arrived are not charged.
+- A gap in the series is usually the route leaving the cheapest thirty, not a failed run. Check the run status before backfilling.
+- Baseline fields missing: `maxDurationMinutes` is set on the task. Remove it and re-run.
+- Transient upstream failures: retry once. A scheduled run that fails is not charged for undelivered rows.
+- Costs climbing faster than expected: count airports times deals times runs per month before widening a schedule.


### PR DESCRIPTION
Adds one skill, `apify-google-flights-tracking`, targeting **google flights tracking**, built on the public Store Actor [`johnvc/google-flights-deals-api`](https://apify.com/johnvc/google-flights-deals-api).

The data layer under a price-alert product. Schedule the feed and each observation arrives with its own reference price, so a notify rule can be 'below typical' instead of a guessed threshold. States explicitly and repeatedly that the Actor keeps no history and sends no alerts; storing readings and writing the rule are the caller's job.

**Contents (4 files):**
- `skills/apify-google-flights-tracking/SKILL.md`
- `skills/apify-google-flights-tracking/references/actor-index.md`
- `skills/apify-google-flights-tracking/references/gotchas.md`
- one new entry in `.claude-plugin/marketplace.json`

**Checks:**
- `bash scripts/lint_telemetry.sh` passes; every `apify` call carries `--user-agent apify-awesome-skills/apify-google-flights-tracking`, `--json`, and `2>/dev/null`.
- `uv run scripts/generate_agents.py` fails on `apify-x402-agentic-wallet` being present in `skills/` but absent from `marketplace.json`. That failure reproduces on a clean checkout of upstream `main` with no changes applied, so it is pre-existing and unrelated to this PR. Happy to rebase once it is reconciled.
- One skill per PR; this branch touches only the four files listed above.