### PR TITLE
fix: restore apify-x402-agentic-wallet marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -207,6 +207,28 @@
       ],
       "category": "data-extraction",
       "version": "1.0.0"
+    },
+    {
+      "name": "apify-x402-agentic-wallet",
+      "source": "./skills/apify-x402-agentic-wallet",
+      "skills": "./",
+      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) — no Apify account or API key. Buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, or mentions x402, awal, agentic wallet, or paying on-chain per use.",
+      "keywords": [
+        "x402",
+        "awal",
+        "agentic-wallet",
+        "coinbase",
+        "usdc",
+        "base",
+        "crypto",
+        "pay-per-use",
+        "prepaid-token",
+        "no-api-key",
+        "micropayments",
+        "web-data"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Problem

`main`'s validator has been failing since 2026-06-29. Commit 654793c removed the `apify-x402-agentic-wallet` entry from `.claude-plugin/marketplace.json` but left `skills/apify-x402-agentic-wallet/SKILL.md` in the tree. `scripts/generate_agents.py` treats any `skills/*/SKILL.md` without a marketplace entry as a hard error (`validate_marketplace_sync`), so it exits 1 on `main` as it stands.

Two things break as a result:

1. **The post-merge `regenerate` job fails on every push.** Last successful run: 2026-06-17. The README skills table is stale at 8 rows, missing `apify-booking-host-leads` and `apify-x402-agentic-wallet`.
2. **`validate-pr` fails on every open PR.** `actions/checkout` builds the `pull_request` merge ref, so each PR inherits the orphan and fails a step that has nothing to do with its own contents.

## Fix

Restores the entry verbatim from 74f7763 (the commit immediately before its removal). One file, 22 lines added, no other changes.

`uv run scripts/generate_agents.py` now exits 0 — it also regenerates `agents/AGENTS.md` and the README table, but those are deliberately left out of this commit so the post-merge `regenerate` job owns them, per CONTRIBUTING.md.

## Note for @martinforejt

If pulling x402 from the marketplace listing was intentional, the correct completion is removing `skills/apify-x402-agentic-wallet/` too, not leaving the directory orphaned. Say so and we'll swap this for a directory removal. Meanwhile this unblocks CI for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)