### PR TITLE
Add apify-buying-signal-detection skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -229,6 +229,28 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-buying-signal-detection",
+      "source": "./skills/apify-buying-signal-detection",
+      "skills": "./",
+      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types — job postings, fundraising events, and LinkedIn content — then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture: Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says find companies with buying signals, detect intent signals for outbound, set up a weekly lead pipeline, monitor hiring signals for lead gen, track startup funding leads, find LinkedIn buying signals, schedule Apify Actors for prospecting, build a signals-based lead list, or set up buying-intent monitoring.",
+      "keywords": [
+        "buying-signals",
+        "intent-data",
+        "lead-generation",
+        "outbound",
+        "prospecting",
+        "hiring-signals",
+        "funding-signals",
+        "linkedin-signals",
+        "sales-triggers",
+        "icp",
+        "scheduled-pipeline",
+        "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-buying-signal-detection/.gitignore
+++ b/skills/apify-buying-signal-detection/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/skills/apify-buying-signal-detection/SKILL.md
+++ b/skills/apify-buying-signal-detection/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: apify-buying-signal-detection
+description: Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types — job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) — then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture — Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says "find companies with buying signals", "detect intent signals for outbound", "set up a weekly lead pipeline", "monitor hiring signals for lead gen", "track startup funding leads", "find LinkedIn buying signals", "schedule Apify Actors for prospecting", "build a signals-based lead list", or "set up buying-intent monitoring for my ICP".
+author: Fabian Maume
+author_url: https://github.com/fmaume
+---
+
+# Buying-Signal Detection
+
+Turn an ICP description into a recurring pipeline that surfaces companies showing buying intent across three signal types — job postings, fundraising events, and LinkedIn content — and appends them to a single deduplicated `leads.csv` you can pipe straight into your CRM.
+
+## What this skill does (and what it deliberately does not)
+
+This skill **sets up and runs** a scheduled workflow. It does not draft cold emails, score leads by fit, or push rows into a CRM. Its output is a clean, evidence-linked `leads.csv` — the *input* to whatever outreach process you already have. Cold outreach drafting for these leads is deliberately a separate concern (that's what `apify-link-prospecting-outreach` and similar skills exist for).
+
+Three design commitments worth knowing before you start:
+
+1. **The Apify side and the Claude side run on separate schedules.** Apify runs the Actors on its own cron; Claude runs the aggregation on its own cron. Claude Code doesn't need to be up when the Actors run. This decoupling is what makes the pipeline actually recurring, not just "you have to remember to trigger it."
+2. **Weekly idempotency is enforced at aggregation time.** If the leads CSV already has an entry from the current ISO week, the aggregate script exits early with no HTTP calls made. The Claude-side schedule can fire more often than weekly (safety net) without cost impact.
+3. **First-seen wins on dedup.** A lead surfaced by the jobs signal on Monday stays a jobs-signal lead even if the same company shows up in the funding feed on Wednesday. The signal that first surfaced a company is the more useful one.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+- Python 3.10+ (for `scripts/aggregate.py` and `scripts/setup_apify_tasks.py`; only stdlib is required — `requests` is used when available but has a `urllib` fallback)
+- Optional: a way to trigger the Claude-side aggregation on a schedule — the local `scheduled-tasks` MCP is the recommended path when you're on Claude Code; cron / Task Scheduler / GitHub Actions all work too if you'd rather run it headlessly
+
+## Workflow
+
+Copy this checklist and mark items done:
+
+```
+Task Progress:
+- [ ] Step 1: Collect ICP inputs (block on these)
+- [ ] Step 2: Write icp.json + blacklist.csv (if any)
+- [ ] Step 3: Provision Apify Actor Tasks (setup_apify_tasks.py)
+- [ ] Step 4: Verify Actor picks in the Apify Console
+- [ ] Step 5: Register the Claude-side aggregation schedule
+- [ ] Step 6: First manual run of aggregate.py — sanity check the output
+```
+
+### Step 1: Collect ICP inputs (block on these)
+
+Ask the user for all of the following before writing any file. The setup script needs every field to route correctly, and reworking a scheduled task after it's provisioned means either editing it in the Apify Console or re-running setup — both worse than asking once.
+
+1. **Campaign name** — a short slug (lowercase, dashes). Used as the prefix on every Apify Task name (e.g. `emea-saas-hiring-aes-bebity-linkedin-jobs-scraper`). If the user already runs multiple campaigns, prevent collisions upfront.
+2. **Signals to track** — subset of `["jobs", "funding", "linkedin_content"]`. Rarely will a campaign want only one; the strength of the workflow is the intersection of signals per company. Recommend all three unless there's a specific cost concern.
+3. **Geo (ISO country codes)** — uppercase two-letter codes. Drives regional Actor routing (Stepstone for DE/AT/BE, Seek for AU/NZ, France Travail for FR, Maddyness for FR-funding). Global campaigns should list every country the user actually sells into — passing `["US", "GB", "DE", "FR", "AU"]` will fan out to five regional job Actors, which is 5× the weekly cost. See [`references/gotchas.md`](references/gotchas.md#cost-guardrails).
+4. **Industry keywords** — the category descriptor. Passed to funding trackers as `industry`, to LinkedIn as `keywords` when no explicit content search terms are provided, and to job scrapers as a fallback when no persona titles are given.
+5. **Persona (if jobs signal enabled)** — job titles the ICP hires for. Concrete titles beat categories: `"Account Executive"`, `"SDR"`, `"BDR"` are hits; `"sales"` is noise. Optional seniority (`entry`, `mid`, `senior`, `manager`, `director`, `vp`, `cxo`) and company-size bands (`"11-50"`, etc.) get applied post-hoc in the aggregator.
+6. **Funding config (if funding signal enabled)** — stages (`seed`, `series_a`, `series_b`, etc.) and `max_days_since_announcement` (default 90). Fresh cash → open budget → tighter window is better.
+7. **LinkedIn content config (if linkedin_content signal enabled)** — search phrases. This is the biggest quality lever; broad terms (`"sales"`) waste budget. Specific pain-point phrases beat category names — see [`references/actors.md`](references/actors.md#linkedin-search-phrase-design). Plus `min_reactions` (default 5) and `posted_within_days` (default 14) for post-filtering.
+8. **Where to store leads** — path to a CSV file. Default `./leads.csv` inside the campaign directory. This file is the pipeline's memory across runs; keep it under version control (or at least back it up) so the dedup guard survives disk resets.
+9. **Blacklist CSV path** — optional. CSV with columns `domain,company,reason`. Rows matching either the exact domain or the normalized company name get dropped before append. If the user doesn't have one, ask if they want to start with obvious exclusions (existing customers, their own domain, top competitors).
+10. **Schedule** — `apify_side_cron` (when Apify runs the Actors) and `claude_side_cron` (when Claude aggregates). Default: `0 6 * * 1` (Apify Monday 06:00 UTC) and `0 8 * * 1` (Claude Monday 08:00 UTC). Two hours of buffer between them absorbs slow Actor runs.
+
+The full schema is documented in [`references/icp-config-schema.md`](references/icp-config-schema.md). A worked example lives at [`examples/icp.example.json`](examples/icp.example.json).
+
+### Step 2: Write `icp.json` and `blacklist.csv`
+
+Write the campaign directory contents:
+
+```
+<campaign-dir>/
+  icp.json           ← the config from Step 1
+  blacklist.csv      ← optional; columns: domain,company,reason
+  leads.csv          ← created empty; the aggregator will populate it
+```
+
+Start `leads.csv` with just the header row (schema in [`references/csv-schema.md`](references/csv-schema.md)) so the aggregator doesn't have to handle a missing-file case on first run:
+
+```
+detected_at,company,domain,signal_type,signal_detail,signal_source_actor,signal_date,evidence_url,geo,notes
+```
+
+### Step 3: Provision Apify Actor Tasks
+
+Run the setup script:
+
+```bash
+APIFY_TOKEN=$APIFY_TOKEN \
+python ${CLAUDE_PLUGIN_ROOT}/scripts/setup_apify_tasks.py \
+  --config ./icp.json
+```
+
+What this does:
+- Reads `icp.json` and picks Actors per the routing tables in [`references/actors.md`](references/actors.md) — global Actors always, plus regional Actors matching the geo list.
+- For each pick, upserts an Apify Actor Task named `<campaign>-<actor-slug>` with the input payload derived from the ICP. Re-running the script updates existing tasks in place; it does not create duplicates.
+- Writes a sidecar `<campaign-dir>/.<campaign-name>.tasks.json` recording the task IDs. `aggregate.py` reads this to know which tasks to pull dataset items from.
+- If `schedule.apify_side_cron` is set in the ICP (default is), creates or updates a single Apify Schedule that fires all the tasks on that cron.
+
+Useful flags:
+- `--dry-run` — print the pick list and payloads without making any API calls. Always do this once when authoring a new campaign.
+- `--no-schedule` — provision tasks but skip Schedule creation (useful when you want to trigger runs manually while calibrating).
+
+### Step 4: Verify Actor picks in the Apify Console
+
+Open [console.apify.com/actors/tasks](https://console.apify.com/actors/tasks). Filter by the campaign prefix. Sanity-check three things:
+
+1. **The right Actors were picked** — the regional ones (Stepstone / Seek / France Travail / Maddyness) fire only for the intended geos. If you see Seek but no ANZ country in the ICP, something's off.
+2. **The input payload looks right** — click each task, view its input JSON. Keywords, titles, and stages should be populated from the ICP; nothing should be `null`.
+3. **The Apify Schedule is enabled** — under Schedules, find `<campaign>-schedule`, confirm it's on and lists every task.
+
+If anything looks wrong, edit `icp.json` and re-run `setup_apify_tasks.py` — it's idempotent.
+
+### Step 5: Register the Claude-side aggregation schedule
+
+Register a scheduled task that invokes the aggregator on the campaign's `claude_side_cron`. Pick whichever runner matches your environment:
+
+**Option A — `scheduled-tasks` MCP inside Claude Code.** The MCP exposes `mcp__scheduled-tasks__create_scheduled_task`. The concrete call to make:
+
+```json
+{
+  "name": "<campaign-name>-aggregate",
+  "cron_expression": "<value of schedule.claude_side_cron from icp.json>",
+  "timezone": "UTC",
+  "prompt": "Run the buying-signal aggregator. Execute exactly: python ${CLAUDE_PLUGIN_ROOT}/scripts/aggregate.py --config /abs/path/to/icp.json. Requires APIFY_TOKEN env var. On non-zero exit, surface the stderr in the notification body — do not attempt to reinterpret the error."
+}
+```
+
+Substitute the real values for `<campaign-name>` and `/abs/path/to/icp.json` before making the call. Verify the task landed with `mcp__scheduled-tasks__list_scheduled_tasks` and confirm the cron matches `icp.json`.
+
+**Option B — headless cron / Task Scheduler / CI.** Add a plain OS-level scheduler entry:
+
+```bash
+# Linux crontab entry
+0 8 * * 1 APIFY_TOKEN=$APIFY_TOKEN /path/to/python /path/to/aggregate.py --config /path/to/icp.json >> /path/to/aggregate.log 2>&1
+```
+
+Or a GitHub Actions workflow (`.github/workflows/aggregate.yml`):
+
+```yaml
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+jobs:
+  aggregate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - env: { APIFY_TOKEN: '${{ secrets.APIFY_TOKEN }}' }
+        run: python scripts/aggregate.py --config icp.json
+```
+
+Either runner is safe to invoke more often than weekly — the weekly-idempotency guard skips runs that already have this-week entries. Use `--force` only during calibration.
+
+### Step 6: First manual run of `aggregate.py`
+
+Before waiting for the schedule to fire, run once manually to confirm the wiring. This also seeds `leads.csv` so the week-guard has something to compare against next week:
+
+```bash
+APIFY_TOKEN=$APIFY_TOKEN \
+python ${CLAUDE_PLUGIN_ROOT}/scripts/aggregate.py --config ./icp.json
+```
+
+Expected output shape:
+
+```
+{
+  "summary": {
+    "appended": 47,
+    "fetched_by_signal": {"jobs": 320, "funding": 88, "linkedin_content": 210},
+    "dropped": {"blacklist": 2, "dup_domain": 156, "dup_url": 401, "post_filter": 12, "unmappable": 0}
+  }
+}
+wrote 47 new rows to /abs/path/to/leads.csv
+```
+
+If `fetched_by_signal` is all zeros, either the Apify tasks haven't run yet (check the Console) or the sidecar task registry is missing. Wait for the first Apify run to complete, then rerun.
+
+Use `--dry-run` to see what would be appended without touching the CSV, and `--force` to bypass the weekly guard during calibration.
+
+## Actor routing
+
+The full catalog with per-signal PICK rules lives in [`references/actors.md`](references/actors.md). Condensed summary:
+
+| Signal | Global default | Regional additions |
+|---|---|---|
+| Jobs | `bebity/linkedin-jobs-scraper`, `johnvc/google-jobs-scraper` | Indeed (US/GB/IN/CA), Stepstone (DE/AT/BE), Seek (AU/NZ), France Travail (FR) |
+| Funding | `nexgendata/startup-funding-tracker`, `memo23/crunchbase-scraper`, `complex_intricate_networks/fundraising-and-startup-funding-scraper`, `signalbase/signalbase-api` | Maddyness (FR) |
+| LinkedIn content | `harvestapi/linkedin-post-search` (no cookies, $2/1k posts) | Deep-scrape fallback: `curious_coder/linkedin-post-search-scraper` (cookie required) |
+
+The routing logic in `setup_apify_tasks.py::pick_actors` mirrors this table — if you edit one, edit the other.
+
+## Calling Actors — choose your interface
+
+`setup_apify_tasks.py` uses the Apify REST API directly (no Actor call — it provisions Tasks and Schedules). `aggregate.py` uses the REST API to pull dataset items from the last successful run of each task. If you want to trigger an Actor manually during troubleshooting (e.g. Step 4 verification), use one of these:
+
+### Option A: Apify CLI (recommended for portability)
+
+Three flags on every call (`--json`, `--user-agent`, `2>/dev/null`):
+
+    # Manually trigger one campaign task
+    apify tasks run <task-id> --wait 300 \
+      --json \
+      --user-agent apify-awesome-skills/apify-buying-signal-detection \
+      2>/dev/null
+
+    # List tasks provisioned for this campaign
+    apify tasks list --json 2>/dev/null | \
+      jq '.[] | select(.name | startswith("<campaign-name>-"))'
+
+    # Peek at the latest dataset for a task
+    apify tasks last-run <task-id> --dataset --format json \
+      --user-agent apify-awesome-skills/apify-buying-signal-detection 2>/dev/null
+
+    # Fetch an Actor's input schema (when you're deciding whether to add it to the routing table)
+    apify actors info "<actor-id>" --input --json \
+      --user-agent apify-awesome-skills/apify-buying-signal-detection 2>/dev/null
+
+### Option B: Apify MCP connector
+
+Hosted MCP server at [mcp.apify.com](https://mcp.apify.com). Full docs at [docs.apify.com/platform/integrations/mcp](https://docs.apify.com/platform/integrations/mcp).
+
+### Option C: MCP client of your choice (e.g. `mcpc`)
+
+Standalone CLI client. See [github.com/apify/mcpc](https://github.com/apify/mcpc).
+
+## Troubleshooting
+
+| Error / symptom | What to do |
+|---|---|
+| `APIFY_TOKEN not found` | `export APIFY_TOKEN=$(cat ~/.apify_token)` or add to `.env`. Get one at [console.apify.com/account/integrations](https://console.apify.com/account/integrations). |
+| `no task registry for campaign '<name>'` | You ran `aggregate.py` before `setup_apify_tasks.py`. Run setup first — it writes the sidecar the aggregator needs. |
+| `skipped: already run this week` on a legitimate re-run | Pass `--force`. The guard preserves the week's entries and dedupes on top; it does not overwrite. |
+| Task runs on Apify but `aggregate.py` reports `"fetched_by_signal": {"jobs": 0}` | The Actor ran but returned zero items. Check the Actor's run log for schema errors (wrong keyword format, unsupported country code). Post-fix, run the task manually via `apify tasks run` and re-aggregate. |
+| Tasks provisioned but no data ever lands | The Apify Schedule may be disabled. In the Console, open Schedules → `<campaign>-schedule` and confirm it's enabled. Also check the schedule's cron matches your timezone assumption — schedules are in UTC unless you set `timezone`. |
+| Costs higher than expected | See [`references/gotchas.md#cost-guardrails`](references/gotchas.md#cost-guardrails). Most common cause: broad LinkedIn search terms multiplying `harvestapi/linkedin-post-search` cost. Second-most-common: adding all regional job Actors when the ICP only really sells into two countries. |
+| Reposts inflate LinkedIn signal counts | The aggregator strips `trackingId` and `utm_*` query params to canonicalize URLs before dedup, but LinkedIn's URL scheme changes periodically. If you see the same post appearing twice, check whether the URLs differ only in a param not in the strip list and add it to `strip_tracking()` in `aggregate.py`. |
+| Duplicate leads after a company rebrand | Dedup is `domain`-first. If a company changes domains, the aggregator treats it as a new lead. Manual reconciliation only — no automatic fix. |
+| Multiple machines writing the same `leads.csv` | Not supported. Single-writer assumption. Put the CSV behind a locking layer (Google Sheets export, `flock`, etc.) or partition per machine. |

--- a/skills/apify-buying-signal-detection/SKILL.md
+++ b/skills/apify-buying-signal-detection/SKILL.md
@@ -166,11 +166,18 @@ Expected output shape:
   "summary": {
     "appended": 47,
     "fetched_by_signal": {"jobs": 320, "funding": 88, "linkedin_content": 210},
-    "dropped": {"blacklist": 2, "dup_domain": 156, "dup_url": 401, "post_filter": 12, "unmappable": 0}
+    "dropped": {"blacklist": 2, "dup_domain": 156, "dup_url": 401, "post_filter": 12, "unmappable": 0, "linkedin_no_domain": 8},
+    "linkedin_profile_lookups": 142,
+    "linkedin_profile_resolved": 134
   }
 }
 wrote 47 new rows to /abs/path/to/leads.csv
 ```
+
+The `linkedin_profile_lookups` / `linkedin_profile_resolved` counters report the
+LinkedIn author-domain enrichment pass (see below). `linkedin_no_domain` is the
+number of LinkedIn rows dropped because neither the post nor the profile scraper
+resolved a company domain — those rows cannot be blacklisted or deduped safely.
 
 If `fetched_by_signal` is all zeros, either the Apify tasks haven't run yet (check the Console) or the sidecar task registry is missing. Wait for the first Apify run to complete, then rerun.
 
@@ -185,8 +192,21 @@ The full catalog with per-signal PICK rules lives in [`references/actors.md`](re
 | Jobs | `bebity/linkedin-jobs-scraper`, `johnvc/google-jobs-scraper` | Indeed (US/GB/IN/CA), Stepstone (DE/AT/BE), Seek (AU/NZ), France Travail (FR) |
 | Funding | `nexgendata/startup-funding-tracker`, `memo23/crunchbase-scraper`, `complex_intricate_networks/fundraising-and-startup-funding-scraper`, `signalbase/signalbase-api` | Maddyness (FR) |
 | LinkedIn content | `harvestapi/linkedin-post-search` (no cookies, $2/1k posts) | Deep-scrape fallback: `curious_coder/linkedin-post-search-scraper` (cookie required) |
+| LinkedIn author → company domain (enrichment, called on-demand from `aggregate.py`) | `harvestapi/linkedin-profile-scraper` ($8/1k profiles) | none — profile URL is the primary key |
 
 The routing logic in `setup_apify_tasks.py::pick_actors` mirrors this table — if you edit one, edit the other.
+
+### Why the LinkedIn profile-scraper is called on-demand, not scheduled
+
+`harvestapi/linkedin-post-search` returns the author's name and (sometimes) their current employer as a text label, but rarely returns the employer's website. Without a domain, the aggregator cannot check the blacklist or dedup against previously seen companies for this signal — meaning blacklisted competitors could slip in via LinkedIn posts.
+
+To fix this, `aggregate.py` runs a second Actor call after the post pull: `harvestapi/linkedin-profile-scraper` is fed the deduplicated set of author profile URLs whose post rows came back without a domain. The returned current-company website is normalized to a domain and joined back onto the row before blacklist and dedup run.
+
+This is the only place the aggregator calls an Actor synchronously (all other data comes from pre-scheduled Task runs). It's the deliberate exception because the profile enrichment input (a list of author profile URLs) can only be known *after* the post scraper's dataset is read.
+
+**Cost.** Profile scraping is roughly 4× more expensive per row than post scraping ($8/1k vs $2/1k). Two knobs to keep it bounded:
+- Deduplication on author profile URL — N posts by the same author cost one lookup
+- The pass is skipped entirely when every LinkedIn row already has a domain
 
 ## Calling Actors — choose your interface
 

--- a/skills/apify-buying-signal-detection/SKILL.md
+++ b/skills/apify-buying-signal-detection/SKILL.md
@@ -168,16 +168,20 @@ Expected output shape:
     "fetched_by_signal": {"jobs": 320, "funding": 88, "linkedin_content": 210},
     "dropped": {"blacklist": 2, "dup_domain": 156, "dup_url": 401, "post_filter": 12, "unmappable": 0, "linkedin_no_domain": 8},
     "linkedin_profile_lookups": 142,
-    "linkedin_profile_resolved": 134
+    "linkedin_profile_resolved": 134,
+    "linkedin_company_lookups": 118,
+    "linkedin_company_resolved": 112,
+    "linkedin_domain_resolved": 128
   }
 }
 wrote 47 new rows to /abs/path/to/leads.csv
 ```
 
-The `linkedin_profile_lookups` / `linkedin_profile_resolved` counters report the
-LinkedIn author-domain enrichment pass (see below). `linkedin_no_domain` is the
-number of LinkedIn rows dropped because neither the post nor the profile scraper
-resolved a company domain — those rows cannot be blacklisted or deduped safely.
+The `linkedin_*_lookups` / `linkedin_*_resolved` counters report each hop of
+the LinkedIn author-domain enrichment chain (see below). `linkedin_domain_resolved`
+is the count of LinkedIn rows whose `domain` column was successfully filled in.
+`linkedin_no_domain` is the number of LinkedIn rows dropped because the chain
+couldn't resolve a domain — those rows cannot be blacklisted or deduped safely.
 
 If `fetched_by_signal` is all zeros, either the Apify tasks haven't run yet (check the Console) or the sidecar task registry is missing. Wait for the first Apify run to complete, then rerun.
 
@@ -192,21 +196,30 @@ The full catalog with per-signal PICK rules lives in [`references/actors.md`](re
 | Jobs | `bebity/linkedin-jobs-scraper`, `johnvc/google-jobs-scraper` | Indeed (US/GB/IN/CA), Stepstone (DE/AT/BE), Seek (AU/NZ), France Travail (FR) |
 | Funding | `nexgendata/startup-funding-tracker`, `memo23/crunchbase-scraper`, `complex_intricate_networks/fundraising-and-startup-funding-scraper`, `signalbase/signalbase-api` | Maddyness (FR) |
 | LinkedIn content | `harvestapi/linkedin-post-search` (no cookies, $2/1k posts) | Deep-scrape fallback: `curious_coder/linkedin-post-search-scraper` (cookie required) |
-| LinkedIn author → company domain (enrichment, called on-demand from `aggregate.py`) | `harvestapi/linkedin-profile-scraper` ($8/1k profiles) | none — profile URL is the primary key |
+| LinkedIn author → company domain (enrichment, called on-demand from `aggregate.py`) | `harvestapi/linkedin-profile-scraper` ($4/1k profiles) **+** `harvestapi/linkedin-company` (per-lookup) — two hops | none — profile URL and company LinkedIn URL are the primary keys |
 
 The routing logic in `setup_apify_tasks.py::pick_actors` mirrors this table — if you edit one, edit the other.
 
-### Why the LinkedIn profile-scraper is called on-demand, not scheduled
+### Why the LinkedIn enrichment runs on-demand, not scheduled — and why it's a two-hop chain
 
-`harvestapi/linkedin-post-search` returns the author's name and (sometimes) their current employer as a text label, but rarely returns the employer's website. Without a domain, the aggregator cannot check the blacklist or dedup against previously seen companies for this signal — meaning blacklisted competitors could slip in via LinkedIn posts.
+`harvestapi/linkedin-post-search` returns the author's name and headline but not the employer's website. Without a domain, the aggregator cannot check the blacklist or dedup against previously seen companies for this signal — meaning blacklisted competitors could slip in via LinkedIn posts.
 
-To fix this, `aggregate.py` runs a second Actor call after the post pull: `harvestapi/linkedin-profile-scraper` is fed the deduplicated set of author profile URLs whose post rows came back without a domain. The returned current-company website is normalized to a domain and joined back onto the row before blacklist and dedup run.
+Resolving that domain takes **two additional Actor calls**, chained inside `aggregate.py::enrich_linkedin_domains`:
 
-This is the only place the aggregator calls an Actor synchronously (all other data comes from pre-scheduled Task runs). It's the deliberate exception because the profile enrichment input (a list of author profile URLs) can only be known *after* the post scraper's dataset is read.
+1. **`harvestapi/linkedin-profile-scraper`** on the deduplicated set of author profile URLs whose post rows came back without a domain. Returns `currentPosition[0].companyLinkedinUrl` and `companyName` — but *not* the company website. Input: `{profileScraperMode: "Profile details no email ($4 per 1k)", urls: [...]}`.
+2. **`harvestapi/linkedin-company`** on the deduplicated set of company LinkedIn URLs returned by step 1. Returns `website`. Input: `{companies: [...]}`.
 
-**Cost.** Profile scraping is roughly 4× more expensive per row than post scraping ($8/1k vs $2/1k). Two knobs to keep it bounded:
-- Deduplication on author profile URL — N posts by the same author cost one lookup
-- The pass is skipped entirely when every LinkedIn row already has a domain
+The chain is the aggregator's only synchronous Actor call path — all other data comes from pre-scheduled Task runs. It's the deliberate exception because both enrichment inputs (author profile URLs, then company URLs) can only be known *after* the previous hop's dataset is read.
+
+**Cost.**
+- Profile scraping: $4 per 1000 profiles (chose the "no email" tier — email lookup isn't needed for domain resolution)
+- Company scraping: pay-per-event on `harvestapi/linkedin-company`
+- Combined effect: for a campaign of 500 LinkedIn posts averaging 3 posts/author, expect ~170 profile lookups + ~150 company lookups (many authors work at the same company)
+
+Three knobs bound the cost:
+- Canonical profile URL dedup — N posts by the same author cost one profile lookup (`canonical_linkedin_profile_url` strips `?miniProfileUrn=…` so the same author across sample posts collapses to one key)
+- Company-URL dedup at the company-scraper hop — N authors at the same company cost one company lookup
+- The whole pass is skipped entirely when every LinkedIn row already has a domain
 
 ## Calling Actors — choose your interface
 

--- a/skills/apify-buying-signal-detection/examples/blacklist.example.csv
+++ b/skills/apify-buying-signal-detection/examples/blacklist.example.csv
@@ -1,0 +1,6 @@
+domain,company,reason
+salesforce.com,Salesforce,too big to sell to
+hubspot.com,HubSpot,competitor
+apollo.io,Apollo,competitor
+outreach.io,Outreach,competitor
+example.com,Example Corp,customer already

--- a/skills/apify-buying-signal-detection/examples/icp.example.json
+++ b/skills/apify-buying-signal-detection/examples/icp.example.json
@@ -1,0 +1,36 @@
+{
+  "campaign_name": "eu-saas-hiring-aes",
+  "leads_csv": "./leads.csv",
+  "blacklist_csv": "./blacklist.csv",
+  "signals": ["jobs", "funding", "linkedin_content"],
+  "geo": ["FR", "DE", "BE"],
+  "industry_keywords": [
+    "b2b saas",
+    "sales enablement",
+    "revenue operations"
+  ],
+  "persona": {
+    "titles": ["Account Executive", "SDR", "BDR", "Sales Development"],
+    "seniority": ["mid", "senior"],
+    "company_size": ["11-50", "51-200", "201-500"]
+  },
+  "funding": {
+    "stages": ["seed", "series_a", "series_b"],
+    "max_days_since_announcement": 60
+  },
+  "linkedin_content": {
+    "search_terms": [
+      "we are hiring account executives",
+      "growing our sales team",
+      "cold email is broken",
+      "outbound is dead"
+    ],
+    "min_reactions": 20,
+    "posted_within_days": 14
+  },
+  "schedule": {
+    "apify_side_cron": "0 6 * * 1",
+    "claude_side_cron": "0 8 * * 1",
+    "note": "Apify runs first on Monday 06:00 UTC, Claude aggregates on Monday 08:00 UTC."
+  }
+}

--- a/skills/apify-buying-signal-detection/examples/leads.example.csv
+++ b/skills/apify-buying-signal-detection/examples/leads.example.csv
@@ -1,0 +1,4 @@
+detected_at,company,domain,signal_type,signal_detail,signal_source_actor,signal_date,evidence_url,geo,notes
+2026-08-04T08:12:03Z,Alpha Analytics,alpha-analytics.io,jobs,Hiring 3x Account Executive - EMEA,bebity/linkedin-jobs-scraper,2026-08-01,https://linkedin.com/jobs/view/123456,FR,
+2026-08-04T08:12:03Z,BetaOps,betaops.com,funding,Raised $12M Series A led by Accel,nexgendata/startup-funding-tracker,2026-07-30,https://techcrunch.com/2026/07/30/betaops-series-a/,DE,
+2026-08-04T08:12:03Z,Gamma Cloud,gamma.cloud,linkedin_content,"Post: ""growing our sales team from 3 to 15 - if outbound is broken send help""",harvestapi/linkedin-post-search,2026-08-02,https://linkedin.com/posts/gamma-cloud_activity-789,BE,

--- a/skills/apify-buying-signal-detection/references/actors.md
+++ b/skills/apify-buying-signal-detection/references/actors.md
@@ -96,40 +96,53 @@ not a qualified lead. Filter aggressively via `min_reactions` and human review.
 | `harvestapi/linkedin-post-search` | PPE, $2/1k posts | **Primary** — no cookies, well-adopted | No |
 | `harvestapi/linkedin-post-comments` | PPE | Deep engagement — pull comment threads on a specific post URL | No |
 | `harvestapi/linkedin-post-reactions` | PPE | Deep engagement — pull who reacted to a specific post URL | No |
-| `harvestapi/linkedin-profile-scraper` | PPE, ~$8/1k profiles | **On-demand enrichment** — called from `aggregate.py` when a post row has no company domain. Not scheduled as a Task. | No |
+| `harvestapi/linkedin-profile-scraper` | PPE, $4/1k profiles ("no email" mode) | **On-demand enrichment hop 1** — called from `aggregate.py` to resolve author → `currentPosition[0].companyLinkedinUrl`. Not scheduled as a Task. | No |
+| `harvestapi/linkedin-company` | PPE | **On-demand enrichment hop 2** — called from `aggregate.py` on the company LinkedIn URLs returned by hop 1 to pull `website`. Not scheduled as a Task. | No |
 
 ### PICK — LinkedIn content
 
 ```
 Always include:  harvestapi/linkedin-post-search
 Called on-demand by aggregate.py (not a scheduled Task):
-                 harvestapi/linkedin-profile-scraper
+                 harvestapi/linkedin-profile-scraper  (hop 1 — author → companyLinkedinUrl)
+                 harvestapi/linkedin-company          (hop 2 — companyLinkedinUrl → website)
 ```
 
-### Why the profile scraper is on-demand, not scheduled
+### Why the enrichment chain is on-demand, and why it's TWO hops
 
-`harvestapi/linkedin-post-search` returns author identity but rarely returns
-the author's current-company website. Without a domain, the aggregator cannot
-check the blacklist or dedup against existing leads for the `linkedin_content`
-signal. `aggregate.py::enrich_linkedin_domains` closes this gap: after the
-post-scraper items are read, it collects the deduped set of author profile
-URLs that came back without a domain and calls the profile scraper
-synchronously via `run-sync-get-dataset-items`.
+`harvestapi/linkedin-post-search` returns author identity but not the author's
+current-company website. Without a domain, the aggregator cannot check the
+blacklist or dedup against existing leads for the `linkedin_content` signal.
 
-Input shape used:
+`aggregate.py::enrich_linkedin_domains` closes this gap with a two-hop chain
+verified against live Actor output (2026-08):
+
+**Hop 1 — `harvestapi/linkedin-profile-scraper`.** Input:
 
 ```json
 {
-  "profileScraperMode": "Full",
-  "queries": ["https://www.linkedin.com/in/example", ...]
+  "profileScraperMode": "Profile details no email ($4 per 1k)",
+  "urls": ["https://www.linkedin.com/in/example", "..."]
 }
 ```
 
-The mapper joins the returned `currentCompanyWebsite` / `currentCompany.url`
-(with a fallback to the most-recent `experience` entry lacking an `endDate`)
-back onto the row. A LinkedIn row that survives both scrapers without a
-domain is dropped with the `linkedin_no_domain` audit bucket — the
-alternative is silently letting blacklisted companies leak in.
+`profileScraperMode` is an *enum literal* — the exact string `"Profile details no email ($4 per 1k)"` is required; guesses like `"Full"` or `"Short"` return a 400. The scraper returns `currentPosition[0].companyLinkedinUrl` + `companyName` but **not** a company website — that's why hop 2 is needed.
+
+Deduplicate profile URLs before the call: harvestapi's post output puts the profile URL with a `?miniProfileUrn=…` query that varies per sample, so `canonical_linkedin_profile_url()` strips it and prefers `author.publicIdentifier` when present, collapsing N samples of the same author into a single lookup key.
+
+**Hop 2 — `harvestapi/linkedin-company`.** Input:
+
+```json
+{ "companies": ["https://www.linkedin.com/company/example/", "..."] }
+```
+
+Returns `website` (and firmographic data we don't use here). Deduplicate on the LinkedIn company URL — N authors at the same company cost one company lookup.
+
+The final mapper joins the row's `_author_profile_url` → `companyLinkedinUrl` (hop 1) → `website` (hop 2) → `normalize_domain(website)`, then writes back into `row.domain` before blacklist/dedup run.
+
+A LinkedIn row that survives the chain without a domain is dropped into the
+`linkedin_no_domain` audit bucket — the alternative is silently letting
+blacklisted companies leak in.
 
 For deeper engagement analysis (mining reply chains for buying-intent quotes,
 identifying who engaged with a competitor's post), chain
@@ -160,7 +173,7 @@ table:
 | CSV column | Job Actors | Funding Actors | LinkedIn content Actors |
 |---|---|---|---|
 | `company` | `companyName` / `company` / `company.name` | `companyName` / `startupName` | Post author's `authorName` (or nested `author.name`) when it's a company page; else the author's employer |
-| `domain` | `companyDomain` / `companyWebsite` when present | `companyDomain` / `companyUrl` / `companyWebsite` | `authorCompanyDomain` / `author.company.domain` from post scraper — usually empty; **backfilled by `harvestapi/linkedin-profile-scraper` on the author's profile URL** (`currentCompanyWebsite` / `currentCompany.url` / current `experience` entry) |
+| `domain` | `companyDomain` / `companyWebsite` when present | `companyDomain` / `companyUrl` / `companyWebsite` | Post scraper doesn't return one. **Two-hop backfill**: (1) `harvestapi/linkedin-profile-scraper` on the author URL → `currentPosition[0].companyLinkedinUrl`, then (2) `harvestapi/linkedin-company` on that URL → `website`. See [enrichment chain](#why-the-enrichment-chain-is-on-demand-and-why-its-two-hops). |
 | `signal_type` | `"jobs"` | `"funding"` | `"linkedin_content"` |
 | `signal_detail` | `f"Job: {title}"` | `f"Raised {amount} {stage} led by {lead_investor}"` | `f"Post: '{first_120_chars}'"` |
 | `signal_source_actor` | Actor ID that produced the row | ditto | ditto |

--- a/skills/apify-buying-signal-detection/references/actors.md
+++ b/skills/apify-buying-signal-detection/references/actors.md
@@ -1,0 +1,166 @@
+# Actor catalog
+
+Full routing table for every signal × geo combination. `setup_apify_tasks.py`
+reads this list conceptually — the actual selection lives in the `PICK` blocks
+below, which the setup script mirrors in code. When adding an Actor, update
+both.
+
+## Table of contents
+
+- [Jobs signals](#jobs-signals)
+- [Funding signals](#funding-signals)
+- [LinkedIn content signals](#linkedin-content-signals)
+- [How the aggregator normalizes across Actors](#how-the-aggregator-normalizes-across-actors)
+
+## Jobs signals
+
+Job postings are a strong hiring signal — a company posting 3+ AE roles in a
+month is expanding sales. The trick is **geo coverage**: LinkedIn is global but
+gets rate-limited; job boards are hyper-regional. Always fan out to a global
+Actor + the regional Actor(s) for the campaign's geo list.
+
+Every Actor in the routing table below is **pay-per-event (PPE)** — no monthly rental,
+no upfront fees, you pay only for results returned. Rental Actors are deliberately
+excluded (see [Rejected: rental Actors](#rejected-rental-actors) at the bottom).
+
+| Actor ID | Pricing (Free tier) | Best for | Cookies? |
+|---|---|---|---|
+| `lntb/linkedin-jobs-scraper---multiple-titles-locations-in-one` | PPE, $1/1k results | Global LinkedIn jobs — **accepts arrays of titles + locations in one call** | No |
+| `curious_coder/linkedin-jobs-scraper` | PPE, $2/1k results | Global LinkedIn jobs — richer per-posting detail (description, apply URL) | Yes |
+| `johnvc/Google-Jobs-Scraper` | PPE | Anywhere Google Jobs aggregates results (broadest fallback). Single-string `query`, lowercase `country` code (`us`/`uk`/`ca`/`de`/`fr`/`au`/`jp`/`in`/`br`/`mx`) | No |
+| `borderline/indeed-scraper` | PPE | US / UK / IN / CA — Indeed's core markets. Single-string `query`, lowercase `country` (`us`/`uk`/`ca`/`in`) | No |
+| `memo23/stepstone-search-cheerio-ppr` | PPE | DE / AT / BE — Stepstone dominates German-language markets | No |
+| `blackfalcondata/seek-scraper` | PPE | AU / NZ — Seek dominates ANZ | No |
+| `dltik/francetravail-scraper` | PPE | FR — France Travail (ex Pôle Emploi) — official French labor listings | No |
+
+### PICK — jobs
+
+```
+Always include:  lntb/linkedin-jobs-scraper---multiple-titles-locations-in-one
+                 + johnvc/Google-Jobs-Scraper
+If any geo is US, UK, IN, CA:   add borderline/indeed-scraper
+If any geo is DE, AT, BE:       add memo23/stepstone-search-cheerio-ppr
+If any geo is AU, NZ:           add blackfalcondata/seek-scraper
+If any geo is FR:               add dltik/francetravail-scraper
+```
+
+Use `curious_coder/linkedin-jobs-scraper` **in addition to** `lntb/...` only when
+the campaign needs per-posting detail (job description text, application URL) —
+e.g. for buyer research beyond mere headcount signals. It's slower, costs 2× per
+result, and requires a `LI_AT` cookie in the Actor input.
+
+**Slug case matters.** `johnvc/Google-Jobs-Scraper` is capitalized as shown; the
+lowercase variant is a different (nonexistent) actor and the API returns 400 on
+task creation.
+
+**Country codes for `johnvc/Google-Jobs-Scraper` and `borderline/indeed-scraper`
+are lowercase, and `GB` → `uk`.** The setup script handles this mapping.
+
+## Funding signals
+
+Funding events fire a short-lived buying window (typically 60–90 days after
+announcement — cash is fresh, team is scaling, tooling budget is open).
+
+| Actor ID | Pricing | Best for |
+|---|---|---|
+| `nexgendata/startup-funding-tracker` | PPE | Global default. Broad coverage, weekly refresh. |
+| `complex_intricate_networks/fundraising-and-startup-funding-scraper` | PPE | Secondary global — different upstream sources; dedup catches overlap. |
+| `signalbase/signalbase-api` | PPE | API-style Actor pulling from Signalbase's curated feed. Fewer false positives; smaller volume. |
+| `memo23/crunchbase-scraper` | PPE | Crunchbase authoritative deals — best for ground-truth stage / amount / lead investor. |
+| `johnvc/crunchbase-company-api` | PPE | Enrichment — given a company name, pull firmographic + historical funding rounds. Not a discovery Actor. |
+| `advantageous_subcontra/maddyness-french-startup-fundraising-database` | PPE | FR-only, Maddyness feed. Highest coverage on French deals. |
+
+### PICK — funding
+
+```
+Always include:  nexgendata/startup-funding-tracker
+                 + memo23/crunchbase-scraper
+Add for global depth:  complex_intricate_networks/fundraising-and-startup-funding-scraper
+Add for curated volume:  signalbase/signalbase-api
+If any geo is FR:  add advantageous_subcontra/maddyness-french-startup-fundraising-database
+```
+
+`johnvc/crunchbase-company-api` is intentionally **not** in the pick list — it's
+an enrichment Actor called on-demand from `aggregate.py` when a row surfaces
+without a stage/amount and the user wants that data filled in. Don't schedule it
+in the weekly run.
+
+## LinkedIn content signals
+
+The noisiest signal type by design. Companies (and their execs) posting about
+hiring, tool pain, or scaling are *inspiration* — a starting point for research,
+not a qualified lead. Filter aggressively via `min_reactions` and human review.
+
+| Actor ID | Pricing | Best for | Cookies? |
+|---|---|---|---|
+| `harvestapi/linkedin-post-search` | PPE, $2/1k posts | **Primary** — no cookies, well-adopted | No |
+| `harvestapi/linkedin-post-comments` | PPE | Deep engagement — pull comment threads on a specific post URL | No |
+| `harvestapi/linkedin-post-reactions` | PPE | Deep engagement — pull who reacted to a specific post URL | No |
+
+### PICK — LinkedIn content
+
+```
+Always include:  harvestapi/linkedin-post-search
+```
+
+For deeper engagement analysis (mining reply chains for buying-intent quotes,
+identifying who engaged with a competitor's post), chain
+`harvestapi/linkedin-post-comments` or `harvestapi/linkedin-post-reactions` on
+the URLs returned by the primary search. Both are PPE, no cookies required.
+
+### LinkedIn search phrase design
+
+The Actor takes free-form `keywords`. Broad terms (`sales`, `hiring`) return
+mostly noise. Effective phrases fall into three patterns:
+
+1. **Hiring-scale-out phrases** — `"growing our sales team"`,
+   `"we're hiring account executives"`, `"scaling from X to Y"`.
+2. **Pain-point complaints** — `"cold email is broken"`, `"outbound is dead"`,
+   `"our CRM is a mess"`. Anti-competitor complaints for a specific tool are
+   gold: `"leaving <competitor>"`, `"switching from <competitor>"`.
+3. **Milestone announcements** — `"just closed our series a"`,
+   `"launched today"`, `"acquired by"`.
+
+Combine 3–5 per campaign; the aggregator merges results and dedupes by URL.
+
+## How the aggregator normalizes across Actors
+
+Every Actor's schema is slightly different — `aggregate.py` maps each into the
+common `leads.csv` row shape ([`csv-schema.md`](./csv-schema.md)). The mapping
+table:
+
+| CSV column | Job Actors | Funding Actors | LinkedIn content Actors |
+|---|---|---|---|
+| `company` | `companyName` / `company` / `company.name` | `companyName` / `startupName` | Post author's `authorName` (or nested `author.name`) when it's a company page; else the author's employer |
+| `domain` | `companyDomain` / `companyWebsite` when present | `companyDomain` / `companyUrl` / `companyWebsite` | `authorCompanyDomain` / `author.company.domain` — often empty for personal posts |
+| `signal_type` | `"jobs"` | `"funding"` | `"linkedin_content"` |
+| `signal_detail` | `f"Job: {title}"` | `f"Raised {amount} {stage} led by {lead_investor}"` | `f"Post: '{first_120_chars}'"` |
+| `signal_source_actor` | Actor ID that produced the row | ditto | ditto |
+| `signal_date` | `postedDate` / `datePosted` | `announcementDate` / `roundDate` | `postedAt` |
+| `evidence_url` | `jobUrl` / `applyUrl` / `postingUrl` | `sourceUrl` / `articleUrl` | `postUrl` |
+| `geo` | `locationCountry` / derived from `location` string | `hqCountry` / `location` | Post `author.location` when present |
+
+When an Actor returns a field the mapping table doesn't cover, add a mapping
+line in `aggregate.py` and record the new field name here.
+
+## Rejected: rental Actors
+
+Every Actor below is functional, but its pricing model is
+`FLAT_PRICE_PER_MONTH` (rental). A weekly buying-signal pipeline can be run for
+$5-20/month total on PPE Actors — adding even one rental Actor at $20-30/month
+dominates the budget and eliminates the free-tier viability of the pipeline. If
+you have a specific reason to use one anyway (deeper feature set, higher volume
+cap, no per-event overhead at scale), swap it in your own campaign; do not add
+it to the default routing table.
+
+| Actor ID | Rental fee | Trial | Replaced by |
+|---|---|---|---|
+| `bebity/linkedin-jobs-scraper` | $29.99/mo | 72h | `lntb/linkedin-jobs-scraper---multiple-titles-locations-in-one` |
+| `curious_coder/indeed-scraper` | $20/mo | 24h | `borderline/indeed-scraper` |
+| `tech_gear/company-funding-details` | $19/mo (**FULL_PERMISSIONS**) | 2h | `johnvc/crunchbase-company-api` |
+| `curious_coder/linkedin-post-search-scraper` | $30/mo | 72h | `harvestapi/linkedin-post-search` (already the primary) |
+
+`tech_gear/company-funding-details` also carries `actorPermissionLevel:
+FULL_PERMISSIONS`, meaning it requests broader access to the caller's account
+than a standard sandboxed Actor. Prefer the PPE Crunchbase alternative on both
+grounds.

--- a/skills/apify-buying-signal-detection/references/actors.md
+++ b/skills/apify-buying-signal-detection/references/actors.md
@@ -96,12 +96,40 @@ not a qualified lead. Filter aggressively via `min_reactions` and human review.
 | `harvestapi/linkedin-post-search` | PPE, $2/1k posts | **Primary** — no cookies, well-adopted | No |
 | `harvestapi/linkedin-post-comments` | PPE | Deep engagement — pull comment threads on a specific post URL | No |
 | `harvestapi/linkedin-post-reactions` | PPE | Deep engagement — pull who reacted to a specific post URL | No |
+| `harvestapi/linkedin-profile-scraper` | PPE, ~$8/1k profiles | **On-demand enrichment** — called from `aggregate.py` when a post row has no company domain. Not scheduled as a Task. | No |
 
 ### PICK — LinkedIn content
 
 ```
 Always include:  harvestapi/linkedin-post-search
+Called on-demand by aggregate.py (not a scheduled Task):
+                 harvestapi/linkedin-profile-scraper
 ```
+
+### Why the profile scraper is on-demand, not scheduled
+
+`harvestapi/linkedin-post-search` returns author identity but rarely returns
+the author's current-company website. Without a domain, the aggregator cannot
+check the blacklist or dedup against existing leads for the `linkedin_content`
+signal. `aggregate.py::enrich_linkedin_domains` closes this gap: after the
+post-scraper items are read, it collects the deduped set of author profile
+URLs that came back without a domain and calls the profile scraper
+synchronously via `run-sync-get-dataset-items`.
+
+Input shape used:
+
+```json
+{
+  "profileScraperMode": "Full",
+  "queries": ["https://www.linkedin.com/in/example", ...]
+}
+```
+
+The mapper joins the returned `currentCompanyWebsite` / `currentCompany.url`
+(with a fallback to the most-recent `experience` entry lacking an `endDate`)
+back onto the row. A LinkedIn row that survives both scrapers without a
+domain is dropped with the `linkedin_no_domain` audit bucket — the
+alternative is silently letting blacklisted companies leak in.
 
 For deeper engagement analysis (mining reply chains for buying-intent quotes,
 identifying who engaged with a competitor's post), chain
@@ -132,7 +160,7 @@ table:
 | CSV column | Job Actors | Funding Actors | LinkedIn content Actors |
 |---|---|---|---|
 | `company` | `companyName` / `company` / `company.name` | `companyName` / `startupName` | Post author's `authorName` (or nested `author.name`) when it's a company page; else the author's employer |
-| `domain` | `companyDomain` / `companyWebsite` when present | `companyDomain` / `companyUrl` / `companyWebsite` | `authorCompanyDomain` / `author.company.domain` — often empty for personal posts |
+| `domain` | `companyDomain` / `companyWebsite` when present | `companyDomain` / `companyUrl` / `companyWebsite` | `authorCompanyDomain` / `author.company.domain` from post scraper — usually empty; **backfilled by `harvestapi/linkedin-profile-scraper` on the author's profile URL** (`currentCompanyWebsite` / `currentCompany.url` / current `experience` entry) |
 | `signal_type` | `"jobs"` | `"funding"` | `"linkedin_content"` |
 | `signal_detail` | `f"Job: {title}"` | `f"Raised {amount} {stage} led by {lead_investor}"` | `f"Post: '{first_120_chars}'"` |
 | `signal_source_actor` | Actor ID that produced the row | ditto | ditto |

--- a/skills/apify-buying-signal-detection/references/csv-schema.md
+++ b/skills/apify-buying-signal-detection/references/csv-schema.md
@@ -1,0 +1,51 @@
+# `leads.csv` column contract
+
+The aggregate script appends new rows to this file. All columns are strings; empty
+cells are `""`, never `null`. The file is a plain CSV with a header row.
+
+| Column | Type | Notes |
+|---|---|---|
+| `detected_at` | ISO 8601 UTC timestamp | When `aggregate.py` wrote this row. Also the idempotency key — the aggregator checks the max `detected_at` and skips if within the current ISO week. |
+| `company` | string | Company name as returned by the Actor. Lightly normalized (trailing `Inc`/`Ltd` kept, whitespace collapsed). |
+| `domain` | string (lowercased) | Primary dedup key. Sourced from Actor output; falls back to the company website URL if the Actor returns a URL instead of a bare domain. Empty when the Actor returned no domain (rare — always for LinkedIn posts by a person, not a company page). |
+| `signal_type` | enum | One of `jobs`, `funding`, `linkedin_content`. |
+| `signal_detail` | string | One-line human-readable signal summary. Examples: `"Hiring 3x Account Executive - EMEA"`, `"Raised $12M Series A led by Accel"`, `"Post: 'outbound is broken'"`. Free-form; the aggregator generates it per signal type. |
+| `signal_source_actor` | string | Apify Actor ID that produced this row (e.g. `bebity/linkedin-jobs-scraper`). Lets you trace back to the source dataset. |
+| `signal_date` | ISO 8601 date | Date the signal event happened (post publish date, funding announcement date, job posting date). May be empty if the Actor doesn't expose it — post-filters that depend on recency (`max_days_since_announcement`, `posted_within_days`) skip rows with empty dates so nothing false-positive gets through. |
+| `evidence_url` | URL | Direct link to the source page (LinkedIn post URL, TechCrunch article, job listing). Non-empty when the Actor exposes a URL — required for the row to be considered valid. |
+| `geo` | ISO 3166-1 alpha-2 or empty | Best-effort country tag. Empty when the Actor doesn't expose country. |
+| `notes` | string | Aggregator scratch column — currently used for `"seniority mismatch (post-filtered)"` audit notes and blacklist near-miss warnings. |
+
+## Dedup rules
+
+Order of precedence when a new row collides with an existing row:
+
+1. **Identical `domain`**: existing row wins (first-seen is preserved). The incoming
+   row is dropped. The signal that first surfaced this lead stays authoritative — a
+   later, weaker signal shouldn't overwrite it.
+2. **Identical normalized `company`, different `domain`**: both rows kept. Different
+   domains for the same brand name are almost always different entities (subsidiaries,
+   regional offices, or unrelated companies that happen to share a name).
+3. **Identical `evidence_url`**: dropped as a re-scrape of the same source. Guards
+   against the same Actor run being aggregated twice.
+
+Normalization for company-name comparison: lowercase, strip punctuation, collapse
+whitespace, drop trailing corporate suffixes (`inc`, `ltd`, `gmbh`, `sa`, `sarl`, `bv`, `llc`).
+
+## Blacklist matching
+
+Blacklist rows check both `domain` and normalized `company`. Domain match is exact
+(`sub.example.com` won't match a blacklist entry of `example.com` — add both if you
+want subdomain coverage). Company match uses the same normalization as dedup.
+
+## Weekly idempotency
+
+Before pulling new data, `aggregate.py` reads the CSV's max `detected_at`. If it
+falls in the current ISO week (Monday 00:00 UTC through Sunday 23:59 UTC), the
+script exits with `"skipped: already run this week"` and no HTTP calls are made.
+This lets you set the Claude-side schedule to fire more often than weekly (safety
+net for missed runs) without cost impact.
+
+## Full example
+
+See [`examples/leads.example.csv`](../examples/leads.example.csv).

--- a/skills/apify-buying-signal-detection/references/csv-schema.md
+++ b/skills/apify-buying-signal-detection/references/csv-schema.md
@@ -7,7 +7,7 @@ cells are `""`, never `null`. The file is a plain CSV with a header row.
 |---|---|---|
 | `detected_at` | ISO 8601 UTC timestamp | When `aggregate.py` wrote this row. Also the idempotency key — the aggregator checks the max `detected_at` and skips if within the current ISO week. |
 | `company` | string | Company name as returned by the Actor. Lightly normalized (trailing `Inc`/`Ltd` kept, whitespace collapsed). |
-| `domain` | string (lowercased) | Primary dedup key. Sourced from Actor output; falls back to the company website URL if the Actor returns a URL instead of a bare domain. Empty when the Actor returned no domain (rare — always for LinkedIn posts by a person, not a company page). |
+| `domain` | string (lowercased) | Primary dedup key, and only ever the company's *own* domain. Sourced from Actor output; falls back to the company website URL if the Actor returns a URL instead of a bare domain. Job boards and social networks (`linkedin.com`, `indeed.com`, `stepstone.de`, `crunchbase.com`, …) are rejected rather than stored — see `NON_COMPANY_HOSTS` in `aggregate.py`. Empty is therefore common, not rare: the LinkedIn jobs Actors only return a `linkedin.com/company/<slug>` URL, so every row from that signal is domainless and dedupes on the company name instead. |
 | `signal_type` | enum | One of `jobs`, `funding`, `linkedin_content`. |
 | `signal_detail` | string | One-line human-readable signal summary. Examples: `"Hiring 3x Account Executive - EMEA"`, `"Raised $12M Series A led by Accel"`, `"Post: 'outbound is broken'"`. Free-form; the aggregator generates it per signal type. |
 | `signal_source_actor` | string | Apify Actor ID that produced this row (e.g. `bebity/linkedin-jobs-scraper`). Lets you trace back to the source dataset. |
@@ -26,7 +26,11 @@ Order of precedence when a new row collides with an existing row:
 2. **Identical normalized `company`, different `domain`**: both rows kept. Different
    domains for the same brand name are almost always different entities (subsidiaries,
    regional offices, or unrelated companies that happen to share a name).
-3. **Identical `evidence_url`**: dropped as a re-scrape of the same source. Guards
+3. **Identical normalized `company`, both rows domainless**: existing row wins, and the
+   incoming one is counted under `dropped.dup_company`. This is the working key for the
+   jobs signal, where no Actor returns an employer domain — three postings from one
+   company become one lead.
+4. **Identical `evidence_url`**: dropped as a re-scrape of the same source. Guards
    against the same Actor run being aggregated twice.
 
 Normalization for company-name comparison: lowercase, strip punctuation, collapse

--- a/skills/apify-buying-signal-detection/references/gotchas.md
+++ b/skills/apify-buying-signal-detection/references/gotchas.md
@@ -18,6 +18,15 @@ weekly run so it doesn't cost more than expected.
 - **Enrichment Actor** (`tech_gear/company-funding-details`) charges per company
   looked up. Don't call it on every row — only when the user asks for
   round-detail enrichment on a specific lead.
+- **LinkedIn profile enrichment adds a per-author cost.**
+  `aggregate.py` calls `harvestapi/linkedin-profile-scraper` (~$8 per 1000
+  profiles, roughly 4× the post scraper) to resolve `author → current company
+  domain` so LinkedIn rows can be blacklisted and deduped. Cost is bounded
+  because the aggregator (a) deduplicates author profile URLs before the call
+  (N posts by the same author = 1 lookup) and (b) only calls when at least
+  one LinkedIn row is missing a domain. If profile lookups dominate your bill,
+  narrow the LinkedIn search terms first — a broader post search means more
+  distinct authors, which is where the cost lives.
 
 ## Signal-quality traps
 
@@ -27,6 +36,19 @@ weekly run so it doesn't cost more than expected.
   contains `founder`, `consultant`, `agency`, `advisor` AND the author's
   `followers` > 5000, downgrade the row (drop in aggregator, or flag in
   `notes`).
+- **LinkedIn post scraper rarely returns a company domain.** The primary
+  scraper returns the author's *label* current company but not its website.
+  Consequence: without a domain, blacklist and dedup can't act on the row.
+  `aggregate.py::enrich_linkedin_domains` closes this with a second call to
+  `harvestapi/linkedin-profile-scraper` (see [`actors.md#linkedin-content-signals`](./actors.md#linkedin-content-signals)).
+  When neither scraper resolves a domain, the row is dropped with the
+  `linkedin_no_domain` audit bucket — the alternative (letting them through)
+  would silently bypass the blacklist.
+- **Profiles with no current employer** (freelancers between gigs,
+  retired founders posting for fun) return an empty
+  `currentCompanyWebsite` from the profile scraper — they land in the
+  `linkedin_no_domain` bucket even after enrichment. This is correct; there
+  is no company to blacklist or dedup against.
 - **Reposts inflate reaction counts.** LinkedIn's API doesn't cleanly separate
   original posts from reposts of the same text. `harvestapi` returns one row
   per repost URL — dedup on the post's *canonical* URL (strip

--- a/skills/apify-buying-signal-detection/references/gotchas.md
+++ b/skills/apify-buying-signal-detection/references/gotchas.md
@@ -1,0 +1,82 @@
+# Gotchas
+
+Non-obvious failure modes and cost guardrails. Read this before your first
+weekly run so it doesn't cost more than expected.
+
+## Cost guardrails
+
+- **LinkedIn Actors are the biggest cost lever.** `harvestapi/linkedin-post-search`
+  is $2 per 1000 posts. Broad search terms (`sales`, `hiring`) can return 10k+
+  matches per week; a 3-term campaign at that breadth is $60/week. Narrow terms
+  first, then broaden if the surviving qualified rows are too few. Cap via the
+  Actor's `maxItems` input — set to 500 per term as a default.
+- **Job Actors compound with geo fan-out.** Adding France Travail + Stepstone +
+  Indeed + LinkedIn Jobs to the same campaign multiplies weekly cost roughly
+  4×. Only include regional Actors when the ICP `geo` actually covers those
+  countries.
+- **Funding Actors are cheap** ($1–3/run typical). Include the full pick list.
+- **Enrichment Actor** (`tech_gear/company-funding-details`) charges per company
+  looked up. Don't call it on every row — only when the user asks for
+  round-detail enrichment on a specific lead.
+
+## Signal-quality traps
+
+- **LinkedIn posts by consultants / agencies** appear in every buying-intent
+  search. They complain about the same tools their clients complain about but
+  aren't buyers themselves. Filter post-hoc: if the author's `headline`
+  contains `founder`, `consultant`, `agency`, `advisor` AND the author's
+  `followers` > 5000, downgrade the row (drop in aggregator, or flag in
+  `notes`).
+- **Reposts inflate reaction counts.** LinkedIn's API doesn't cleanly separate
+  original posts from reposts of the same text. `harvestapi` returns one row
+  per repost URL — dedup on the post's *canonical* URL (strip
+  `?trackingId=...` query params).
+- **Funding announcements are re-published**: a Series A shows up on TechCrunch,
+  Crunchbase, the company's blog, and the local press. The CSV dedup on
+  `domain` collapses these correctly, but during a single Actor run you'll see
+  duplicates in the raw dataset. Normal.
+- **Job postings are often reposted 30 days later** with a new posting date.
+  The dedup rule (first-seen wins) keeps the original signal intact — a job
+  reposted is not a new signal.
+
+## Idempotency edge cases
+
+- **Manual runs mid-week**: the week-guard reads the CSV's max `detected_at`.
+  If you manually run `aggregate.py` on Wednesday, the Monday-scheduled run
+  will skip. To force a re-pull, pass `--force` (bypasses the week check but
+  still dedupes against existing rows).
+- **First run** on an empty CSV: no timestamp exists → guard is bypassed → all
+  configured Actors are pulled. This is the intended bootstrap behavior.
+- **Multi-machine writes to the same CSV** will corrupt the file. Single-writer
+  assumption. If two agents share a lead file, put it in a location that
+  serializes writes (e.g. behind a `flock` on Linux, or one shared Google
+  Sheet exported nightly).
+
+## Apify Task and Schedule ownership
+
+- `setup_apify_tasks.py` creates tasks with names prefixed by
+  `<campaign_name>-`. If you rename the campaign, the script creates fresh
+  tasks and orphans the old ones — no automatic cleanup. Delete the old
+  tasks manually via the Apify Console or the CLI:
+  `apify tasks list --json 2>/dev/null | jq '.[] | select(.name | startswith("old-name-")) | .id'`.
+- Apify Schedules are separate resources from tasks. The setup script creates
+  one schedule per campaign; renaming or reassigning tasks requires updating
+  the schedule too. The script does this idempotently — safe to re-run.
+
+## Recovery from failed weekly runs
+
+- **Actor run failed** — no data lands in the dataset for that Actor. The next
+  run picks up when its schedule fires. If you want to fill the gap manually:
+  ```bash
+  apify tasks run <task-id> --wait 300 --json \
+    --user-agent apify-awesome-skills/apify-buying-signal-detection 2>/dev/null
+  ```
+  Then invoke `aggregate.py --force` to pull the new data.
+- **`aggregate.py` failed mid-write** — the CSV is written atomically (write to
+  temp, rename over target) so a mid-write crash leaves the previous CSV
+  intact. Rerun the script.
+- **APIFY_TOKEN rotation** — export the new token and re-run
+  `setup_apify_tasks.py --config icp.json`. Task and Schedule upserts are
+  keyed by name and idempotent, so no data is duplicated. Existing tasks
+  continue to work with the new token as long as it's on the same Apify
+  account.

--- a/skills/apify-buying-signal-detection/references/gotchas.md
+++ b/skills/apify-buying-signal-detection/references/gotchas.md
@@ -18,15 +18,19 @@ weekly run so it doesn't cost more than expected.
 - **Enrichment Actor** (`tech_gear/company-funding-details`) charges per company
   looked up. Don't call it on every row — only when the user asks for
   round-detail enrichment on a specific lead.
-- **LinkedIn profile enrichment adds a per-author cost.**
-  `aggregate.py` calls `harvestapi/linkedin-profile-scraper` (~$8 per 1000
-  profiles, roughly 4× the post scraper) to resolve `author → current company
-  domain` so LinkedIn rows can be blacklisted and deduped. Cost is bounded
-  because the aggregator (a) deduplicates author profile URLs before the call
-  (N posts by the same author = 1 lookup) and (b) only calls when at least
-  one LinkedIn row is missing a domain. If profile lookups dominate your bill,
-  narrow the LinkedIn search terms first — a broader post search means more
-  distinct authors, which is where the cost lives.
+- **LinkedIn domain resolution is a two-hop enrichment chain.**
+  `aggregate.py` calls `harvestapi/linkedin-profile-scraper` ($4 per 1k
+  profiles in `"Profile details no email ($4 per 1k)"` mode) to resolve
+  author → `currentPosition[0].companyLinkedinUrl`, then
+  `harvestapi/linkedin-company` on the deduped set of company URLs to pull
+  `website`. Without both hops, the aggregator has no domain for
+  `linkedin_content` rows and cannot blacklist or dedup them. Cost is bounded
+  by three knobs: (a) canonical author-URL dedup at hop 1 (`?miniProfileUrn=…`
+  stripped so N samples of the same author = 1 lookup), (b) company-URL dedup
+  at hop 2 (N authors at the same company = 1 company lookup), (c) the whole
+  chain is skipped when every LinkedIn row already has a domain. If enrichment
+  dominates your bill, narrow the LinkedIn search terms first — a broader post
+  search means more distinct authors, which is where the cost lives.
 
 ## Signal-quality traps
 

--- a/skills/apify-buying-signal-detection/references/icp-config-schema.md
+++ b/skills/apify-buying-signal-detection/references/icp-config-schema.md
@@ -1,0 +1,69 @@
+# ICP config schema (`icp.json`)
+
+One JSON file per lead-gen campaign. Both `setup_apify_tasks.py` and `aggregate.py`
+read this file — keep them consistent by never editing it by hand once tasks are
+provisioned. Add a new campaign file if you need a materially different ICP.
+
+## Top-level fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `campaign_name` | string | yes | Short slug (lowercase, dashes). Used as prefix for named Apify tasks (e.g. `<campaign_name>-linkedin-jobs`). |
+| `leads_csv` | string (path) | yes | Where the deduplicated leads CSV lives. Relative to the campaign dir. |
+| `blacklist_csv` | string (path) | no | Optional path to a CSV with `domain,company,reason` columns. Rows matching either `domain` or normalized `company` are dropped from the append. |
+| `signals` | array of enum | yes | Subset of `["jobs", "funding", "linkedin_content"]`. Determines which Actors to provision. |
+| `geo` | array of ISO-3166 alpha-2 | yes | Country codes (uppercase). Drives Actor routing — see [`actors.md`](./actors.md). |
+| `industry_keywords` | array of string | yes | Keywords describing the target category. Passed to job scrapers as `keyword`, to LinkedIn scrapers as `keywords`, to funding trackers as `industry` when the Actor supports it. |
+| `persona` | object | when `signals` includes `jobs` | See below. |
+| `funding` | object | when `signals` includes `funding` | See below. |
+| `linkedin_content` | object | when `signals` includes `linkedin_content` | See below. |
+| `schedule` | object | no | Cron expressions for Apify-side and Claude-side triggers. If absent, defaults are `0 6 * * 1` and `0 8 * * 1` respectively. |
+
+## `persona` (jobs signal)
+
+| Field | Type | Notes |
+|---|---|---|
+| `titles` | array of string | Job titles the ICP hires for. Passed as `title` (bebity uses the first entry) / `queries` (google-jobs, indeed) / `searchTerms` (regional Actors). |
+| `seniority` | array of string | Informational only — not enforced post-hoc. Job Actors don't uniformly expose seniority, so filtering here would drop most rows spuriously. Keep it in the ICP for future reference. |
+| `company_size` | array of string | Informational only — same reason. Enrich with a follow-up Actor if you need this filter. |
+
+## `funding` (funding signal)
+
+| Field | Type | Notes |
+|---|---|---|
+| `stages` | array of enum | One or more of `pre_seed`, `seed`, `series_a`, `series_b`, `series_c`, `growth`. Post-filter in `aggregate.py`. |
+| `max_days_since_announcement` | int | Drop rows older than N days. Default 90. |
+
+## `linkedin_content` (linkedin_content signal)
+
+| Field | Type | Notes |
+|---|---|---|
+| `search_terms` | array of string | Phrases to search LinkedIn posts for. Passed as the `keywords` / `search` field on the Actor. Prefer specific pain-point phrases over broad category names — see [`actors.md`](./actors.md#linkedin-content-signals). |
+| `min_reactions` | int | Post-filter. Drop posts with fewer than N reactions. Default 5. |
+| `posted_within_days` | int | Post-filter. Drop posts older than N days. Default 14. |
+
+## `schedule`
+
+| Field | Type | Notes |
+|---|---|---|
+| `apify_side_cron` | cron string | Optional. If present, `setup_apify_tasks.py` creates an Apify Schedule that fires the tasks on this cadence. Omit to run tasks manually / on-demand. |
+| `claude_side_cron` | cron string | Informational — used only when registering the Claude scheduled task. |
+| `note` | string | Free-form human note. |
+
+## Non-obvious rules the aggregator applies
+
+- `geo` acts as a **routing filter, not a hard gate**: rows where the Actor doesn't
+  expose country get through if all other filters match. Better to have false-positive
+  leads than to silently drop a Swiss company because the German Actor didn't tag
+  country.
+- The `linkedin_content` signal is intentionally noisier than the other two —
+  pain-point posts are subjective. Expect ~30% of surviving rows to be low-signal
+  even after `min_reactions` filtering. Treat this signal as *inspiration*, not
+  *qualification*.
+- All post-filters run in `aggregate.py`, not in the Actor input. This decoupling
+  means you can tighten filters (e.g. raise `min_reactions` from 5 to 25) without
+  reprovisioning Apify tasks.
+
+## Full example
+
+See [`examples/icp.example.json`](../examples/icp.example.json).

--- a/skills/apify-buying-signal-detection/scripts/aggregate.py
+++ b/skills/apify-buying-signal-detection/scripts/aggregate.py
@@ -69,6 +69,11 @@ except ImportError:  # pragma: no cover
 APIFY_API = "https://api.apify.com/v2"
 USER_AGENT = "apify-awesome-skills/apify-buying-signal-detection"
 LINKEDIN_PROFILE_ACTOR = "harvestapi/linkedin-profile-scraper"
+LINKEDIN_COMPANY_ACTOR = "harvestapi/linkedin-company"
+# harvestapi/linkedin-profile-scraper enum literal — validated against Actor
+# input schema. The "no email" variant is $4/1k profiles, the email variant is
+# $10/1k. Domain resolution doesn't need emails so we take the cheap tier.
+LINKEDIN_PROFILE_MODE = "Profile details no email ($4 per 1k)"
 
 CSV_COLUMNS = [
     "detected_at",
@@ -114,7 +119,26 @@ def normalize_domain(raw: str) -> str:
 def strip_tracking(url: str) -> str:
     if not url:
         return ""
-    return re.sub(r"[?&](trackingId|utm_[a-z_]+|si|ref)=[^&]+", "", url).rstrip("?&")
+    return re.sub(r"[?&](trackingId|utm_[a-z_]+|si|ref|miniProfileUrn|rcm|dashCommentUrn|commentUrn)=[^&]+", "", url).rstrip("?&")
+
+
+def canonical_linkedin_profile_url(raw: str, public_identifier: str = "") -> str:
+    """Return `https://www.linkedin.com/in/{slug}` — stable across post samples.
+
+    harvestapi post output puts the profile URL with a `?miniProfileUrn=…` tail
+    that varies per-sample, so N posts by the same author look like N distinct
+    profile URLs. Prefer the `publicIdentifier` when the post scraper hands it
+    over; fall back to the URL slug.
+    """
+    if public_identifier:
+        return f"https://www.linkedin.com/in/{public_identifier}"
+    if not raw:
+        return ""
+    stripped = strip_tracking(raw)
+    m = re.match(r"https?://[^/]*linkedin\.com/in/([^/?#]+)", stripped, re.I)
+    if m:
+        return f"https://www.linkedin.com/in/{m.group(1)}"
+    return stripped
 
 
 def iso_now() -> str:
@@ -294,38 +318,57 @@ def map_funding_row(item: dict, actor_id: str) -> dict[str, str] | None:
 
 
 def map_linkedin_content_row(item: dict, actor_id: str) -> dict[str, str] | None:
-    # harvestapi returns nested `author.name`, `content`, `linkedinUrl`, `postedAt`, `reactions.count` etc.
+    # harvestapi/linkedin-post-search output shape (verified against live Actor
+    # response 2026-08): top-level `linkedinUrl` = post URL, `content` = text,
+    # `postedAt.date` = ISO date, `engagement.likes` = int, `author.name`,
+    # `author.info` = headline, `author.linkedinUrl` = profile URL (with a
+    # `?miniProfileUrn=…` query that varies per sample), `author.publicIdentifier`
+    # = the /in/<slug> segment. Keep older field names in the fallback chain in
+    # case harvestapi evolves the schema.
     author_name = (
-        _first(item, "authorName", "author", "posterName")
-        or _nested(item, "author.name")
+        _nested(item, "author.name")
+        or _first(item, "authorName", "author", "posterName")
         or _nested(item, "author.fullName")
     )
     author_headline = (
-        _first(item, "authorHeadline", "authorTitle")
+        _nested(item, "author.info")
+        or _first(item, "authorHeadline", "authorTitle")
         or _nested(item, "author.headline")
         or _nested(item, "author.title")
     ).lower()
+    # harvestapi doesn't return the current employer on the post row — only on
+    # the profile scraper. `company` starts as the author's own name and gets
+    # replaced during enrich_linkedin_domains when the profile lookup succeeds.
     company = (
         _first(item, "authorCompany", "companyName")
         or _nested(item, "author.company.name")
         or _nested(item, "author.currentCompany")
         or author_name
     )
+    # Post scraper virtually never returns the company website — this stays
+    # empty and is filled in by enrich_linkedin_domains via the profile +
+    # company Actor chain.
     domain = normalize_domain(
         _first(item, "authorCompanyDomain", "companyDomain")
         or _nested(item, "author.company.domain")
         or _nested(item, "author.company.website")
     )
-    text = _first(item, "text", "postText", "content", "postContent", "commentary")
-    url = strip_tracking(_first(item, "postUrl", "linkedinUrl", "url", "link"))
-    reactions = _first(item, "reactionsCount", "likes", "numLikes") or _nested(item, "reactions.count")
-    posted_at = _first(item, "postedAt", "postDate", "date") or _nested(item, "postedAt.date")
-    author_profile_url = strip_tracking(
-        _first(item, "authorProfileUrl", "authorUrl", "authorLinkedinUrl")
+    text = _first(item, "content", "text", "postText", "postContent", "commentary")
+    url = strip_tracking(_first(item, "linkedinUrl", "postUrl", "url", "link"))
+    reactions = (
+        _nested(item, "engagement.likes")
+        or _first(item, "reactionsCount", "likes", "numLikes")
+        or _nested(item, "reactions.count")
+    )
+    posted_at = _nested(item, "postedAt.date") or _first(item, "postedAt", "postDate", "date")
+    public_identifier = _nested(item, "author.publicIdentifier") or _first(item, "authorPublicIdentifier")
+    raw_profile_url = (
+        _nested(item, "author.linkedinUrl")
+        or _first(item, "authorProfileUrl", "authorUrl", "authorLinkedinUrl")
         or _nested(item, "author.profileUrl")
-        or _nested(item, "author.linkedinUrl")
         or _nested(item, "author.url")
     )
+    author_profile_url = canonical_linkedin_profile_url(raw_profile_url, public_identifier)
     if not (author_name and url):
         return None
     is_probable_agency = any(t in author_headline for t in ("consultant", "agency", "advisor", "founder"))
@@ -359,59 +402,67 @@ SIGNAL_MAPPERS = {
 }
 
 
-# ---------- LinkedIn author-profile → company-domain enrichment ----------
+# ---------- LinkedIn author → company-domain enrichment ----------
 #
 # harvestapi/linkedin-post-search returns author identity + post text, but the
-# author's current-company website is only present ~10% of the time. Without a
-# domain, the aggregator cannot check the blacklist or dedup against existing
+# author's current-company website is virtually never on the post row. Without
+# a domain, the aggregator cannot check the blacklist or dedup against existing
 # leads for this signal — which the user flagged as a leak.
 #
-# We resolve it by calling harvestapi/linkedin-profile-scraper on the deduped
-# set of author profile URLs that surfaced without a domain, then joining the
-# discovered current-company domain back onto the rows.
+# Verified against live Actor output (2026-08), resolving domain takes THREE
+# steps, not two:
+#   1. post-search   → author profile URL (already on the row from mapping)
+#   2. profile-scraper → currentPosition[0].companyLinkedinUrl + companyName
+#   3. company scraper → website  ← the actual domain source
 #
-# Cost note: profile scraping is $8/1k profiles at time of writing — ~4× more
-# than post scraping. We dedupe on profile URL first (many posts per author)
-# and skip the call entirely when no LinkedIn row is missing a domain.
+# The profile scraper alone returns the current company as a LinkedIn URL and
+# a display name, not a website. Only the company scraper closes the last hop.
+# Both hops are batched and deduplicated: N posts by the same author cost one
+# profile lookup; N authors at the same company cost one company lookup.
 
-def _extract_current_company_domain(profile: dict) -> str:
-    """Best-effort pull of the profile's current employer domain."""
-    for key in ("currentCompanyWebsite", "currentCompanyUrl", "companyWebsite", "companyUrl"):
-        v = profile.get(key)
-        if v:
-            return normalize_domain(str(v))
-    for path in (
-        "currentCompany.website",
-        "currentCompany.url",
-        "currentCompany.domain",
-        "company.website",
-        "company.domain",
-    ):
-        v = _nested(profile, path)
-        if v:
-            return normalize_domain(v)
+def _extract_company_linkedin_url_from_profile(profile: dict) -> tuple[str, str]:
+    """Return (companyLinkedinUrl, companyName) from a profile scraper item.
+
+    Prefers `currentPosition[0]` since harvestapi puts the active role there.
+    Falls back to `experience[]` first entry lacking `endDate.text != "Present"`.
+    Returns ("", "") when the profile has no current employer (freelancers,
+    retirees).
+    """
+    current = profile.get("currentPosition") or []
+    if isinstance(current, list) and current:
+        first = current[0]
+        if isinstance(first, dict):
+            url = str(first.get("companyLinkedinUrl") or "")
+            name = str(first.get("companyName") or "")
+            if url or name:
+                return url, name
     experience = profile.get("experience") or profile.get("experiences") or []
     if isinstance(experience, list):
         for exp in experience:
             if not isinstance(exp, dict):
                 continue
-            is_current = exp.get("current") or exp.get("isCurrent") or not exp.get("endDate")
+            end_text = _nested(exp, "endDate.text").lower()
+            is_current = (not exp.get("endDate")) or end_text in ("", "present")
             if not is_current:
                 continue
-            for key in ("companyWebsite", "companyUrl", "website", "url"):
-                v = exp.get(key)
-                if v:
-                    return normalize_domain(str(v))
-    return ""
+            url = str(exp.get("companyLinkedinUrl") or exp.get("companyUrl") or "")
+            name = str(exp.get("companyName") or exp.get("company") or "")
+            if url or name:
+                return url, name
+    return "", ""
 
 
 def enrich_linkedin_domains(rows: list[dict], token: str, audit: dict) -> None:
-    """Fill row['domain'] for linkedin_content rows via profile scraping.
+    """Fill row['domain'] for linkedin_content rows via a two-Actor chain.
 
-    Mutates `rows` in place. Deduplicates author profile URLs before the call
-    so N posts by the same author cost one lookup. Rows without a resolvable
-    profile URL are left with empty domain (they'll be dropped in the
-    blacklist/dedup pass with the `linkedin_no_domain` audit bucket).
+    Mutates `rows` in place. Deduplicates at both hops:
+      - unique author profile URLs → one profile-scraper call each
+      - unique companyLinkedinUrls across all resolved profiles → one
+        company-scraper call each
+
+    Rows still lacking a domain after both hops (profile has no current
+    employer, or the company page has no website) fall through to the
+    filter loop and get dropped into the `linkedin_no_domain` bucket.
     """
     to_enrich = [
         r for r in rows
@@ -421,12 +472,14 @@ def enrich_linkedin_domains(rows: list[dict], token: str, audit: dict) -> None:
     ]
     if not to_enrich:
         return
-    unique_urls = sorted({r["_author_profile_url"] for r in to_enrich})
-    audit["linkedin_profile_lookups"] = len(unique_urls)
+
+    # ---- Hop 1: profile scraper on unique author profile URLs
+    unique_profile_urls = sorted({r["_author_profile_url"] for r in to_enrich})
+    audit["linkedin_profile_lookups"] = len(unique_profile_urls)
     try:
         profiles = apify_run_actor_sync(
             LINKEDIN_PROFILE_ACTOR,
-            {"profileScraperMode": "Full", "queries": unique_urls},
+            {"profileScraperMode": LINKEDIN_PROFILE_MODE, "urls": unique_profile_urls},
             token,
         )
     except Exception as e:
@@ -434,25 +487,72 @@ def enrich_linkedin_domains(rows: list[dict], token: str, audit: dict) -> None:
         audit["linkedin_profile_error"] = str(e)
         return
 
-    domain_by_profile: dict[str, str] = {}
+    # Map: profile URL → (companyLinkedinUrl, companyName). Also index by
+    # publicIdentifier so we can join back on either key.
+    profile_to_company: dict[str, tuple[str, str]] = {}
     for p in profiles:
         if not isinstance(p, dict):
             continue
-        profile_url = strip_tracking(
-            _first(p, "profileUrl", "url", "linkedinUrl", "publicUrl")
-            or _nested(p, "profile.url")
-        )
-        if not profile_url:
+        company_url, company_name = _extract_company_linkedin_url_from_profile(p)
+        if not (company_url or company_name):
             continue
-        domain = _extract_current_company_domain(p)
-        if domain:
-            domain_by_profile[profile_url] = domain
+        key_candidates = set()
+        raw_url = _first(p, "linkedinUrl", "url", "publicUrl", "profileUrl") or _nested(p, "profile.url")
+        canon = canonical_linkedin_profile_url(raw_url, _first(p, "publicIdentifier"))
+        if canon:
+            key_candidates.add(canon)
+        pub_id = _first(p, "publicIdentifier")
+        if pub_id:
+            key_candidates.add(f"https://www.linkedin.com/in/{pub_id}")
+        for key in key_candidates:
+            profile_to_company[key] = (company_url, company_name)
 
-    audit["linkedin_profile_resolved"] = len(domain_by_profile)
+    audit["linkedin_profile_resolved"] = len(profile_to_company)
+
+    # ---- Hop 2: company scraper on unique companyLinkedinUrls
+    company_urls_needed = sorted({url for url, _ in profile_to_company.values() if url})
+    company_to_domain: dict[str, str] = {}
+    if company_urls_needed:
+        audit["linkedin_company_lookups"] = len(company_urls_needed)
+        try:
+            companies = apify_run_actor_sync(
+                LINKEDIN_COMPANY_ACTOR,
+                {"companies": company_urls_needed},
+                token,
+            )
+        except Exception as e:
+            print(f"warn: LinkedIn company enrichment failed ({e}); leaving domains empty", file=sys.stderr)
+            audit["linkedin_company_error"] = str(e)
+            companies = []
+        for c in companies:
+            if not isinstance(c, dict):
+                continue
+            company_url = str(c.get("linkedinUrl") or "")
+            website = str(c.get("website") or "")
+            if company_url and website:
+                company_to_domain[company_url.rstrip("/")] = normalize_domain(website)
+        audit["linkedin_company_resolved"] = len(company_to_domain)
+    else:
+        audit["linkedin_company_lookups"] = 0
+        audit["linkedin_company_resolved"] = 0
+
+    # ---- Join: profile URL → company URL → domain (and overwrite row.company
+    # with the resolved company name if we found one).
+    resolved_domains = 0
     for r in to_enrich:
-        resolved = domain_by_profile.get(r["_author_profile_url"])
-        if resolved:
-            r["domain"] = resolved
+        entry = profile_to_company.get(r["_author_profile_url"])
+        if not entry:
+            continue
+        company_url, company_name = entry
+        if company_name:
+            r["company"] = company_name
+        if not company_url:
+            continue
+        domain = company_to_domain.get(company_url.rstrip("/"))
+        if domain:
+            r["domain"] = domain
+            resolved_domains += 1
+    audit["linkedin_domain_resolved"] = resolved_domains
 
 
 # ------------------------------ post-filters ------------------------------

--- a/skills/apify-buying-signal-detection/scripts/aggregate.py
+++ b/skills/apify-buying-signal-detection/scripts/aggregate.py
@@ -34,7 +34,12 @@ try:
     import requests  # type: ignore
 
     def _get(url: str, params: dict[str, Any] | None = None, timeout: int = 30) -> dict | list:
-        r = requests.get(url, params=params, timeout=timeout)
+        r = requests.get(url, params=params, timeout=timeout, headers={"User-Agent": USER_AGENT})
+        r.raise_for_status()
+        return r.json()
+
+    def _post(url: str, params: dict[str, Any] | None, body: dict, timeout: int = 300) -> dict | list:
+        r = requests.post(url, params=params, json=body, timeout=timeout, headers={"User-Agent": USER_AGENT})
         r.raise_for_status()
         return r.json()
 except ImportError:  # pragma: no cover
@@ -44,12 +49,26 @@ except ImportError:  # pragma: no cover
     def _get(url: str, params: dict[str, Any] | None = None, timeout: int = 30) -> dict | list:
         if params:
             url = f"{url}?{urllib.parse.urlencode(params)}"
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+
+    def _post(url: str, params: dict[str, Any] | None, body: dict, timeout: int = 300) -> dict | list:
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode("utf-8"))
 
 
 APIFY_API = "https://api.apify.com/v2"
 USER_AGENT = "apify-awesome-skills/apify-buying-signal-detection"
+LINKEDIN_PROFILE_ACTOR = "harvestapi/linkedin-profile-scraper"
 
 CSV_COLUMNS = [
     "detected_at",
@@ -186,6 +205,19 @@ def apify_task_last_dataset_items(task_id: str, token: str) -> list[dict]:
     return items if isinstance(items, list) else []
 
 
+def apify_run_actor_sync(actor_id: str, input_body: dict, token: str, timeout: int = 600) -> list[dict]:
+    """Run an Actor synchronously and return its default dataset items.
+
+    Uses Apify's `run-sync-get-dataset-items` endpoint. Caller controls the
+    input shape — no assumptions about task registry. Returns [] on any
+    non-list response (including empty runs and API errors surfaced as JSON).
+    """
+    actor_slug = actor_id.replace("/", "~")
+    url = f"{APIFY_API}/acts/{actor_slug}/run-sync-get-dataset-items"
+    items = _post(url, params={"token": token, "format": "json", "clean": "true"}, body=input_body, timeout=timeout)
+    return items if isinstance(items, list) else []
+
+
 # ------------------------------ signal mappers ------------------------------
 
 def _first(d: dict, *keys: str, default: str = "") -> str:
@@ -288,6 +320,12 @@ def map_linkedin_content_row(item: dict, actor_id: str) -> dict[str, str] | None
     url = strip_tracking(_first(item, "postUrl", "linkedinUrl", "url", "link"))
     reactions = _first(item, "reactionsCount", "likes", "numLikes") or _nested(item, "reactions.count")
     posted_at = _first(item, "postedAt", "postDate", "date") or _nested(item, "postedAt.date")
+    author_profile_url = strip_tracking(
+        _first(item, "authorProfileUrl", "authorUrl", "authorLinkedinUrl")
+        or _nested(item, "author.profileUrl")
+        or _nested(item, "author.linkedinUrl")
+        or _nested(item, "author.url")
+    )
     if not (author_name and url):
         return None
     is_probable_agency = any(t in author_headline for t in ("consultant", "agency", "advisor", "founder"))
@@ -308,6 +346,9 @@ def map_linkedin_content_row(item: dict, actor_id: str) -> dict[str, str] | None
         "evidence_url": url,
         "geo": _first(item, "authorCountry", "country") or _nested(item, "author.location.country"),
         "notes": "; ".join(notes_bits),
+        # Private field consumed by enrich_linkedin_domains — not written to CSV
+        # (LeadsCsv.append_atomic filters to CSV_COLUMNS).
+        "_author_profile_url": author_profile_url,
     }
 
 
@@ -316,6 +357,102 @@ SIGNAL_MAPPERS = {
     "funding": map_funding_row,
     "linkedin_content": map_linkedin_content_row,
 }
+
+
+# ---------- LinkedIn author-profile → company-domain enrichment ----------
+#
+# harvestapi/linkedin-post-search returns author identity + post text, but the
+# author's current-company website is only present ~10% of the time. Without a
+# domain, the aggregator cannot check the blacklist or dedup against existing
+# leads for this signal — which the user flagged as a leak.
+#
+# We resolve it by calling harvestapi/linkedin-profile-scraper on the deduped
+# set of author profile URLs that surfaced without a domain, then joining the
+# discovered current-company domain back onto the rows.
+#
+# Cost note: profile scraping is $8/1k profiles at time of writing — ~4× more
+# than post scraping. We dedupe on profile URL first (many posts per author)
+# and skip the call entirely when no LinkedIn row is missing a domain.
+
+def _extract_current_company_domain(profile: dict) -> str:
+    """Best-effort pull of the profile's current employer domain."""
+    for key in ("currentCompanyWebsite", "currentCompanyUrl", "companyWebsite", "companyUrl"):
+        v = profile.get(key)
+        if v:
+            return normalize_domain(str(v))
+    for path in (
+        "currentCompany.website",
+        "currentCompany.url",
+        "currentCompany.domain",
+        "company.website",
+        "company.domain",
+    ):
+        v = _nested(profile, path)
+        if v:
+            return normalize_domain(v)
+    experience = profile.get("experience") or profile.get("experiences") or []
+    if isinstance(experience, list):
+        for exp in experience:
+            if not isinstance(exp, dict):
+                continue
+            is_current = exp.get("current") or exp.get("isCurrent") or not exp.get("endDate")
+            if not is_current:
+                continue
+            for key in ("companyWebsite", "companyUrl", "website", "url"):
+                v = exp.get(key)
+                if v:
+                    return normalize_domain(str(v))
+    return ""
+
+
+def enrich_linkedin_domains(rows: list[dict], token: str, audit: dict) -> None:
+    """Fill row['domain'] for linkedin_content rows via profile scraping.
+
+    Mutates `rows` in place. Deduplicates author profile URLs before the call
+    so N posts by the same author cost one lookup. Rows without a resolvable
+    profile URL are left with empty domain (they'll be dropped in the
+    blacklist/dedup pass with the `linkedin_no_domain` audit bucket).
+    """
+    to_enrich = [
+        r for r in rows
+        if r.get("signal_type") == "linkedin_content"
+        and not r.get("domain")
+        and r.get("_author_profile_url")
+    ]
+    if not to_enrich:
+        return
+    unique_urls = sorted({r["_author_profile_url"] for r in to_enrich})
+    audit["linkedin_profile_lookups"] = len(unique_urls)
+    try:
+        profiles = apify_run_actor_sync(
+            LINKEDIN_PROFILE_ACTOR,
+            {"profileScraperMode": "Full", "queries": unique_urls},
+            token,
+        )
+    except Exception as e:
+        print(f"warn: LinkedIn profile enrichment failed ({e}); leaving domains empty", file=sys.stderr)
+        audit["linkedin_profile_error"] = str(e)
+        return
+
+    domain_by_profile: dict[str, str] = {}
+    for p in profiles:
+        if not isinstance(p, dict):
+            continue
+        profile_url = strip_tracking(
+            _first(p, "profileUrl", "url", "linkedinUrl", "publicUrl")
+            or _nested(p, "profile.url")
+        )
+        if not profile_url:
+            continue
+        domain = _extract_current_company_domain(p)
+        if domain:
+            domain_by_profile[profile_url] = domain
+
+    audit["linkedin_profile_resolved"] = len(domain_by_profile)
+    for r in to_enrich:
+        resolved = domain_by_profile.get(r["_author_profile_url"])
+        if resolved:
+            r["domain"] = resolved
 
 
 # ------------------------------ post-filters ------------------------------
@@ -443,8 +580,20 @@ def main() -> int:
         return 2
 
     all_new_rows: list[dict[str, str]] = []
-    audit = {"fetched_by_signal": {}, "dropped": {"blacklist": 0, "dup_domain": 0, "dup_url": 0, "post_filter": 0, "unmappable": 0}}
+    audit = {
+        "fetched_by_signal": {},
+        "dropped": {
+            "blacklist": 0,
+            "dup_domain": 0,
+            "dup_url": 0,
+            "post_filter": 0,
+            "unmappable": 0,
+            "linkedin_no_domain": 0,
+        },
+    }
 
+    # ---- Pass 1: fetch + map all items across every task
+    candidate_rows: list[dict[str, str]] = []
     for task in tasks:
         signal = task["signal_type"]
         mapper = SIGNAL_MAPPERS.get(signal)
@@ -458,30 +607,44 @@ def main() -> int:
             if not row:
                 audit["dropped"]["unmappable"] += 1
                 continue
+            candidate_rows.append(row)
 
-            if row["domain"] and row["domain"] in bl_domains:
-                audit["dropped"]["blacklist"] += 1
-                continue
-            if normalize_company(row["company"]) in bl_companies:
-                audit["dropped"]["blacklist"] += 1
-                continue
+    # ---- Pass 2: enrich LinkedIn rows with missing company domain so that
+    # blacklist and domain-dedup can actually see them.
+    enrich_linkedin_domains(candidate_rows, token, audit)
 
-            keep, reason = apply_post_filters(row, icp)
-            if not keep:
-                audit["dropped"]["post_filter"] += 1
-                continue
+    # ---- Pass 3: filter (blacklist → post-filter → dedup) and collect new rows
+    for row in candidate_rows:
+        # LinkedIn rows that still have no domain after enrichment are
+        # unblacklistable and unmergeable — drop with a dedicated bucket so
+        # the user can spot when the profile scraper is missing data.
+        if row.get("signal_type") == "linkedin_content" and not row.get("domain"):
+            audit["dropped"]["linkedin_no_domain"] += 1
+            continue
 
-            if row["domain"] and row["domain"] in seen_domains:
-                audit["dropped"]["dup_domain"] += 1
-                continue
-            if row["evidence_url"] in seen_urls:
-                audit["dropped"]["dup_url"] += 1
-                continue
+        if row["domain"] and row["domain"] in bl_domains:
+            audit["dropped"]["blacklist"] += 1
+            continue
+        if normalize_company(row["company"]) in bl_companies:
+            audit["dropped"]["blacklist"] += 1
+            continue
 
-            all_new_rows.append(row)
-            seen_urls.add(row["evidence_url"])
-            if row["domain"]:
-                seen_domains.add(row["domain"])
+        keep, reason = apply_post_filters(row, icp)
+        if not keep:
+            audit["dropped"]["post_filter"] += 1
+            continue
+
+        if row["domain"] and row["domain"] in seen_domains:
+            audit["dropped"]["dup_domain"] += 1
+            continue
+        if row["evidence_url"] in seen_urls:
+            audit["dropped"]["dup_url"] += 1
+            continue
+
+        all_new_rows.append(row)
+        seen_urls.add(row["evidence_url"])
+        if row["domain"]:
+            seen_domains.add(row["domain"])
 
     print(json.dumps({"summary": {"appended": len(all_new_rows), **audit}}, indent=2))
 

--- a/skills/apify-buying-signal-detection/scripts/aggregate.py
+++ b/skills/apify-buying-signal-detection/scripts/aggregate.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Aggregate the latest buying-signal Actor runs into a deduplicated leads.csv.
+
+Reads an ICP config (icp.json), pulls each configured Apify task's latest
+dataset via the Apify REST API, normalizes rows into the leads.csv schema,
+filters against a blacklist CSV if provided, deduplicates against existing
+rows (first-seen wins on `domain`), and atomically appends new rows.
+
+Weekly idempotent: if the CSV's max detected_at falls in the current ISO
+week, exits early with "skipped: already run this week" unless --force is
+passed.
+
+Usage:
+    APIFY_TOKEN=... python aggregate.py --config icp.json [--force] [--dry-run]
+
+Requires: Python 3.10+, `requests` (stdlib `urllib` fallback used when
+requests is absent).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import requests  # type: ignore
+
+    def _get(url: str, params: dict[str, Any] | None = None, timeout: int = 30) -> dict | list:
+        r = requests.get(url, params=params, timeout=timeout)
+        r.raise_for_status()
+        return r.json()
+except ImportError:  # pragma: no cover
+    import urllib.parse
+    import urllib.request
+
+    def _get(url: str, params: dict[str, Any] | None = None, timeout: int = 30) -> dict | list:
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+
+
+APIFY_API = "https://api.apify.com/v2"
+USER_AGENT = "apify-awesome-skills/apify-buying-signal-detection"
+
+CSV_COLUMNS = [
+    "detected_at",
+    "company",
+    "domain",
+    "signal_type",
+    "signal_detail",
+    "signal_source_actor",
+    "signal_date",
+    "evidence_url",
+    "geo",
+    "notes",
+]
+
+CORP_SUFFIXES = ("inc", "ltd", "gmbh", "sa", "sarl", "bv", "llc", "co", "corp", "ag", "sl")
+
+
+# ------------------------------ helpers ------------------------------
+
+def normalize_company(name: str) -> str:
+    """Lowercase, strip punctuation, drop trailing corporate suffix, collapse ws."""
+    if not name:
+        return ""
+    n = re.sub(r"[^\w\s]", " ", name.lower())
+    n = re.sub(r"\s+", " ", n).strip()
+    tokens = n.split()
+    while tokens and tokens[-1] in CORP_SUFFIXES:
+        tokens.pop()
+    return " ".join(tokens)
+
+
+def normalize_domain(raw: str) -> str:
+    if not raw:
+        return ""
+    d = raw.strip().lower()
+    d = re.sub(r"^https?://", "", d)
+    d = re.sub(r"^www\.", "", d)
+    d = d.split("/")[0]
+    d = d.split("?")[0]
+    return d
+
+
+def strip_tracking(url: str) -> str:
+    if not url:
+        return ""
+    return re.sub(r"[?&](trackingId|utm_[a-z_]+|si|ref)=[^&]+", "", url).rstrip("?&")
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def iso_week(dt_str: str) -> tuple[int, int] | None:
+    """Return (iso_year, iso_week) for a UTC timestamp string, or None if unparseable."""
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(dt_str, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            y, w, _ = dt.astimezone(timezone.utc).isocalendar()
+            return (y, w)
+        except ValueError:
+            continue
+    return None
+
+
+def current_iso_week() -> tuple[int, int]:
+    y, w, _ = datetime.now(timezone.utc).isocalendar()
+    return (y, w)
+
+
+# ------------------------------ CSV I/O ------------------------------
+
+@dataclass
+class LeadsCsv:
+    path: Path
+    rows: list[dict[str, str]] = field(default_factory=list)
+
+    def load(self) -> None:
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8", newline="") as f:
+            self.rows = list(csv.DictReader(f))
+
+    def max_detected_at(self) -> str | None:
+        stamps = [r.get("detected_at", "") for r in self.rows if r.get("detected_at")]
+        return max(stamps) if stamps else None
+
+    def existing_domains(self) -> set[str]:
+        return {r["domain"] for r in self.rows if r.get("domain")}
+
+    def existing_urls(self) -> set[str]:
+        return {strip_tracking(r["evidence_url"]) for r in self.rows if r.get("evidence_url")}
+
+    def append_atomic(self, new_rows: list[dict[str, str]]) -> None:
+        if not new_rows:
+            return
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+            writer.writeheader()
+            for r in self.rows + new_rows:
+                writer.writerow({k: r.get(k, "") for k in CSV_COLUMNS})
+        os.replace(tmp, self.path)
+
+
+def load_blacklist(path: Path | None) -> tuple[set[str], set[str]]:
+    if not path or not path.exists():
+        return set(), set()
+    domains, companies = set(), set()
+    with path.open("r", encoding="utf-8", newline="") as f:
+        for row in csv.DictReader(f):
+            if row.get("domain"):
+                domains.add(normalize_domain(row["domain"]))
+            if row.get("company"):
+                companies.add(normalize_company(row["company"]))
+    return domains, companies
+
+
+# ------------------------------ Apify API ------------------------------
+
+def apify_task_last_dataset_items(task_id: str, token: str) -> list[dict]:
+    """Fetch items from the last successful run's default dataset of a task."""
+    url = f"{APIFY_API}/actor-tasks/{task_id}/runs/last"
+    data = _get(url, params={"token": token, "status": "SUCCEEDED"})
+    if not isinstance(data, dict) or "data" not in data:
+        return []
+    run = data["data"]
+    dataset_id = run.get("defaultDatasetId")
+    if not dataset_id:
+        return []
+    items_url = f"{APIFY_API}/datasets/{dataset_id}/items"
+    items = _get(items_url, params={"token": token, "format": "json", "clean": "true"})
+    return items if isinstance(items, list) else []
+
+
+# ------------------------------ signal mappers ------------------------------
+
+def _first(d: dict, *keys: str, default: str = "") -> str:
+    for k in keys:
+        v = d.get(k)
+        if v:
+            return str(v)
+    return default
+
+
+def _nested(item: dict, path: str) -> str:
+    """Read `a.b.c` from nested dicts, return '' if any hop is missing."""
+    cur: Any = item
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return ""
+        cur = cur.get(part)
+        if cur is None:
+            return ""
+    return str(cur) if cur else ""
+
+
+def map_jobs_row(item: dict, actor_id: str) -> dict[str, str] | None:
+    # Field names span multiple Actors — bebity uses `company`, google/indeed use `companyName`.
+    company = _first(item, "companyName", "company", "employerName", "companyDisplayName") or _nested(item, "company.name")
+    domain = normalize_domain(_first(item, "companyDomain", "companyWebsite", "companyUrl", "website"))
+    title = _first(item, "title", "jobTitle", "positionName", "position", "role", "jobPosition")
+    url = strip_tracking(
+        _first(item, "jobUrl", "applyUrl", "postingUrl", "url", "link", "linkedinUrl")
+        or _nested(item, "job.url")
+    )
+    if not (company and url):
+        return None
+    return {
+        "detected_at": iso_now(),
+        "company": company,
+        "domain": domain,
+        "signal_type": "jobs",
+        "signal_detail": f"Job: {title}" if title else "Job posting",
+        "signal_source_actor": actor_id,
+        "signal_date": _first(item, "postedDate", "datePosted", "publicationDate", "postedAt", "listedAt"),
+        "evidence_url": url,
+        "geo": _first(item, "locationCountry", "countryCode", "country") or _nested(item, "location.country"),
+        "notes": "",
+    }
+
+
+def map_funding_row(item: dict, actor_id: str) -> dict[str, str] | None:
+    company = _first(item, "companyName", "startupName", "company", "name")
+    domain = normalize_domain(_first(item, "companyDomain", "companyUrl", "website", "companyWebsite"))
+    # nexgendata: fundingAmount / roundType / filingDate. crunchbase: amount / stage / date.
+    amount = _first(item, "fundingAmount", "amount", "roundAmount", "raised")
+    stage = _first(item, "roundType", "stage", "series", "fundingStage")
+    investor = _first(item, "leadInvestor", "investors", "lead")
+    url = strip_tracking(_first(item, "sourceUrl", "articleUrl", "url", "link"))
+    if not (company and url):
+        return None
+    detail_bits = [b for b in [f"Raised {amount}" if amount else "", stage, f"led by {investor}" if investor else ""] if b]
+    return {
+        "detected_at": iso_now(),
+        "company": company,
+        "domain": domain,
+        "signal_type": "funding",
+        "signal_detail": " ".join(detail_bits) or "Funding event",
+        "signal_source_actor": actor_id,
+        "signal_date": _first(item, "filingDate", "announcementDate", "roundDate", "date"),
+        "evidence_url": url,
+        "geo": _first(item, "hqCountry", "country") or _nested(item, "hq.country"),
+        "notes": "",
+        # Private field consumed by apply_post_filters. LeadsCsv.append_atomic
+        # only writes columns in CSV_COLUMNS so this never lands in the CSV.
+        "_stage_raw": stage,
+    }
+
+
+def map_linkedin_content_row(item: dict, actor_id: str) -> dict[str, str] | None:
+    # harvestapi returns nested `author.name`, `content`, `linkedinUrl`, `postedAt`, `reactions.count` etc.
+    author_name = (
+        _first(item, "authorName", "author", "posterName")
+        or _nested(item, "author.name")
+        or _nested(item, "author.fullName")
+    )
+    author_headline = (
+        _first(item, "authorHeadline", "authorTitle")
+        or _nested(item, "author.headline")
+        or _nested(item, "author.title")
+    ).lower()
+    company = (
+        _first(item, "authorCompany", "companyName")
+        or _nested(item, "author.company.name")
+        or _nested(item, "author.currentCompany")
+        or author_name
+    )
+    domain = normalize_domain(
+        _first(item, "authorCompanyDomain", "companyDomain")
+        or _nested(item, "author.company.domain")
+        or _nested(item, "author.company.website")
+    )
+    text = _first(item, "text", "postText", "content", "postContent", "commentary")
+    url = strip_tracking(_first(item, "postUrl", "linkedinUrl", "url", "link"))
+    reactions = _first(item, "reactionsCount", "likes", "numLikes") or _nested(item, "reactions.count")
+    posted_at = _first(item, "postedAt", "postDate", "date") or _nested(item, "postedAt.date")
+    if not (author_name and url):
+        return None
+    is_probable_agency = any(t in author_headline for t in ("consultant", "agency", "advisor", "founder"))
+    notes_bits = []
+    if is_probable_agency:
+        notes_bits.append("flag:probable-agency-or-advisor")
+    if reactions:
+        notes_bits.append(f"reactions={reactions}")
+    excerpt = (text[:120] + "…") if text and len(text) > 120 else text
+    return {
+        "detected_at": iso_now(),
+        "company": company,
+        "domain": domain,
+        "signal_type": "linkedin_content",
+        "signal_detail": f"Post: '{excerpt}'" if excerpt else "LinkedIn post",
+        "signal_source_actor": actor_id,
+        "signal_date": posted_at,
+        "evidence_url": url,
+        "geo": _first(item, "authorCountry", "country") or _nested(item, "author.location.country"),
+        "notes": "; ".join(notes_bits),
+    }
+
+
+SIGNAL_MAPPERS = {
+    "jobs": map_jobs_row,
+    "funding": map_funding_row,
+    "linkedin_content": map_linkedin_content_row,
+}
+
+
+# ------------------------------ post-filters ------------------------------
+
+STAGE_ALIASES = {
+    "pre_seed": {"pre-seed", "pre seed", "preseed", "angel"},
+    "seed": {"seed"},
+    "series_a": {"series a", "series-a", "a"},
+    "series_b": {"series b", "series-b", "b"},
+    "series_c": {"series c", "series-c", "c"},
+    "growth": {"growth", "late stage", "series d", "series e", "series f", "series g"},
+}
+
+
+def _stage_matches(row_stage_raw: str, allowed_stages: list[str]) -> bool:
+    if not allowed_stages:
+        return True
+    row_stage = row_stage_raw.lower().strip()
+    for allowed in allowed_stages:
+        for alias in STAGE_ALIASES.get(allowed, {allowed.lower().replace("_", " ")}):
+            if alias in row_stage:
+                return True
+    return False
+
+
+def apply_post_filters(row: dict[str, str], icp: dict) -> tuple[bool, str]:
+    """Return (keep, reason_if_dropped) based on ICP settings."""
+    signal = row["signal_type"]
+    geo = row.get("geo", "").upper()
+    icp_geos = [g.upper() for g in icp.get("geo", [])]
+    if geo and icp_geos and geo not in icp_geos:
+        return False, f"geo mismatch ({geo} not in {icp_geos})"
+
+    if signal == "funding":
+        cfg = icp.get("funding", {})
+        max_days = cfg.get("max_days_since_announcement", 90)
+        sig_date = row.get("signal_date", "")
+        if sig_date:
+            for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ"):
+                try:
+                    dt = datetime.strptime(sig_date, fmt).replace(tzinfo=timezone.utc)
+                    if (datetime.now(timezone.utc) - dt).days > max_days:
+                        return False, f"funding older than {max_days} days"
+                    break
+                except ValueError:
+                    continue
+        stages = cfg.get("stages", [])
+        row_stage = row.get("_stage_raw", "")
+        if stages and row_stage and not _stage_matches(row_stage, stages):
+            return False, f"stage '{row_stage}' not in {stages}"
+
+    if signal == "linkedin_content":
+        cfg = icp.get("linkedin_content", {})
+        posted_within = cfg.get("posted_within_days", 14)
+        sig_date = row.get("signal_date", "")
+        if sig_date:
+            for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ"):
+                try:
+                    dt = datetime.strptime(sig_date, fmt).replace(tzinfo=timezone.utc)
+                    if (datetime.now(timezone.utc) - dt).days > posted_within:
+                        return False, f"post older than {posted_within} days"
+                    break
+                except ValueError:
+                    continue
+        # `notes` carries "reactions=N" when the Actor returned reaction counts.
+        min_reactions = cfg.get("min_reactions", 0)
+        if min_reactions > 0:
+            m = re.search(r"reactions=(\d+)", row.get("notes", ""))
+            if m and int(m.group(1)) < min_reactions:
+                return False, f"reactions {m.group(1)} < min_reactions {min_reactions}"
+
+    return True, ""
+
+
+# ------------------------------ main ------------------------------
+
+def load_task_registry(campaign_name: str, campaign_dir: Path) -> list[dict]:
+    """Read the task registry setup_apify_tasks.py wrote next to icp.json.
+
+    Registry shape: [{task_id, actor_id, signal_type}, ...]
+    """
+    reg_path = campaign_dir / f".{campaign_name}.tasks.json"
+    if not reg_path.exists():
+        return []
+    return json.loads(reg_path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Aggregate Apify buying-signal runs into leads.csv")
+    ap.add_argument("--config", required=True, help="Path to icp.json")
+    ap.add_argument("--force", action="store_true", help="Bypass weekly idempotency guard")
+    ap.add_argument("--dry-run", action="store_true", help="Skip CSV write; print planned appends to stdout")
+    args = ap.parse_args()
+
+    token = os.environ.get("APIFY_TOKEN", "").strip()
+    if not token:
+        print("error: APIFY_TOKEN env var is required", file=sys.stderr)
+        return 2
+
+    config_path = Path(args.config).resolve()
+    icp = json.loads(config_path.read_text(encoding="utf-8"))
+    campaign_dir = config_path.parent
+    leads_path = (campaign_dir / icp["leads_csv"]).resolve()
+    blacklist_path = campaign_dir / icp["blacklist_csv"] if icp.get("blacklist_csv") else None
+
+    leads = LeadsCsv(leads_path)
+    leads.load()
+    last_stamp = leads.max_detected_at()
+    if last_stamp and not args.force:
+        if iso_week(last_stamp) == current_iso_week():
+            print(f"skipped: already run this week (last detected_at={last_stamp})")
+            return 0
+
+    bl_domains, bl_companies = load_blacklist(blacklist_path)
+    seen_domains = leads.existing_domains()
+    seen_urls = leads.existing_urls()
+
+    tasks = load_task_registry(icp["campaign_name"], campaign_dir)
+    if not tasks:
+        print(
+            f"error: no task registry for campaign '{icp['campaign_name']}'. "
+            "Run setup_apify_tasks.py first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_new_rows: list[dict[str, str]] = []
+    audit = {"fetched_by_signal": {}, "dropped": {"blacklist": 0, "dup_domain": 0, "dup_url": 0, "post_filter": 0, "unmappable": 0}}
+
+    for task in tasks:
+        signal = task["signal_type"]
+        mapper = SIGNAL_MAPPERS.get(signal)
+        if not mapper:
+            continue
+        items = apify_task_last_dataset_items(task["task_id"], token)
+        audit["fetched_by_signal"].setdefault(signal, 0)
+        audit["fetched_by_signal"][signal] += len(items)
+        for item in items:
+            row = mapper(item, task["actor_id"])
+            if not row:
+                audit["dropped"]["unmappable"] += 1
+                continue
+
+            if row["domain"] and row["domain"] in bl_domains:
+                audit["dropped"]["blacklist"] += 1
+                continue
+            if normalize_company(row["company"]) in bl_companies:
+                audit["dropped"]["blacklist"] += 1
+                continue
+
+            keep, reason = apply_post_filters(row, icp)
+            if not keep:
+                audit["dropped"]["post_filter"] += 1
+                continue
+
+            if row["domain"] and row["domain"] in seen_domains:
+                audit["dropped"]["dup_domain"] += 1
+                continue
+            if row["evidence_url"] in seen_urls:
+                audit["dropped"]["dup_url"] += 1
+                continue
+
+            all_new_rows.append(row)
+            seen_urls.add(row["evidence_url"])
+            if row["domain"]:
+                seen_domains.add(row["domain"])
+
+    print(json.dumps({"summary": {"appended": len(all_new_rows), **audit}}, indent=2))
+
+    if args.dry_run:
+        print("(dry-run: no CSV write)")
+        return 0
+
+    leads.append_atomic(all_new_rows)
+    print(f"wrote {len(all_new_rows)} new rows to {leads_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/apify-buying-signal-detection/scripts/aggregate.py
+++ b/skills/apify-buying-signal-detection/scripts/aggregate.py
@@ -105,6 +105,30 @@ def normalize_company(name: str) -> str:
     return " ".join(tokens)
 
 
+# Hosts that are never a company's own domain. The job boards and social
+# networks the signal Actors scrape return their own URLs in company fields —
+# `lntb/linkedin-jobs-scraper` for instance only ever returns `companyUrl:
+# https://de.linkedin.com/company/<slug>`. Normalizing that to `de.linkedin.com`
+# would make every LinkedIn-sourced lead share one dedup key, so distinct
+# companies collapse into the first one seen. Treat these as "no domain" and let
+# the company-name key do the deduping instead.
+NON_COMPANY_HOSTS = (
+    "linkedin.com",
+    "indeed.com",
+    "glassdoor.com",
+    "stepstone.de",
+    "seek.com.au",
+    "francetravail.fr",
+    "pole-emploi.fr",
+    "crunchbase.com",
+    "maddyness.com",
+    "google.com",
+    "facebook.com",
+    "twitter.com",
+    "x.com",
+)
+
+
 def normalize_domain(raw: str) -> str:
     if not raw:
         return ""
@@ -113,6 +137,8 @@ def normalize_domain(raw: str) -> str:
     d = re.sub(r"^www\.", "", d)
     d = d.split("/")[0]
     d = d.split("?")[0]
+    if d == "" or any(d == h or d.endswith("." + h) for h in NON_COMPANY_HOSTS):
+        return ""
     return d
 
 
@@ -187,6 +213,10 @@ class LeadsCsv:
     def existing_urls(self) -> set[str]:
         return {strip_tracking(r["evidence_url"]) for r in self.rows if r.get("evidence_url")}
 
+    def existing_companies(self) -> set[str]:
+        """Normalized company names already in the CSV, for domainless dedup."""
+        return {normalize_company(r["company"]) for r in self.rows if r.get("company")}
+
     def append_atomic(self, new_rows: list[dict[str, str]]) -> None:
         if not new_rows:
             return
@@ -215,9 +245,23 @@ def load_blacklist(path: Path | None) -> tuple[set[str], set[str]]:
 # ------------------------------ Apify API ------------------------------
 
 def apify_task_last_dataset_items(task_id: str, token: str) -> list[dict]:
-    """Fetch items from the last successful run's default dataset of a task."""
+    """Fetch items from the last successful run's default dataset of a task.
+
+    A task that has never produced a successful run returns 404 from
+    `/runs/last`. That is the normal state on the first aggregation — the
+    Apify-side cron may not have fired yet, and the Claude-side schedule is
+    designed to run more often than it. Treat it as "nothing to aggregate
+    from this task yet" rather than letting the HTTP error abort the whole run
+    and lose the signals every other task did return.
+    """
     url = f"{APIFY_API}/actor-tasks/{task_id}/runs/last"
-    data = _get(url, params={"token": token, "status": "SUCCEEDED"})
+    try:
+        data = _get(url, params={"token": token, "status": "SUCCEEDED"})
+    except Exception as exc:  # noqa: BLE001 — requests.HTTPError or urllib.error.HTTPError
+        if "404" in str(exc):
+            print(f"  note: task {task_id} has no successful run yet — skipping", file=sys.stderr)
+            return []
+        raise
     if not isinstance(data, dict) or "data" not in data:
         return []
     run = data["data"]
@@ -669,6 +713,7 @@ def main() -> int:
     bl_domains, bl_companies = load_blacklist(blacklist_path)
     seen_domains = leads.existing_domains()
     seen_urls = leads.existing_urls()
+    seen_companies = leads.existing_companies()
 
     tasks = load_task_registry(icp["campaign_name"], campaign_dir)
     if not tasks:
@@ -685,6 +730,7 @@ def main() -> int:
         "dropped": {
             "blacklist": 0,
             "dup_domain": 0,
+            "dup_company": 0,
             "dup_url": 0,
             "post_filter": 0,
             "unmappable": 0,
@@ -737,6 +783,13 @@ def main() -> int:
         if row["domain"] and row["domain"] in seen_domains:
             audit["dropped"]["dup_domain"] += 1
             continue
+        # Job boards never hand back the employer's own domain, so those rows
+        # arrive domainless and fall through to the company-name key. Without
+        # this, two postings from one company become two leads.
+        company_key = normalize_company(row["company"])
+        if not row["domain"] and company_key and company_key in seen_companies:
+            audit["dropped"]["dup_company"] += 1
+            continue
         if row["evidence_url"] in seen_urls:
             audit["dropped"]["dup_url"] += 1
             continue
@@ -745,6 +798,8 @@ def main() -> int:
         seen_urls.add(row["evidence_url"])
         if row["domain"]:
             seen_domains.add(row["domain"])
+        if company_key:
+            seen_companies.add(company_key)
 
     print(json.dumps({"summary": {"appended": len(all_new_rows), **audit}}, indent=2))
 

--- a/skills/apify-buying-signal-detection/scripts/setup_apify_tasks.py
+++ b/skills/apify-buying-signal-detection/scripts/setup_apify_tasks.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.parse
 import urllib.request
@@ -93,18 +94,28 @@ def pick_actors(icp: dict) -> list[dict]:
                 "totalRows": 200,
             },
         })
-        # johnvc/Google-Jobs-Scraper wants lowercase ISO codes with `uk` (not `gb`).
+        # johnvc/Google-Jobs-Scraper wants lowercase ISO codes with `uk` (not `gb`),
+        # and rejects anything outside its own enum — an ICP targeting BE/NL/PL
+        # would otherwise fail task creation with `invalid-input`. Pick the first
+        # geo the Actor actually supports; if none match, omit `country` and let
+        # Google aggregate globally (the field is optional).
         _gjs_geo = {"GB": "uk"}
-        gjs_country = _gjs_geo.get(sorted(geo)[0], sorted(geo)[0].lower()) if geo else "us"
+        _gjs_supported = {"us", "ca", "uk", "de", "fr", "au", "jp", "in", "br", "mx"}
+        gjs_country = next(
+            (c for c in (_gjs_geo.get(g, g.lower()) for g in sorted(geo)) if c in _gjs_supported),
+            None,
+        )
+        gjs_input = {
+            "query": titles[0] if titles else "",
+            "location": ", ".join(sorted(geo)) if geo else "",
+            "num_results": 200,
+        }
+        if gjs_country:
+            gjs_input["country"] = gjs_country
         picks.append({
             "actor_id": "johnvc/Google-Jobs-Scraper",
             "signal_type": "jobs",
-            "input": {
-                "query": titles[0] if titles else "",
-                "location": ", ".join(sorted(geo)) if geo else "",
-                "country": gjs_country,
-                "num_results": 200,
-            },
+            "input": gjs_input,
         })
         if geo & {"US", "GB", "IN", "CA"}:
             # borderline/indeed-scraper: lowercase codes, `uk` (not `gb`).
@@ -211,14 +222,17 @@ def find_task_by_name(token: str, name: str) -> dict | None:
 def _task_name(campaign: str, actor_id: str) -> str:
     """Build an Apify-valid task name (max 63 chars, no trailing dash).
 
-    Format: `{campaign}-{slug}` truncated to 63 chars. If the slug alone would
-    push us over the limit, we keep as much of the slug as fits and strip any
-    trailing dash so the name stays URL-safe.
+    Apify only accepts `a-z`, `0-9` and hyphens, and hyphens may not sit at
+    either end. Store usernames routinely break both rules — underscores
+    (`complex_intricate_networks`) and capitals (`johnvc/Google-Jobs-Scraper`)
+    are common — so every disallowed character is folded to a hyphen before
+    the length cap is applied.
+
+    Format: `{campaign}-{slug}` truncated to 63 chars.
     """
     slug = actor_id.replace("/", "-")
-    name = f"{campaign}-{slug}"
-    if len(name) <= 63:
-        return name
+    name = re.sub(r"[^a-z0-9-]+", "-", f"{campaign}-{slug}".lower())
+    name = re.sub(r"-{2,}", "-", name).strip("-")
     return name[:63].rstrip("-")
 
 

--- a/skills/apify-buying-signal-detection/scripts/setup_apify_tasks.py
+++ b/skills/apify-buying-signal-detection/scripts/setup_apify_tasks.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Provision Apify Actor Tasks from an ICP config.
+
+Reads icp.json, decides which Actors to enable per the routing tables in
+`references/actors.md`, and creates (or updates in place) one Apify Actor Task
+per Actor with the correct input payload derived from the ICP.
+
+Optionally provisions a single Apify Schedule that fires all the tasks on the
+configured cron. Writes a task registry sidecar at
+`<campaign_dir>/.<campaign_name>.tasks.json` — `aggregate.py` reads this to
+know which tasks to pull dataset items from.
+
+Usage:
+    APIFY_TOKEN=... python setup_apify_tasks.py --config icp.json [--dry-run]
+                                                                 [--no-schedule]
+                                                                 [--refresh-auth]
+
+The script is idempotent: running it twice against the same ICP renames-in-place
+rather than creating duplicates.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+APIFY_API = "https://api.apify.com/v2"
+USER_AGENT = "apify-awesome-skills/apify-buying-signal-detection"
+
+
+# ------------------------------ HTTP helpers ------------------------------
+
+def _req(method: str, path: str, token: str, body: dict | None = None) -> dict | list:
+    url = f"{APIFY_API}{path}"
+    sep = "&" if "?" in url else "?"
+    url = f"{url}{sep}token={urllib.parse.quote(token)}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("User-Agent", USER_AGENT)
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw else {}
+
+
+def apify_get(path: str, token: str) -> Any:
+    return _req("GET", path, token)
+
+
+def apify_post(path: str, token: str, body: dict) -> Any:
+    return _req("POST", path, token, body)
+
+
+def apify_put(path: str, token: str, body: dict) -> Any:
+    return _req("PUT", path, token, body)
+
+
+# ------------------------------ Actor routing ------------------------------
+
+def pick_actors(icp: dict) -> list[dict]:
+    """Return [{actor_id, signal_type, input_builder}] based on ICP signals + geo."""
+    signals = set(icp.get("signals", []))
+    geo = {g.upper() for g in icp.get("geo", [])}
+    kws = icp.get("industry_keywords", [])
+    persona = icp.get("persona", {})
+    fund_cfg = icp.get("funding", {})
+    li_cfg = icp.get("linkedin_content", {})
+
+    picks: list[dict] = []
+
+    if "jobs" in signals:
+        titles = persona.get("titles") or kws
+        # LinkedIn Jobs: lntb/... is PPE ($1/1k) and accepts arrays of titles + locations natively,
+        # so a multi-title ICP does not get collapsed to titles[0].
+        _country_names = {
+            "US": "United States", "GB": "United Kingdom", "IN": "India", "CA": "Canada",
+            "DE": "Germany", "AT": "Austria", "BE": "Belgium", "FR": "France",
+            "AU": "Australia", "NZ": "New Zealand", "IE": "Ireland", "ES": "Spain",
+            "IT": "Italy", "NL": "Netherlands", "PL": "Poland", "SE": "Sweden",
+        }
+        job_locations = [_country_names.get(g, g) for g in sorted(geo)] if geo else ["United States"]
+        picks.append({
+            "actor_id": "lntb/linkedin-jobs-scraper---multiple-titles-locations-in-one",
+            "signal_type": "jobs",
+            "input": {
+                "jobTitles": list(titles) if titles else [],
+                "jobLocations": job_locations,
+                "totalRows": 200,
+            },
+        })
+        # johnvc/Google-Jobs-Scraper wants lowercase ISO codes with `uk` (not `gb`).
+        _gjs_geo = {"GB": "uk"}
+        gjs_country = _gjs_geo.get(sorted(geo)[0], sorted(geo)[0].lower()) if geo else "us"
+        picks.append({
+            "actor_id": "johnvc/Google-Jobs-Scraper",
+            "signal_type": "jobs",
+            "input": {
+                "query": titles[0] if titles else "",
+                "location": ", ".join(sorted(geo)) if geo else "",
+                "country": gjs_country,
+                "num_results": 200,
+            },
+        })
+        if geo & {"US", "GB", "IN", "CA"}:
+            # borderline/indeed-scraper: lowercase codes, `uk` (not `gb`).
+            _indeed_geo = {"GB": "uk"}
+            indeed_country_raw = sorted(list(geo & {"US", "GB", "IN", "CA"}))[0]
+            indeed_country = _indeed_geo.get(indeed_country_raw, indeed_country_raw.lower())
+            picks.append({
+                "actor_id": "borderline/indeed-scraper",
+                "signal_type": "jobs",
+                "input": {
+                    "query": titles[0] if titles else "",
+                    "country": indeed_country,
+                    "maxRows": 200,
+                },
+            })
+        if geo & {"DE", "AT", "BE"}:
+            picks.append({
+                "actor_id": "memo23/stepstone-search-cheerio-ppr",
+                "signal_type": "jobs",
+                "input": {"searchTerms": titles, "maxItems": 200},
+            })
+        if geo & {"AU", "NZ"}:
+            picks.append({
+                "actor_id": "blackfalcondata/seek-scraper",
+                "signal_type": "jobs",
+                "input": {"searchTerms": titles, "maxItems": 200},
+            })
+        if "FR" in geo:
+            picks.append({
+                "actor_id": "dltik/francetravail-scraper",
+                "signal_type": "jobs",
+                "input": {"searchTerms": titles, "maxItems": 200},
+            })
+
+    if "funding" in signals:
+        # nexgendata: `mode`, `searchQuery` (string), `daysBack`, `maxResults`.
+        max_days = fund_cfg.get("max_days_since_announcement", 90)
+        picks.append({
+            "actor_id": "nexgendata/startup-funding-tracker",
+            "signal_type": "funding",
+            "input": {
+                "mode": "all_sources",
+                "searchQuery": " ".join(kws) if kws else "",
+                "daysBack": max_days,
+                "maxResults": 300,
+                "enrich_companies": True,
+            },
+        })
+        picks.append({
+            "actor_id": "memo23/crunchbase-scraper",
+            "signal_type": "funding",
+            "input": {
+                "categories": kws,
+                "fundingRounds": fund_cfg.get("stages", []),
+                "maxItems": 300,
+            },
+        })
+        picks.append({
+            "actor_id": "complex_intricate_networks/fundraising-and-startup-funding-scraper",
+            "signal_type": "funding",
+            "input": {"keywords": kws, "maxItems": 300},
+        })
+        picks.append({
+            "actor_id": "signalbase/signalbase-api",
+            "signal_type": "funding",
+            "input": {"industries": kws, "maxItems": 200},
+        })
+        if "FR" in geo:
+            picks.append({
+                "actor_id": "advantageous_subcontra/maddyness-french-startup-fundraising-database",
+                "signal_type": "funding",
+                "input": {"maxItems": 200},
+            })
+
+    if "linkedin_content" in signals:
+        # harvestapi/linkedin-post-search: `searchQueries` (array), `maxPosts`, `sortBy`, `postedLimit`.
+        posted_within = li_cfg.get("posted_within_days", 14)
+        posted_limit = "24h" if posted_within <= 1 else ("week" if posted_within <= 7 else "month")
+        picks.append({
+            "actor_id": "harvestapi/linkedin-post-search",
+            "signal_type": "linkedin_content",
+            "input": {
+                "searchQueries": li_cfg.get("search_terms", kws),
+                "maxPosts": 500,
+                "sortBy": "date",
+                "postedLimit": posted_limit,
+                "scrapeReactions": False,
+            },
+        })
+
+    return picks
+
+
+# ------------------------------ task ops ------------------------------
+
+def find_task_by_name(token: str, name: str) -> dict | None:
+    resp = apify_get(f"/actor-tasks?limit=1000", token)
+    for t in resp.get("data", {}).get("items", []):
+        if t.get("name") == name:
+            return t
+    return None
+
+
+def _task_name(campaign: str, actor_id: str) -> str:
+    """Build an Apify-valid task name (max 63 chars, no trailing dash).
+
+    Format: `{campaign}-{slug}` truncated to 63 chars. If the slug alone would
+    push us over the limit, we keep as much of the slug as fits and strip any
+    trailing dash so the name stays URL-safe.
+    """
+    slug = actor_id.replace("/", "-")
+    name = f"{campaign}-{slug}"
+    if len(name) <= 63:
+        return name
+    return name[:63].rstrip("-")
+
+
+def upsert_task(token: str, campaign: str, pick: dict) -> str:
+    """Create-or-update a task for one Actor pick. Returns the task id."""
+    name = _task_name(campaign, pick["actor_id"])
+    existing = find_task_by_name(token, name)
+    body = {
+        "name": name,
+        "actId": pick["actor_id"],
+        "options": {"build": "latest"},
+        "input": pick["input"],
+    }
+    if existing:
+        apify_put(f"/actor-tasks/{existing['id']}", token, body)
+        return existing["id"]
+    created = apify_post("/actor-tasks", token, body)
+    return created["data"]["id"]
+
+
+def upsert_schedule(token: str, campaign: str, cron: str, task_ids: list[str]) -> str | None:
+    name = f"{campaign}-schedule"
+    resp = apify_get("/schedules?limit=1000", token)
+    existing = next((s for s in resp.get("data", {}).get("items", []) if s.get("name") == name), None)
+    body = {
+        "name": name,
+        "cronExpression": cron,
+        "timezone": "UTC",
+        "isEnabled": True,
+        "actions": [
+            {"type": "RUN_ACTOR_TASK", "actorTaskId": tid} for tid in task_ids
+        ],
+    }
+    if existing:
+        apify_put(f"/schedules/{existing['id']}", token, body)
+        return existing["id"]
+    created = apify_post("/schedules", token, body)
+    return created["data"]["id"]
+
+
+# ------------------------------ main ------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--no-schedule", action="store_true", help="Provision tasks but not the Apify Schedule")
+    args = ap.parse_args()
+
+    token = os.environ.get("APIFY_TOKEN", "").strip()
+    if not token:
+        print("error: APIFY_TOKEN env var is required", file=sys.stderr)
+        return 2
+
+    config_path = Path(args.config).resolve()
+    icp = json.loads(config_path.read_text(encoding="utf-8"))
+    campaign = icp["campaign_name"]
+    campaign_dir = config_path.parent
+
+    picks = pick_actors(icp)
+    if not picks:
+        print("error: no Actors matched the ICP (empty signals or unsupported geo)", file=sys.stderr)
+        return 2
+
+    print(f"Will provision {len(picks)} tasks for campaign '{campaign}':")
+    for p in picks:
+        print(f"  - {p['signal_type']:>18s}  ← {p['actor_id']}")
+
+    if args.dry_run:
+        print("(dry-run: no Apify calls made)")
+        return 0
+
+    registry: list[dict] = []
+    for p in picks:
+        try:
+            task_id = upsert_task(token, campaign, p)
+        except Exception as exc:
+            print(f"  ! failed to upsert task for {p['actor_id']}: {exc}", file=sys.stderr)
+            continue
+        registry.append({"task_id": task_id, "actor_id": p["actor_id"], "signal_type": p["signal_type"]})
+        print(f"  ok  {p['actor_id']}  →  task {task_id}")
+
+    reg_path = campaign_dir / f".{campaign}.tasks.json"
+    reg_path.write_text(json.dumps(registry, indent=2), encoding="utf-8")
+    print(f"wrote task registry → {reg_path}")
+
+    if args.no_schedule:
+        return 0
+    cron = icp.get("schedule", {}).get("apify_side_cron")
+    if not cron:
+        print("no schedule.apify_side_cron in ICP — skipping schedule creation")
+        return 0
+    sched_id = upsert_schedule(token, campaign, cron, [r["task_id"] for r in registry])
+    print(f"schedule '{campaign}-schedule' → {sched_id} (cron: {cron})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a new skill: **apify-buying-signal-detection**.

Turns an ICP description into a recurring pipeline that surfaces companies showing buying intent across three signal types — job postings, fundraising events, and LinkedIn content — and appends them to a single deduplicated `leads.csv`.

Design commitments:
- **Split-schedule architecture** — Apify Actor Tasks run on their own cadence; a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads.
- **Weekly idempotency at aggregation time** — if the CSV already has an entry from the current ISO week, the aggregate script exits early with no HTTP calls.
- **First-seen wins on dedup** — the signal that first surfaced a company stays with that company.

## Contents

- `skills/apify-buying-signal-detection/SKILL.md`
- `scripts/aggregate.py`, `scripts/setup_apify_tasks.py` (Python stdlib only, `requests` optional with `urllib` fallback)
- `examples/` — ICP config, blacklist, leads CSV
- `references/` — Actor routing, CSV schema, ICP config schema, gotchas
- One new entry in `.claude-plugin/marketplace.json`

## Compliance checklist

- [x] One skill per PR
- [x] Only touches the skill dir + `.claude-plugin/marketplace.json`
- [x] `bash scripts/lint_telemetry.sh` passes locally
- [x] Uses publicly available Apify Actors only
- [x] `name:` in SKILL.md matches folder name