### PR TITLE
Add apify-blocked-scrape-triage skill

### DIFF
--- a/skills/apify-blocked-scrape-triage/SKILL.md
+++ b/skills/apify-blocked-scrape-triage/SKILL.md
@@ -123,7 +123,7 @@ You are here only if a server answered. The single most expensive mistake now is
 
 | What came back | Most likely cause | Do NOT | Go to |
 |---|---|---|---|
-| 403, CDN error page, the edge **identified as Cloudflare** (`server: cloudflare`, `cf-ray`), **no** `cf-mitigated` header | a rule that read your address or ASN. Nothing of yours was evaluated | change your client: a real browser can fail identically | Step 3, egress work |
+| 403, CDN error page, the edge **identified as Cloudflare** (`server: cloudflare`, `cf-ray`), **no** `cf-mitigated` header, and a blocked-page body rather than an interstitial | a rule that read your address or ASN. Nothing of yours was evaluated | change your client: a real browser can fail identically | Step 3, egress work |
 | 403 or 503, interstitial body (`Just a moment...`), **`cf-mitigated` present**, CSP naming a challenge host | a managed challenge. The edge will admit a good client, and the check clears itself given seconds | escalate straight to a browser Actor, see Rung 5 for what that actually did | Rung 1, then Rung 5 |
 | 403 from an edge that is **not** Cloudflare, or one you have not identified yet | unclassified. The Cloudflare marker cannot appear here, so its absence carries no information | read "no `cf-mitigated`" as "my address was judged" | name the vendor first, see below |
 | 200, a full server-rendered page carrying a form with hidden state (`__VIEWSTATE`, `__EVENTVALIDATION`, a CSRF field), and no records | not a block and not a shell. The records are behind a POST you never issued | read the empty form as a defence, or send it to Rung 5 for a browser | the form test below |
@@ -147,7 +147,7 @@ You are here only if a server answered. The single most expensive mistake now is
 
 | Edge | What identifies it | What separates hard block from challenge there |
 |---|---|---|
-| Cloudflare | `server: cloudflare`, `cf-ray`. Measured on a refusal: 4,560-byte body, `Sorry, you have been blocked` | `cf-mitigated`. Present means a managed challenge, absent means your address |
+| Cloudflare | `server: cloudflare`, `cf-ray`. Measured on a refusal: 4,560-byte body, `Sorry, you have been blocked` | `cf-mitigated` first, then the body. Present means a managed challenge; absent **plus a blocked-page body** means your address. Absent **with an interstitial body** is still a challenge: custom rules and newer challenge widgets do not all set the header, so let the body overrule it |
 | Akamai | `Server-Timing: ak_p`, `X-Reference-Error`, a body naming `errors.edgesuite.net`. Measured on a refusal: 384 bytes, `Access Denied`, and **no `Server` and no `Via` header at all** | not `cf-mitigated`, which never appears here. Treat the refusal as unclassified and let a second egress decide |
 | anything else, or unidentified | whatever `Server`, `Via`, `X-Cache` and `Server-Timing` do carry | unknown. Say so, and route by the second egress rather than by an absent header |
 
@@ -193,6 +193,10 @@ Write down which row you are in. Every later decision depends on it.
 **Test A moves more often than people expect, and it is free.** Measured on a state assessment portal from one hosting egress: a default HTTP client got `403` and a real desktop Chrome on the same address got the full page, same minutes. The `403` was about the client, not the address, and every proxy in the world would have been the wrong purchase. That page then printed terms forbidding automated collection, which is a Step 0 answer and not a Rung 1 one.
 
 **Two refusals are not a verdict, and this is where people abandon reachable sites.** A hosting IP and a datacenter proxy are the same class of address to a WAF, so refusing both is one fact, not two. Before calling a site defended, spend **exactly one run** on a residential egress in the country the site serves. If residential from the right country is also refused, the site is genuinely defended and "How this ends" applies.
+
+**That probe is billed traffic, so it is the one step to ask about rather than perform.** Residential is charged by volume and this skill exists to prevent buying it reflexively; running it unattended, on someone's account, to satisfy a diagnosis is the same mistake at a smaller scale. State what the probe would cost and what it would settle, then run it once when the answer is yes. Everything before this point is free or sub-cent.
+
+**And prefer a free vantage point to a paid one whenever you have both.** If you can issue a request from a second network yourself, a plain `curl` from there answers the same question as an Actor run, immediately and at no cost, and it shows you the things a crawler hides: whether TCP connected at all, the raw headers, the body before any parsing. Spend the run when your only second egress is the platform's.
 
 **When two same-class egresses disagree, stop before you buy anything.** The rule above expects a hosting IP and a datacenter proxy to be judged alike. When they are not, the rule being applied is not about the class of network at all: it is about your specific address or its immediate neighbours, and the fix is another datacenter egress, which is cheap and probably already in your account. Residential is the wrong purchase here, and this is where the reflex costs the most for the least.
 
@@ -308,7 +312,9 @@ It still retires the blocked session, so the pool keeps rotating away from bad a
 
 **This is a diagnostic switch, not a crawl setting.** Take it out once you have classified the refusal, or your crawl will happily write challenge pages into your dataset as if they were records.
 
-**It also reaches into Crawlee's internals rather than a supported option, so treat it as version-bound.** `retireOnBlockedStatusCodes` is a session method, not a documented input, and an upgrade can rename or restructure it with no error on your side. The failure is silent and recognisable: refusals go back to arriving as items with no status and no headers, exactly as described above. Check that first field before blaming the site. The supported-looking alternative does not do this job, measured: setting `gotOptions.throwHttpErrors = false` left one classified refusal out of six against six out of six with the hook.
+**Why a hook and not a setting.** Crawlee the library does expose this behaviour through session pool options, but you are not calling the library, you are filling in an Actor's input, and that input does not carry them. Measured against the published build schema of `apify/cheerio-scraper`: 30 input fields, and `sessionPoolOptions`, `blockedStatusCodes`, `additionalHttpErrorStatusCodes` and `gotOptions` are absent from all of them; the only session-related field is `sessionPoolName`. `preNavigationHooks` is the one field that hands you a live session object, which is why the fix lives there.
+
+**It does reach into internals, so treat it as version-bound.** `retireOnBlockedStatusCodes` is a session method rather than a documented input, and an upgrade can rename or restructure it with no error on your side. The failure is silent and recognisable: refusals go back to arriving as items with no status and no headers, exactly as described above. Check that field before blaming the site. The setting people try first does not do this job, measured: `gotOptions.throwHttpErrors = false` left one classified refusal out of six, against six out of six with the hook.
 
 ## Troubleshooting
 

--- a/skills/apify-blocked-scrape-triage/SKILL.md
+++ b/skills/apify-blocked-scrape-triage/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: apify-blocked-scrape-triage
+description: Diagnose and recover a scrape that is blocked, throttled, or served empty or partial content, in cost order, before paying for a heavier Actor. Use when a run returns 0 items, when a site answers 403, 429 or a challenge page, when the HTML comes back empty or truncated, when a request fails with no response at all, when the page shows data in a browser that the Actor does not see, or when a scraper that worked yesterday suddenly returns nothing. Triggers - "I'm getting blocked", "403 from the site", "429 rate limited", "Cloudflare challenge", "scraper returns empty results", "connection reset", "page loads in my browser but not in the Actor", "do I need residential proxies", "should I switch to a browser", "my scraper broke overnight". Escalates in cost order - a cheaper published source first, then reachability, request rate and IP spread, request fidelity, session tokens, the site's own internal API, browser last.
+author: Mikhail Koviazin
+author_url: https://github.com/mikhail-koviazin
+---
+
+# Blocked scrape triage
+
+A scrape came back wrong. Find out why before changing anything, then escalate in cost order. Most "blocks" are not bot detection, some are not even a live server, and the browser is the most expensive answer rather than the first one.
+
+Work the steps in order. Step 0 ends more investigations than the whole ladder does.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## What a diagnosis is allowed to cost
+
+**One DNS pair, one navigation per egress per host, then stop and conclude.** The unit is the host, not the organisation: one county published its records across three hostnames that refused a request in three different ways, and a budget spent on "the target" would have bought one of those three answers. The budget counts requests to hosts the target owns; looking something up on a third-party platform, a data catalogue or your own IP check is free. If you are four requests into one host and still cannot name the cause, you are no longer diagnosing, you are probing, and you should say what you know and what it would cost to learn more. One navigation means one page: a browser pulling forty subresources for that page is still one navigation, and a burst of repeated probes is not. The one exception worth spending on is the residential probe in Step 3, a single run that separates "your network" from "actually defended".
+
+Sample before you commit to a fix, change one variable at a time, and remember that your diagnosis is traffic the target counts. Residential traffic and browser Actors are the two line items that surprise people.
+
+**One variable includes time.** Measurements taken from one egress at 05:44 and from another at 05:57 differ by network *and* by half an hour, and a refusal that expired on its own is indistinguishable from one your second egress defeated. When you compare two egresses, interleave them inside the same minute. This bit a real investigation: three hosts looked like a clean "the network is the cause" result until the blocked egress was re-measured later and two of the three answers had changed.
+
+## Know your own vantage point first
+
+Two requests, both free, both about you rather than the target. Skipping them is how a problem with your own address becomes a proxy purchase.
+
+**1. What your egress looks like from outside.** Not its class in the abstract, the actual address, network and country the site sees:
+
+```bash
+curl -s "http://ip-api.com/json/?fields=query,country,as,org,hosting"
+```
+
+That service is free for non-commercial use and rate limited, and it tells you where you stand in its own headers: a live call returned `X-Rl: 44` (calls left in the window) with `X-Ttl: 60` (seconds until reset). Read them rather than discovering the limit as a failure, and for anything regular use a source whose terms fit your use. When you only need the address, the country and which POP you land on, an endpoint with no such conditions does that much:
+
+```bash
+curl -s "https://www.cloudflare.com/cdn-cgi/trace"
+```
+
+Measured side by side from one egress: the trace returned `ip=64.176.60.193`, `loc=JP` and `colo=KIX`, while the first call added what the trace does not carry, `AS20473 The Constant Company` and `"hosting": true`. The ASN and the hosting flag are the parts that predict a refusal, so the cheaper endpoint is a supplement rather than a replacement.
+
+`"hosting": true` means every WAF you meet has classified you before reading a single header of yours, and that a `403` from a public site is the expected answer rather than a surprise. **Egress** below means exactly this: the network your request leaves from, as the site sees it. Two egresses of the same class, a hosting IP and a datacenter proxy, are usually one data point to a WAF rather than two.
+
+**Run this from every machine you are about to call a separate vantage point, and compare the addresses rather than the machines.** A laptop behind a VPN client and the VPN's own server are one egress, not two, and the check says so in one line. Measured: two machines a continent apart returned the same `query` address, so every "second opinion" taken from the laptop was the first opinion again. What did differ was the path: the same request that timed out after 30 seconds from the laptop reported `connect=0.000000s` from the server, which is a silent TCP drop rather than a slow host, and only the second form of the measurement says which one you have.
+
+**2. Whether your DNS answers mean anything.** Resolve over DoH rather than UDP, against two providers:
+
+```bash
+curl -s -H "accept: application/dns-json" "https://dns.google/resolve?name=HOST&type=A"
+curl -s -H "accept: application/dns-json" "https://cloudflare-dns.com/dns-query?name=HOST&type=A"
+```
+
+**If UDP answers hand back a non-routable address while DoH returns a real one, your own machine is answering, and the UDP answer is not evidence of anything.** The usual cause is not hostile: proxy clients in the Clash, mihomo and sing-box family default to fake-ip mode, where the client invents an address out of `198.18.0.0/15` so it can route by hostname rather than by IP. Addressing the query to `1.1.1.1` or `8.8.8.8` changes nothing, because the answer never leaves the machine. Observed on exactly such a setup: both UDP queries returned `198.18.5.101` for a host whose real addresses came back over DoH from those same two providers.
+
+If you are on a VPN or proxy client at all, assume this until DoH says otherwise, and never report a host as dead on a UDP answer alone.
+
+**DoH is the better witness here, not an infallible one.** On a corporate or container network with split-horizon DNS, an internal name resolves only through the local resolver, and DoH will answer NXDOMAIN for a host that exists for you; some networks also block DoH outright. The rule above is about public sites, where the public answer is the one that matters. If your target is internal, invert it: trust the local resolver and use DoH only to prove the name is not public.
+
+## Step 0: is this data published somewhere cheaper
+
+These checks cost at most one request each and they end the investigation outright. In a sweep of twenty-one public data sites, this section was the right answer more often than the entire ladder below. **That sample is public-sector and open-data heavy, where defences are rare and publication is common**, so read the ratio as an argument for checking cheaply first, not as a claim about the web at large: on commercial marketplaces and listing sites the balance moves the other way, and this section will end fewer of your investigations.
+
+- **A deliberate publication of the same data.** An open data portal, an ArcGIS REST service, a bulk download page, a `.json` twin of the HTML route, `sitemap.xml`. A published feed is cheaper, more stable and more complete than anything you will scrape, and it often answers from an egress the main site is refusing.
+- **A login you do not own, or a paywall.** Stop and say so.
+- **Terms that forbid this collection.** Read the target page itself, not only `robots.txt`: assessment portals in particular tend to print the prohibition in the page body while `robots.txt` says nothing. Many sites publish no `robots.txt` at all, and its absence decides nothing either way. Where the terms forbid automated collection and a portal publishes the same records, the portal is not a workaround, it is the supported route.
+
+**Find the portal rather than guessing at it.** Two families cover most public data, and both have a discovery step people skip because the URL template is easy to remember and useless without an id.
+
+```bash
+# Socrata: ask the federated catalog what a domain publishes, then fetch by id
+curl -s "https://api.us.socrata.com/api/catalog/v1?domains=DOMAIN&q=TERM&limit=5"
+curl -s "https://DOMAIN/resource/DATASET_ID.json?\$limit=5"
+
+# ArcGIS: walk the directory instead of guessing a layer number
+curl -s "https://HOST/arcgis/rest/services?f=json"
+curl -s "https://HOST/arcgis/rest/services/FOLDER/SERVICE/MapServer?f=json"
+curl -s "https://HOST/arcgis/rest/services/FOLDER/SERVICE/MapServer/LAYER/query?where=1%3D1&outFields=*&resultRecordCount=5&returnGeometry=false&f=json"
+```
+
+**A hostname that answers is still a guess, and the check is the content rather than the status.** The catalog endpoint above returns the whole federated catalog on *any* host, so a guessed portal name answered `200` with ten thousand results belonging to three other states, and the real portal returned the same rows. Asking the platform whether it knows the domain separated them in one request: `?domains=GUESSED_HOST` answered `{"error":"Domain not found: ..."}` for the guess and its own datasets for the real one. Generalised: **ask whether the records name the host you asked.** The same rule kills wildcard DNS, where every name in a zone resolves and none of them is a service.
+
+**A hostname with no owner in it is usually a vendor serving hundreds of clients**, so the block belongs to the vendor rather than to the body whose data you want, and that body often publishes the records itself. Check the CNAME before assuming independence: four portals under four different government domains resolved to the same three addresses, each CNAME naming the same vendor, sharing one rate limit and one point of failure that the hostnames do not show.
+
+## Step 1: did anything come back, and is the target still there
+
+Everything after this step assumes a server answered you. Three failure classes produce no HTTP conversation at all, they are the cheapest things that can be wrong, and they are the most expensive to miss, because every rung below will fail identically against them at increasing cost.
+
+| Symptom | What it usually is | Check |
+|---|---|---|
+| No status, no headers, no body; the client reports a DNS error | the hostname does not exist publicly | resolve it against **two public resolvers you did not configure** |
+| TCP connects, then the TLS handshake fails | something in your own path is intercepting, or the name resolved to the wrong host | compare the resolved address across resolvers before touching the request |
+| Connection refused or reset with no response | wrong port, dead host, or a network-level drop | as above, then check the site's current navigation |
+| Your resolver returns an address in a private range, CGNAT (`100.64/10`) or `198.18.0.0/15` | **either** the name is not public, **or** your path intercepts transparently | the two-answer test below. Do not stop on the address alone |
+
+**Resolve the way the pre-flight section says, over DoH, against two providers.** A local, corporate or captive resolver will happily answer for a name that does not exist publicly, and on an intercepted path it will do so in the name of whatever resolver you addressed. If two providers both return NXDOMAIN over DoH, the host does not exist and nothing below applies. One free query, and it can end the investigation.
+
+**A non-routable answer is a question, not a verdict.** Transparent interception is common on corporate and VPN paths, and it works: your traffic still reaches the real origin.
+
+| DoH answers | Your traffic | Meaning | Do |
+|---|---|---|---|
+| NXDOMAIN from both | nothing arrives | the host does not exist | stop, re-target |
+| **a non-routable address, typically from `198.18.0.0/15`** | anything | **your own proxy client answered** (fake-ip mode), and the address says nothing about the host | re-resolve over DoH; if DoH gives a real address, use that and move on. If DoH agrees, treat DNS as unavailable and let a second egress decide |
+| real address | nothing arrives, or the origin looks wrong | your path is breaking the connection | fix or bypass your path first, and do not blame the site |
+| real address | real origin headers arrive (CDN POP ids, coherent `ETag`s across repeats) | **transparent interception that works** | **proceed**, and record this vantage point as confounded: any verdict now needs a second egress |
+
+**An answer proves less than absence does.** NXDOMAIN proves the name is not public; a real address proves almost nothing, because behind a shared CDN a wildcard record answers for every name in the zone. Confirm a guessed hostname the way Step 0 describes, by asking whether the content names the host you asked.
+
+**A verdict belongs to a host and a path together.** Measured on one vendor platform in the same minute from one egress: `robots.txt` answered `200` while `/` and `/sitemap.xml` answered `403`. The `200` came from the CDN's own managed copy of `robots.txt` and never reached the origin. Before recording "this host blocks us", fetch a second path as a control, and prefer one the CDN cannot be answering for.
+
+**Then check the URL is still the one the site publishes.** The most ordinary cause of "I pulled nothing useful" is not a defence, it is a stale address. Sites move search, catalogues and APIs onto vendor platforms and leave the old hostname to rot for years. Open the site's own current navigation and confirm the path you are using is the one it links to today.
+
+**Stop rule for this step.** If the host does not resolve, or the site no longer publishes that path, you are finished. There is nothing to unblock.
+
+## Step 2: classify what came back
+
+You are here only if a server answered. The single most expensive mistake now is reading every failure as "they detected me" and jumping to a browser with residential proxies. Match the symptom first, and **read the body before you read the status**.
+
+| What came back | Most likely cause | Do NOT | Go to |
+|---|---|---|---|
+| 403, CDN error page, the edge **identified as Cloudflare** (`server: cloudflare`, `cf-ray`), **no** `cf-mitigated` header | a rule that read your address or ASN. Nothing of yours was evaluated | change your client: a real browser can fail identically | Step 3, egress work |
+| 403 or 503, interstitial body (`Just a moment...`), **`cf-mitigated` present**, CSP naming a challenge host | a managed challenge. The edge will admit a good client, and the check clears itself given seconds | escalate straight to a browser Actor, see Rung 5 for what that actually did | Rung 1, then Rung 5 |
+| 403 from an edge that is **not** Cloudflare, or one you have not identified yet | unclassified. The Cloudflare marker cannot appear here, so its absence carries no information | read "no `cf-mitigated`" as "my address was judged" | name the vendor first, see below |
+| 200, a full server-rendered page carrying a form with hidden state (`__VIEWSTATE`, `__EVENTVALIDATION`, a CSRF field), and no records | not a block and not a shell. The records are behind a POST you never issued | read the empty form as a defence, or send it to Rung 5 for a browser | the form test below |
+| 403 with an XML or JSON error body from a storage service (`AccessDenied`, `RequestId`, `Server: AmazonS3` or equivalent) | **an object that does not exist.** Storage answers 403 rather than 404 for a missing key | shop for proxies | Step 1, the path is dead |
+| 403 only after N successful requests | rate, or a session that aged out | rotate IPs blindly | Rung 1 |
+| 429, often with `Retry-After` | explicit rate limit, and they are telling you the number | ignore the header | Rung 1 |
+| A normal page plus an injected sensor script and edge cookies (`incap_*`, `__cf*`) set on the first hit | not a block. It is notice that the **API behind this page** is defended even though the page is not | assume the next layer is as open as this one | Rung 4, and carry those cookies (Rung 3) |
+| 200, small body, a mount point and a JS bundle (`<div id="root">`, `/assets/index-*.js`) | a single-page app shell. The records arrive after load | assume blocking; assume the URL matters | Rung 4 |
+| 200, a rendered site whose record links point at another domain | a brochure. The data was never on this host | keep parsing this host | Step 1, re-target |
+| 200, tiny body, no scripts, a `<meta http-equiv="refresh">` or a `location` assignment | a redirect stub. The real page is one hop away | parse this body for records | follow the target, then re-classify |
+| 200, a body of a few dozen bytes that **is** the refusal (`Invalid Password`, `Not authorized`, `Missing parameter`) | not a block and not a defence. An endpoint that wants arguments you did not send | treat the 200 as success, or send it to Rung 4: there is no JSON twin behind a CGI | the parameter test below |
+| 200, small body, a stock server welcome page (`IIS Windows Server`, `Welcome to nginx`) | a bare host or the wrong virtual host, not the application | read it as the site's answer | Step 1, re-target |
+| A 2xx that is not 200, especially `202` with a near-empty body | not a success. Often an edge answering for an origin that did not, and frequently the site has moved | treat 2xx as "it worked" | compare `loadedUrl` with what you asked for, then Step 1 |
+| 200, but fewer items than the browser shows | pagination cap, API limit, or a logged-out view | assume blocking | Rung 4 |
+| 200 titled `Page not found`, with full site chrome | a soft 404 | trust status, headers or size; only content shows it | Step 1, the path is dead |
+| Worked yesterday, empty today, no error | the site changed markup or endpoints | escalate proxies | Rung 4, re-inspect |
+
+**The first two rows are one status code and two different situations.** A hard block and a managed challenge both arrive as `403` from the same CDN vendor, they route in opposite directions, and the header separates them. Both were measured on the same afternoon from one egress: a government portal answered a plain HTTP client with a bare `403` and no `cf-mitigated`, a vendor platform answered the same client with `cf-mitigated: challenge` and `Just a moment...`. **Your diagnostic Actor cannot see either header until you unblind it**, and until then both arrive as an empty item. The one-line fix is in "Making refusals visible" below; apply it before using this table.
+
+**Name the edge before you use its marker, because `cf-mitigated` is one vendor's header and absence is not evidence.** On any edge that is not Cloudflare the header cannot appear, so "no `cf-mitigated`" is guaranteed and tells you nothing, while the rule that reads it happily returns "your address was judged" for every one of them. Identify the vendor from what did arrive:
+
+| Edge | What identifies it | What separates hard block from challenge there |
+|---|---|---|
+| Cloudflare | `server: cloudflare`, `cf-ray`. Measured on a refusal: 4,560-byte body, `Sorry, you have been blocked` | `cf-mitigated`. Present means a managed challenge, absent means your address |
+| Akamai | `Server-Timing: ak_p`, `X-Reference-Error`, a body naming `errors.edgesuite.net`. Measured on a refusal: 384 bytes, `Access Denied`, and **no `Server` and no `Via` header at all** | not `cf-mitigated`, which never appears here. Treat the refusal as unclassified and let a second egress decide |
+| anything else, or unidentified | whatever `Server`, `Via`, `X-Cache` and `Server-Timing` do carry | unknown. Say so, and route by the second egress rather than by an absent header |
+
+**A refusal is a measurement, not a property of the site, and some refusals expire.** The Akamai refusal above carried `Server-Timing: cdn-cache; desc=HIT` on a `403` whose own `Cache-Control` said `max-age=0`, meaning the error object was served from the edge cache and never reached the origin. Thirty-eight minutes later the same URL from the same address answered `302` and then `200` with 81,337 bytes, three times running. Nothing about the requester had changed. This is not a promise that refusals dissolve: an ASN or geo rule in a firewall is stable for as long as someone leaves it there, and re-measuring only confirms it. The point is the asymmetry of cost. One repeat request is free and it either upgrades a single observation into a stable fact or saves you a proxy purchase against a refusal that was never about you.
+
+**The parameter test, for an endpoint that answers 200 by refusing you.** A missing argument and a credential you do not own look identical in the response, and they end in opposite places: one is Rung 3, the other stops the investigation at Step 0. Decide by where the value comes from, not by what it is called.
+
+- **The site itself hands it out** to anyone who loads the page: a district code in a public dropdown, a build id in the HTML, a token the page fetches before its first search, a guest login printed in the UI. That is a parameter of a public route. Take it the way the page does, Rung 3.
+- **It is issued to a person**, or it gates records the site does not otherwise publish. That is a credential you do not own, whatever the field is named. **Stop and say so**, and never guess, rotate or construct one.
+- **Unsure after one look at the page that issues it?** Treat it as the second case and go to Step 0 to look for a published copy of the data. A source that requires an account almost always has a bulk or catalogue route that does not.
+
+**The form test, for a full page that carries a form instead of records.** Server-rendered forms with hidden state are the default shape of government and utility record systems, and a GET-only crawler receives a valid `200` from one forever, with no error and no records. This is not the SPA shell row: there is no mount point and no bundle, the page is large, and the data is one POST away rather than one XHR away.
+
+1. **Issue the POST the form describes**, carrying every hidden field it hands you (`__VIEWSTATE`, `__VIEWSTATEGENERATOR`, `__EVENTVALIDATION` and friends) plus the search field, with a `Referer` of the form page.
+2. **Read where the answer goes.** If the response is a redirect to a URL carrying your query in its parameters, you have the record address rather than a session.
+3. **Then test that address cold**, in a fresh client with no cookies and no `Referer`. This is the step that decides the whole job.
+
+Measured on a county assessor's system: the form page answered `200` with 5,316 bytes and a `__VIEWSTATE`; the POST answered `302` to `.../ParcelDetail.aspx?hdnParcel=<key>&hdnInstance=pcl7`; and a cold `curl` of that URL, no cookies, no `Referer`, default user agent, answered `200` with 38,817 bytes of the actual record. One of the two redirect parameters turned out to be optional, so **strip parameters one at a time before you build them into a crawl**. A key the system does not know answered `200` with 747 bytes reading `No record found`, which is a third outcome to record rather than an empty row to drop.
+
+When the cold GET works, the crawl collapses to one request per key, no browser, no session, no postback: fetch the keys from whatever Step 0 turned up and go straight to record URLs.
+
+**Separating a shell from a brochure**, since both are a `200` with no data and the advice is opposite. Do not ask where a human would go; a human really does use the SPA's host. **Ask the body.** A shell is small, has a single empty mount element, loads a JS bundle, and returns the *same bytes and the same `ETag`* for different record ids. A brochure is a full rendered page whose record links point at another domain. Shell means stay, go to Rung 4. Brochure means the target is wrong, return to Step 1.
+
+**Compare the URL you asked for with the URL that answered**, every time. Redirect chains cross domains silently, and a site that moved hosts is the cheapest diagnosis to miss. On one sweep `loadedUrl` was the only field that revealed a county assessor had moved onto the city's domain, behind a `202` that looked like nothing at all.
+
+**`loadedUrl` only exists on a request that completed, which is the case this skill is about.** While every egress is refused you have no redirect chain and no way to see that two hostnames are one site, so two refusals from two different CDN vendors read as two independent targets and double your apparent problem. Two ways out, both cheap: compare the CNAME chains, or wait for the first egress that answers and read `loadedUrl` there. Measured: a `.com` hostname refused by Cloudflare and a `.gov` hostname behind Akamai turned out to be one site, and the `loadedUrl` from the egress that was admitted said so in one field.
+
+Write down which row you are in. Every later decision depends on it.
+
+## Step 3: change one thing about who is asking
+
+**Test A, different client, same egress.** Fetch the same URL with a client that has a different stack; a real desktop browser is ideal, since it differs from a script in headers, TLS and JS execution at once. **If you have no browser sharing your egress, this test is unavailable.** Say so rather than substituting something that is not the same comparison.
+
+**Test B, different egress.** On Apify that is an Actor run, not a one-line curl: write an input file, write a `pageFunction`, call the Actor, take the dataset id from the response, fetch the items. Budget a few minutes and a sub-cent run. The ready-made input is in [references/diagnostic-run.md](references/diagnostic-run.md).
+
+| Test A (other client, same egress) | Test B (same client, other egress) | What it means | Next |
+|---|---|---|---|
+| works | blocked | your request looks wrong, your network is fine | Rung 2 |
+| blocked | works | your network is the problem, not your client | Rung 1, and you already have the fix |
+| blocked | blocked | **not a verdict yet.** Read the next paragraph before concluding anything | Rung 1, residential probe |
+| works | works, but no data in the HTML | not a block at all, the data is rendered or fetched separately | Rung 4 |
+
+**Test A moves more often than people expect, and it is free.** Measured on a state assessment portal from one hosting egress: a default HTTP client got `403` and a real desktop Chrome on the same address got the full page, same minutes. The `403` was about the client, not the address, and every proxy in the world would have been the wrong purchase. That page then printed terms forbidding automated collection, which is a Step 0 answer and not a Rung 1 one.
+
+**Two refusals are not a verdict, and this is where people abandon reachable sites.** A hosting IP and a datacenter proxy are the same class of address to a WAF, so refusing both is one fact, not two. Before calling a site defended, spend **exactly one run** on a residential egress in the country the site serves. If residential from the right country is also refused, the site is genuinely defended and "How this ends" applies.
+
+**When two same-class egresses disagree, stop before you buy anything.** The rule above expects a hosting IP and a datacenter proxy to be judged alike. When they are not, the rule being applied is not about the class of network at all: it is about your specific address or its immediate neighbours, and the fix is another datacenter egress, which is cheap and probably already in your account. Residential is the wrong purchase here, and this is where the reflex costs the most for the least.
+
+Measured on one county's hosts, one afternoon, two egresses of the same class:
+
+| Host | Hosting IP | Datacenter proxy |
+|---|---|---|
+| the GIS service | no response at all, 30 s timeout | `200`, the service directory |
+| the file download page | `403`, a 399-byte `Access Denied` | `200`, 75 KB, the real page |
+| the API host | `403`, CDN error page, no `cf-mitigated` | not attempted |
+
+Three refusal shapes from one county on one egress, and none of them from the other. Note also that this is Step 1's host-and-path rule again: a silent timeout, a CDN block and a short `Access Denied` are three different mechanisms, and reporting "the county blocks us" would have hidden all three.
+
+**With Test B alone**, the normal case for an agent: **B blocked** means run the residential probe before deciding anything, **B returns a body with no data** means Rung 4 regardless of what A would have shown, and anything needing A is unresolved rather than guessed. B also changes the network *and* the client stack at once, so when the two disagree you cannot attribute it to either until you hold one constant.
+
+**A single outcome is not a rate.** Six identical requests to one vendor platform, one run, returned three clean pages and three refusals from the same proxy pool. Draw conclusions from a sample. The four-request worked example behind this whole section, where the answer was the network and residential bought nothing, and the sample size that makes a block rate countable, are both in [references/gotchas.md](references/gotchas.md).
+
+## The ladder
+
+Enter it only if Step 2 or Step 3 sent you here. Classification decides; the ladder only remediates, cheapest rung first.
+
+**Rungs 1 to 3 are remediation you will recognise**, and each is a paragraph rather than a page here, with the settings and the traps in [references/rungs-1-3.md](references/rungs-1-3.md):
+
+1. **Rate and IP spread.** Lower `maxConcurrency`, honour `Retry-After`, and run the residential probe Step 3 already described, once. Choose `proxyRotation` deliberately, because a stateful flow under `PER_REQUEST` looks far more suspicious than a steady crawler.
+2. **Request fidelity.** Make your headers, their order and the `Referer` chain form one plausible client, and match `Accept-Language` to the proxy country. `curl -H` cannot control header order, so set them in `preNavigationHooks`. Below headers sits the TLS and HTTP/2 fingerprint, which no header work fixes: that layer means uTLS or curl-impersonate, or Rung 5.
+3. **Tokens and edge cookies from a legitimate flow.** A build id, a CSRF or search token, a signed URL, or the cookies a WAF sets on first contact. Take it the way the page does, bind it to the session and address that earned it, respect its TTL. If Step 2 saw a sensor script on an otherwise clean page, carry those cookies into Rung 4.
+
+### Rung 4: the site's own internal API
+
+The highest-leverage rung, and the one most often skipped. The public HTML is the most defended, most fragile and least complete surface a site has. All four routes below work without a browser, which is why this rung comes first:
+
+1. **State embedded in the HTML you already downloaded.** `__NEXT_DATA__`, `window.__INITIAL_STATE__`, `<script type="application/json">`, JSON-LD. Zero extra requests.
+2. **The JS bundle the shell loads.** For a plain React or Vue app with no embedded state, fetch the bundle named in the shell and grep it for path literals: `/api/`, `/v1/`, `.json`, a bare hostname. The endpoint the app calls is a string inside that file. One request per bundle.
+3. **Sitemaps, feeds and `.json` twins** of `.html` routes.
+4. **A hosted search provider.** Sites often front their catalogue with one, and its endpoint returns clean structured records.
+
+With a browser, devtools filtered to XHR is faster than all of the above; it is listed last because it costs a browser, not because it is worse. Payoff for the rung: usually faster, cheaper per record, more stable across redesigns, and less defended. It often removes the blocking problem instead of working around it.
+
+**The HTTP Actor will not fetch the endpoint you just found unless you tell it to.** `apify/cheerio-scraper` supports `text/html` and `application/xhtml+xml` and **skips every other content type**, which is exactly the JSON this rung exists to reach. The field that fixes it is:
+
+```json
+{ "additionalMimeTypes": ["application/json", "text/plain"] }
+```
+
+**Measured trap: that field is currently not accepted through the MCP `call-actor` tool at all**, and its error message sends you hunting in the wrong place. An array is rejected with `Validation errors: must be object`, the same array as a JSON string is rejected the same way, and an object is rejected with `must be array`, while the Actor's own build schema declares the field `"type": "array"`. Everything else in the diagnostic input goes through untouched, including `preNavigationHooks`, `maxRequestRetries: 0`, `maxConcurrency`, `pageLoadTimeoutSecs`, a `customData` object and a `pageFunction` full of backslashes, so this is one field rather than your escaping. Three ways past it, cheapest first:
+
+- **Ask the endpoint for HTML.** An ArcGIS or Socrata service answers `f=html` or a browsable catalogue page with the same content, and that route measured `200` through the Actor on a host whose JSON form the Actor would have skipped. Good enough to diagnose, not what you want in production.
+- **Fetch it with your own code.** A paginated JSON endpoint is a loop over `resultOffset`, not a crawl: there are no links to follow and no HTML to parse, so twenty lines beat any crawler Actor and the MIME question disappears.
+- **Run the Actor from somewhere other than the MCP tool** if you have the Console or the CLI. Not tested here, so verify before you count on it.
+
+### Rung 5: browser, last
+
+**A browser is not automatically the stronger client.** Measured on one vendor platform, same URL, same proxy pool, one minute apart: the browser Actor got a hard block page while the plain HTTP Actor got a managed challenge twice and a clean `200` on the third request. Confirm a browser buys you something before you buy one. It costs about twelve times the HTTP Actor per page, and it demands approval of full account access in the Console before its first run, which stops an unattended flow dead.
+
+**A Crawlee-based browser Actor will not wait out a challenge by default:** it aborts on the challenge's `403` before the page can clear, which is the one thing a browser was supposed to be for. Unblind it exactly as below, then wait for the interstitial to disappear inside your `pageFunction`. Numbers and the Chrome comparison: [references/gotchas.md](references/gotchas.md).
+
+**Coherence rule.** Proxy country, `Accept-Language`, timezone and browser profile must agree. An incoherent profile is not stealth, it is a slower way to get blocked at browser prices.
+
+## How this ends
+
+Most investigations end without touching the ladder. All of these are finished results, not failures:
+
+- **The cause is named and it is not a block.** A dead path, a stale URL, an SPA whose records come from an endpoint, data published in a feed. Write down the cause, the egresses you measured from, and the next concrete step.
+- **The cause is named and it is a block you fixed.** Record which single change moved it.
+
+Stop and tell the user when:
+
+- The host does not resolve, the path is gone, or the data is not on this host. Re-target rather than unblock.
+- The terms of the source forbid this collection. Say so at Step 0 rather than after a fix.
+- **A hard block survives residential from the country the site serves.** That is the cheap stop, and it comes after one run rather than after a browser. A managed challenge is the other case: it earns one browser run first, because it is built to clear. On a Cloudflare edge `cf-mitigated` tells you which of the two you have; elsewhere, use the residential result itself as the discriminator rather than an absent header.
+- Browser plus residential plus a coherent profile is still blocked. Cost per record now dominates; look for an official API, a data licence, or another source.
+- Over a real sample, three rungs produced no change in block rate. The diagnosis is wrong, not the tooling.
+- Cost per successful record exceeds what the record is worth. Compute it.
+- The block is a login wall or a paywall.
+
+Once a source is in production, track its failure rate and alert on it. A source that quietly degrades still produces something that looks like a dataset, and you want to hear about it from a graph rather than from a hole in the data.
+
+## Actor routing
+
+| User need | Actor ID | Tier | Best for |
+|---|---|---|---|
+| Plain HTML, no JS needed, cheapest per page | `apify/cheerio-scraper` | apify | Steps 1-3 and Rungs 1-4, the default starting point |
+| Full browser, page function, Chrome | `apify/web-scraper` | apify | Rung 5, client-side rendering |
+| Full browser with Playwright control | `apify/playwright-scraper` | apify | Rung 5, complex flows |
+| Full browser with Puppeteer control | `apify/puppeteer-scraper` | apify | Rung 5, existing Puppeteer logic |
+| Whole-site text extraction for AI pipelines | `apify/website-content-crawler` | apify | content harvesting, not field-level extraction |
+
+Full table with the inputs that matter when blocked: [references/actor-index.md](references/actor-index.md).
+
+## Calling Actors
+
+**Through the Apify MCP server**, which is how an agent normally reaches the platform: `call-actor` with the Actor name and an input object, then `get-dataset-items` with the id from the reply. There is no input file and no shell redirection in this path, and the id you need is at **`storages.datasets.default.id`**, not `defaultDatasetId`. Do not paste the CLI's flags into MCP arguments; they are not parameters of these tools.
+
+Two traps in that reply, both measured. The **item count is read while the run is still flushing and undercounts**: four runs on four different days reported `1` against six stored items, `4` against six, and `3` against four, so read the dataset before concluding how many items a run produced. And **`Validation errors: must be object` does not name the field it means, and its wording points away from the cause**: the same rejection appears for a valid array (`must be object`) and for an object in that same field (`must be array`). Do not go looking for your own escaping. Submit the small input from [references/diagnostic-run.md](references/diagnostic-run.md), which validates as a whole, then add fields one at a time; the known offender is `additionalMimeTypes`, see Rung 4.
+
+**Through the CLI**, if you have one, the call takes an input file and the reply names its storages differently (`storage.defaultDatasetId`, not `storages.datasets.default.id`). Commands and flags: [references/actor-index.md](references/actor-index.md).
+
+### Making refusals visible
+
+**Your diagnostic goes blind on exactly the case you are diagnosing.** Crawlee treats 401, 403 and 429 as blocking and throws `Request blocked - received 403 status code.` before your `pageFunction` runs. The item reaches the dataset with **no fields of yours at all**: no status, no headers, no body, nothing to classify with. Both the HTTP Actors and the browser Actors do this, and the two rows Step 2 opens with are precisely the ones you cannot tell apart in that state.
+
+Put this in `preNavigationHooks` and the refusal arrives as data instead:
+
+```json
+{
+  "preNavigationHooks": "[async ({ session }) => { if (session) { const retire = session.retireOnBlockedStatusCodes.bind(session); session.retireOnBlockedStatusCodes = (code, extra) => { retire(code, extra); return false; }; } }]"
+}
+```
+
+It still retires the blocked session, so the pool keeps rotating away from bad addresses, but it stops the throw, so the response reaches your code. Measured over six identical requests to a challenged platform, this took a run from three classified refusals out of six to six out of six, while the variant that skips the retire call sees everything and gets nothing through. The comparison table and the diagnostic `pageFunction` that uses it: [references/diagnostic-run.md](references/diagnostic-run.md).
+
+**There is no fallback field to read instead, and this is worth stating because `#debug.statusCode` looks like one.** It is present on requests that completed, so a run full of `200`s will show it and give you the wrong impression of what you have. Measured on a run without the hook against a platform that refuses: two items, `#error: true`, `#debug.retryCount: 0`, and the entire field list was `#error`, `#debug.requestId`, `#debug.url`, `#debug.method`, `#debug.retryCount`, `#debug.errorMessages`. No status, no headers, no body. If you took the run without the hook, you have the fact that something failed and the message Crawlee threw, and you must re-run to classify.
+
+**This is a diagnostic switch, not a crawl setting.** Take it out once you have classified the refusal, or your crawl will happily write challenge pages into your dataset as if they were records.
+
+**It also reaches into Crawlee's internals rather than a supported option, so treat it as version-bound.** `retireOnBlockedStatusCodes` is a session method, not a documented input, and an upgrade can rename or restructure it with no error on your side. The failure is silent and recognisable: refusals go back to arriving as items with no status and no headers, exactly as described above. Check that first field before blaming the site. The supported-looking alternative does not do this job, measured: setting `gotOptions.throwHttpErrors = false` left one classified refusal out of six against six out of six with the hook.
+
+## Troubleshooting
+
+- **A target is missing from your dataset, or items arrive empty** → Crawlee threw before your code ran. Add the hook from "Making refusals visible", then classify.
+- **403 and you cannot tell a hard block from a challenge** → name the edge first. On Cloudflare `cf-mitigated` decides it. On any other edge that header cannot appear, so its absence is not an answer and the refusal stays unclassified until a second egress speaks.
+- **A refusal that will not reproduce an hour later** → a cached edge error or a rule that has since gone. Check for `cdn-cache` in `Server-Timing` on the refusal itself, and re-measure both egresses inside one minute before you conclude anything.
+- **A 200 carrying a full page, a form and no records** → the form test in Step 2. Issue the POST, then check whether its redirect target answers a cold GET.
+- **Your two vantage points return the same address** → they are one egress. Compare `query` from the egress check on each machine before treating them as independent.
+- **Your resolver answers `198.18.x.x`** → your own proxy client in fake-ip mode, not the site. Re-resolve over DoH.
+- **Your hosting IP is refused and a datacenter proxy is not** → your specific address, not its class. Change datacenter egress, do not buy residential.
+- **A 200 whose whole body is `Invalid Password` or `Not authorized`** → a missing argument or a credential. Apply the parameter test in Step 2.
+- **The JSON endpoint you found comes back empty through the Actor** → `apify/cheerio-scraper` skips non-HTML, and `additionalMimeTypes` is currently rejected through MCP whatever you encode it as. Ask the service for `f=html`, or fetch the endpoint with your own code.
+- **No status, no headers, no body** → Step 1, and check your own vantage point first.
+- **A non-routable address from your own resolver, but traffic works** → transparent interception. Proceed, mark the vantage point confounded, require Test B before any verdict.
+- **0 items, run succeeded** → read `SDK_CRAWLER_STATISTICS_0`; a green run proves nothing.
+- **403 with an XML body naming a storage service** → a missing object, not a defence. The path is dead.
+- **403 from two datacenter or hosting egresses** → not a verdict. One residential run before you conclude.
+- **A guessed portal hostname answers 200** → confirm the records name that host before building on it.
+- **Intermittent 403, or a failure that takes the same number of seconds every time** → look at concurrency and at configured timeouts, not at fingerprints.
+- Detailed traps and recovery: [references/gotchas.md](references/gotchas.md).

--- a/skills/apify-blocked-scrape-triage/SKILL.md
+++ b/skills/apify-blocked-scrape-triage/SKILL.md
@@ -3,6 +3,9 @@ name: apify-blocked-scrape-triage
 description: Diagnose and recover a scrape that is blocked, throttled, or served empty or partial content, in cost order, before paying for a heavier Actor. Use when a run returns 0 items, when a site answers 403, 429 or a challenge page, when the HTML comes back empty or truncated, when a request fails with no response at all, when the page shows data in a browser that the Actor does not see, or when a scraper that worked yesterday suddenly returns nothing. Triggers - "I'm getting blocked", "403 from the site", "429 rate limited", "Cloudflare challenge", "scraper returns empty results", "connection reset", "page loads in my browser but not in the Actor", "do I need residential proxies", "should I switch to a browser", "my scraper broke overnight". Escalates in cost order - a cheaper published source first, then reachability, request rate and IP spread, request fidelity, session tokens, the site's own internal API, browser last.
 author: Mikhail Koviazin
 author_url: https://github.com/mikhail-koviazin
+metadata:
+  category: data-extraction
+  keywords: "blocked, 403, 429, rate-limit, anti-bot, bot-detection, cloudflare-challenge, proxy, residential-proxy, session, empty-results, troubleshooting, web-data"
 ---
 
 # Blocked scrape triage

--- a/skills/apify-blocked-scrape-triage/references/actor-index.md
+++ b/skills/apify-blocked-scrape-triage/references/actor-index.md
@@ -1,0 +1,63 @@
+# Actor index: what to reach for at each rung
+
+All Actor IDs below were resolved against the public Apify Store API and are public at the time of writing. Always confirm the input schema before building an input:
+
+    apify actors info "ACTOR_ID" --input --json \
+      --user-agent apify-awesome-skills/apify-blocked-scrape-triage \
+      2>/dev/null
+
+## Routing
+
+| Need | Actor ID | Tier | Notes |
+|---|---|---|---|
+| Static HTML, cheapest per page | `apify/cheerio-scraper` | apify | Start here. No browser, no JS execution. If the data is in the HTML, nothing else is cheaper. |
+| Browser, Chrome, page function | `apify/web-scraper` | apify | Client-side rendering. One to two orders of magnitude more per page than Cheerio. |
+| Browser, Playwright control | `apify/playwright-scraper` | apify | Multi-engine, complex interaction flows. |
+| Browser, Puppeteer control | `apify/puppeteer-scraper` | apify | When existing Puppeteer logic is being ported. |
+| Whole-site text for AI pipelines | `apify/website-content-crawler` | apify | Content harvesting, not field-level extraction. Wrong tool for structured records. |
+
+## The inputs that matter when you are blocked
+
+These fields exist on `apify/cheerio-scraper`, `apify/web-scraper`, `apify/playwright-scraper` and `apify/puppeteer-scraper` (checked against each Actor's published input schema).
+
+| Field | Type | Why it matters here |
+|---|---|---|
+| `proxyConfiguration` | object | `{"useApifyProxy": true, "apifyProxyGroups": ["RESIDENTIAL"], "apifyProxyCountry": "US"}`. Groups and country are the two knobs; residential is a cost decision, not a default. |
+| `proxyRotation` | string | `RECOMMENDED`, `PER_REQUEST`, `UNTIL_FAILURE`. See the table in `SKILL.md`; stateful flows need `UNTIL_FAILURE`. |
+| `sessionPoolName` | string | Keeps sessions separate between runs that must not share cookies or IP affinity. |
+| `initialCookies` | array | Carry cookies the site issues before the target page. |
+| `preNavigationHooks` | string | Where request headers and their order are set. |
+| `maxConcurrency` | integer | The first thing to lower. Most "detection" is rate. |
+| `maxRequestRetries` | integer | Raise with backoff rather than hammering. |
+| `pageLoadTimeoutSecs` | integer | A slow challenge page and a genuine timeout look the same in logs; separate them. |
+| `ignoreSslErrors` | boolean | Diagnostic only. If this changes the outcome, an interception layer sits in the path. |
+| `respectRobotsTxtFile` | boolean | Defaults to **false**. Turning it on is the right default for a crawl, and it also means a URL can vanish from your results for a reason that is not a block. |
+
+Browser Actors additionally expose `headless`, `useChrome` and `waitUntil`; an incoherent combination of these with the proxy country is the classic self-inflicted block.
+
+**Two things to know before the first browser run.** A browser Actor asks for full account access and refuses to start until that is approved in the Console, which stops an unattended flow dead. And its `pageFunction` context is not the raw Puppeteer or Playwright API: the `response` it hands you is a plain object with `status` and `headers`, the same shape `apify/cheerio-scraper` uses, so `response.status()` throws.
+
+## Calling these from the CLI
+
+`SKILL.md` describes the MCP path, which is how an agent normally runs these. If you have the CLI instead, the same diagnostic input goes in a file, and three flags belong on every call: `--json` for stable output, `--user-agent` for attribution, `2>/dev/null` so progress messages do not break JSON parsing.
+
+```bash
+apify actors call "apify/cheerio-scraper" --input-file diagnose.json \
+  --json \
+  --user-agent apify-awesome-skills/apify-blocked-scrape-triage \
+  2>/dev/null
+```
+
+```bash
+apify datasets get-items DATASET_ID --format json \
+  --user-agent apify-awesome-skills/apify-blocked-scrape-triage \
+  2>/dev/null
+```
+
+**The field names differ between the two paths**, which is a quiet way to lose an hour: the CLI reply carries `storage.defaultDatasetId` and `storage.defaultKeyValueStoreId`, while the MCP reply carries `storages.datasets.default.id`. Neither is `defaultDatasetId` on its own.
+
+## What is deliberately not in this list
+
+- Antidetect browsers and account-warming services. Out of scope for this skill.
+- CAPTCHA-solving services. If a challenge is still the wall after the ladder, the answer is the "How this ends" section of `SKILL.md` (stop and reconsider the source), not automated solving.
+- TLS-level impersonation libraries (uTLS, curl-impersonate). Named in `SKILL.md` as the correct tool class when the evidence points below the header layer, but they are not Apify Actors and are not routed here.

--- a/skills/apify-blocked-scrape-triage/references/diagnostic-run.md
+++ b/skills/apify-blocked-scrape-triage/references/diagnostic-run.md
@@ -1,0 +1,97 @@
+# The diagnostic run: input, output, and the fields that answer Step 2
+
+`SKILL.md` says what to look at. This file is the ready-made run that produces it, plus the places the platform hides something you will need.
+
+## Start with the small input, not the big one
+
+Through the MCP server this whole object is the `input` argument to `call-actor` with `actor: "apify/cheerio-scraper"`; through the CLI it is `diagnose.json`. Either way, **start here**: this object validates as it stands, measured on the first attempt, escaped `pageFunction` and hook included. Start from it and add one field at a time, because when a larger input is rejected the message is `Validation errors: must be object`, it names no field, and its wording points at the wrong thing entirely, see the note under the full input:
+
+```json
+{
+  "startUrls": [{ "url": "https://example.com/" }],
+  "proxyConfiguration": { "useApifyProxy": true },
+  "maxRequestRetries": 0,
+  "maxConcurrency": 1,
+  "preNavigationHooks": "[async ({ session }) => { if (session) { const retire = session.retireOnBlockedStatusCodes.bind(session); session.retireOnBlockedStatusCodes = (code, extra) => { retire(code, extra); return false; }; } }]",
+  "pageFunction": "async function pageFunction(context) { const r = context.response || {}; const h = r.headers || {}; const body = String(context.body || ''); return { url: context.request.url, loadedUrl: context.request.loadedUrl, status: r.status, cfMitigated: h['cf-mitigated'], bytes: body.length, title: context.$('title').text().trim().slice(0, 80) }; }"
+}
+```
+
+Six fields answer the first two rows of Step 2, which is where most investigations end. Grow to the full version below only when the answer is a `200` and you have to tell a shell from a brochure.
+
+**If your target serves JSON rather than HTML**, the field that fixes it is `"additionalMimeTypes": ["application/json", "text/plain"]`, because without it the Actor skips the response and the endpoint looks broken when it is not. **Through MCP that field is rejected in every encoding measured**: an array gives `Validation errors: must be object`, the array as a JSON string gives the same, an object gives `must be array`, and the build schema declares it an array. Everything else here validates alongside it, so when a run is rejected, this is the field to pull first. Workarounds are in Rung 4 of `SKILL.md`: ask the service for an HTML representation, or fetch the endpoint with your own code.
+
+## The full input
+
+The `preNavigationHooks` line is the one from `SKILL.md`, and without it every refusal arrives as an empty item.
+
+```json
+{
+  "startUrls": [{ "url": "https://example.com/" }],
+  "proxyConfiguration": { "useApifyProxy": true },
+  "maxRequestRetries": 0,
+  "maxConcurrency": 1,
+  "preNavigationHooks": "[async ({ session }) => { if (session) { const retire = session.retireOnBlockedStatusCodes.bind(session); session.retireOnBlockedStatusCodes = (code, extra) => { retire(code, extra); return false; }; } }]",
+  "pageFunction": "async function pageFunction(context) { const $ = context.$; const r = context.response || {}; const h = r.headers || {}; const host = new URL(context.request.url).hostname; const links = $('a[href^=\"http\"]').map((i, el) => { try { return new URL($(el).attr('href')).hostname; } catch (e) { return null; } }).get().filter(Boolean); const offHost = links.filter(x => x !== host); const tally = {}; offHost.forEach(x => { tally[x] = (tally[x] || 0) + 1; }); const topOffHost = Object.entries(tally).sort((a, b) => b[1] - a[1]).slice(0, 5); return { url: context.request.url, loadedUrl: context.request.loadedUrl, status: r.status, cfMitigated: h['cf-mitigated'], etag: h.etag, server: h.server, via: h.via, cfRay: h['cf-ray'], xCache: h['x-cache'], retryAfter: h['retry-after'], setCookie: h['set-cookie'] ? String(h['set-cookie']).slice(0, 200) : null, contentType: h['content-type'], bytes: context.body ? context.body.length : 0, title: $('title').text().trim().slice(0, 80), mountPoints: $('#root, #app, #vue-app, [id^=\"__next\"]').length, scripts: $('script[src]').length, offHostLinks: offHost.length, topOffHost: topOffHost, bodyHead: String(context.body || '').replace(/\\s+/g, ' ').slice(0, 300) }; }"
+}
+```
+
+Which field decides what:
+
+- `status` and `cfMitigated` separate a hard block from a managed challenge, the first two rows of Step 2.
+- `etag` and `bytes` run the shell test: an SPA shell returns the same bytes and the same `ETag` for two different record ids.
+- `offHostLinks` and `topOffHost` separate a shell from a brochure.
+- `bodyHead` catches meta-refresh stubs, stock server pages and soft 404s without a second request.
+- `loadedUrl` catches the site that moved. Compare it with `url` every time.
+
+**To measure a rate rather than an outcome**, repeat one URL in `startUrls` with distinct `uniqueKey` values. Six entries, one run, six independent proxy draws, sub-cent.
+
+## The response object is not the raw client's
+
+In `apify/cheerio-scraper` the `response` handed to a `pageFunction` carries exactly two keys, `status` and `headers`. There is no `statusCode`; asking for one returns undefined rather than throwing, which is how it goes silently missing from a diagnostic. The browser Actors hand you the same shape, so `response.status()` throws there instead of returning a number.
+
+The platform also writes its own view into every dataset item: `#debug.statusCode`, `#debug.retryCount`, `#debug.errorMessages` and `#debug.loadedUrl`. When an item arrives with `#error: true` and nothing else, `#debug.errorMessages` is the only thing that says what happened.
+
+## Reading the reply, whichever interface you are on
+
+| What you want | MCP | CLI |
+|---|---|---|
+| the dataset to read | `storages.datasets.default.id` | `storage.defaultDatasetId` |
+| the store holding run counters | `storages.keyValueStores.default.id` | `storage.defaultKeyValueStoreId` |
+| the items | `get-dataset-items` with that id | `apify datasets get-items <id> --format json` |
+
+**The item count in that reply undercounts**, because it is read while the run is still flushing. Measured three times in one afternoon: a reply reporting one item belonged to a dataset holding six, and another reporting four belonged to one holding six. Read the dataset before concluding anything about how many items a run produced.
+
+## Getting the input schema, which is not where you would expect
+
+`apify actors info <actor> --input --json` returns the Actor record, with the schema nested inside it as an escaped string under `taggedBuilds.<tag>.build.inputSchema`, so grepping that output for a field name finds nothing. The direct route works from either interface and returns it as JSON:
+
+```bash
+curl -s "https://api.apify.com/v2/acts/apify~cheerio-scraper/builds/default" \
+  | python -c "import json,sys; print(sorted(json.load(sys.stdin)['data']['actorDefinition']['input']['properties']))"
+```
+
+## Where the request counters actually live
+
+They are not in the call reply and not in `apify runs info`, whose `stats` holds duration, compute units and memory only. Take the key-value store id (see the table above) and read:
+
+```bash
+curl -s "https://api.apify.com/v2/key-value-stores/KV_STORE_ID/records/SDK_CRAWLER_STATISTICS_0"
+```
+
+`requestsFinished`, `requestsFailed` and `requestsRetries` are in there, and so is `requestsWithStatusCode`, a histogram naming the status codes the run actually received. A run can finish `SUCCEEDED` with `exitCode 0` while some requests failed, so read this before concluding anything from a short dataset. Once the hook above is in place the dataset itself answers most of these questions, and the counters are the cross-check rather than the source.
+
+## What the un-blinding hook is worth, measured
+
+Six identical requests to one challenged vendor platform, one run each, same proxy pool, `PER_REQUEST` rotation:
+
+| Hook | Items carrying fields | Refusals classified | Requests that got through |
+|---|---|---|---|
+| none | 3 of 6 | 0, three empty error items | 3 |
+| `gotOptions.throwHttpErrors = false` only | 1 of 6 | 0, five empty error items | 1 |
+| retire and return false | **6 of 6** | **2, both `cf-mitigated: challenge`** | 4 |
+| never retire | 6 of 6 | 6 | **0** |
+
+`throwHttpErrors` is the flag people reach for, and on this failure it changes nothing: Crawlee is not throwing because got threw, it is throwing because the session pool treats 401, 403 and 429 as blocking. Dropping the retire call unblinds the run and costs every request that would have succeeded, because the pool stops rotating away from addresses the site has already refused.
+
+**Take the hook out once the refusal is classified.** Left in, a crawl writes challenge pages into the dataset as if they were records.

--- a/skills/apify-blocked-scrape-triage/references/gotchas.md
+++ b/skills/apify-blocked-scrape-triage/references/gotchas.md
@@ -1,0 +1,92 @@
+# Gotchas: what the field notes say, and what they cost
+
+Every item here was observed on a live public source, not reasoned from documentation. Where a claim is inference rather than measurement, it says so. Anything already stated in `SKILL.md` is not repeated here.
+
+## Diagnosis
+
+### Record where you tested from, every time
+
+A block is a statement about a pair: your request **and** your path to the site. The same URL can answer a residential connection and refuse a hosting IP in the same second. A note that says "the site blocks scrapers" and does not say which network it was tested from cannot be reused by anyone, including its author a month later.
+
+Minimum to write down, and the first two matter more than people expect:
+
+1. **Which resolver answered, and what it said.** Not your configured one alone: a local, corporate or captive resolver can answer for a name that does not exist publicly.
+2. **Whether the returned address is routable.** Private ranges, CGNAT (`100.64/10`) and the RFC 2544 benchmarking range `198.18.0.0/15` mean you are looking at your own path, not the site's.
+3. Egress IP and country.
+4. Whether the egress ASN is residential, mobile or hosting.
+
+Recording only 3 and 4 is how a diagnosis goes wrong quietly. A real case: a host that failed with a TLS error resolved locally to `198.18.4.138`, a bogon, while two public resolvers returned NXDOMAIN. The note written from fields 3 and 4 alone reads "hosting IP in Japan, blocked" and points the next reader at geo and ASN reputation. The host simply did not exist.
+
+### Verdicts of "not blocked" need a second egress too
+
+Everyone knows a single "blocked" result is provisional. A single **clean** result is provisional in the same way, and more dangerously, because nobody re-checks good news. If your own path is confounded at all, and transparent interception is enough to confound it, a local `200` is not evidence that the site is open.
+
+### Connection-level failures leave a different artefact
+
+When there is no response, the usual advice to keep the raw response does not apply. Keep these instead, because they are what the diagnosis is made from:
+
+- the answer from each resolver you asked, including which one, and the returned address;
+- whether TCP connected, and how long that took, separately from what failed afterwards;
+- the exact client error string, since "connection reset", "connection refused" and "TLS handshake failed" point at three different layers.
+
+### Block rate, and when you are allowed to use the words
+
+**Block rate** is refused requests divided by attempted requests, over a sample large enough to mean something: at least twenty requests to the same source. **On a single URL there is no block rate, only an outcome.** Say "it worked" or "it did not" and do not dress one request as a measurement. The "three rungs with no change" stop rule below is a statement about a rate, so it does not apply until you have one.
+
+### A CDN error page is not the site's opinion of you
+
+A generic edge error (`Request blocked`, `Access Denied`, a bare `403` with the CDN named in `Server` or `Via`) is produced before the origin sees the request. It carries no information about your headers, your fingerprint or your behaviour, because nothing of yours was evaluated beyond the network. Treating it as bot detection sends you up the whole ladder against a rule that only reads an address.
+
+Observed on a large US county assessor site fronted by a CDN, four requests to one URL:
+
+| Egress | Client | Result |
+|---|---|---|
+| hosting provider, non-US | default HTTP client | `403`, CDN error page |
+| same IP | live desktop Chrome | `403`, identical |
+| Apify Proxy, **datacenter** | Cheerio, no browser, no JS | **`200`, full page, first attempt** |
+| Apify Proxy, **residential**, US | Cheerio, no browser, no JS | `200`, byte-identical to the row above |
+
+Rows one and two say "not my client": a real browser failed exactly like the script, in the same second. Row three says "not datacenter addresses as a class" either, because the request that succeeded came from a datacenter and was the least browser-like client in the table. What was left was the specific network rows one and two went out on. Row four is the expensive lesson: residential bought nothing here, so it is a probe to run once rather than a setting to adopt.
+
+**Do not predict the result of that test from this one.** The same pair of clients on a state assessment portal, from the same kind of hosting egress, gave the opposite answer: `403` to the HTTP client and the full page to Chrome, in the same minutes. Both sites are `403` behind the same CDN vendor, and only running Test A tells you which of the two you are looking at.
+
+### The browser was the worse client, measured three ways
+
+On one vendor platform behind a managed challenge, in the same fifteen minutes:
+
+| Client and egress | Answer |
+|---|---|
+| HTTP Actor, Apify datacenter proxy | `cf-mitigated: challenge` twice, then a clean `200` with the real page |
+| Browser Actor, same proxy pool, one minute later | hard block page, no `cf-mitigated` |
+| Desktop Chrome, hosting egress that the HTTP client had been challenged from | sat through "Verifying you are human", then loaded the real page |
+
+Three things follow. Escalating to a browser can move you from a passable challenge to a hard refusal, so it is not a strictly stronger client. A managed challenge really does clear itself for an ordinary browser, so the challenge class is worth one browser run. And a Crawlee browser Actor never reaches that point unless unblinded, because it aborts on the challenge's `403` before the page can clear: three requests, three empty error items.
+
+Cost of the comparison: `0.0011` compute units for three requests through the HTTP Actor against `0.0131` through the browser Actor, roughly twelve times, before proxy traffic.
+
+### A soft 404 is not a block
+
+A `200` can carry full site chrome, correct headers, a plausible size, and a body that says the page does not exist. Only the content distinguishes it. A crawler counts it as a success, and a diff against an earlier capture reports a page that changed rather than a link that died.
+
+### Your own client's failure looks exactly like the site's
+
+A script that throws while formatting a result writes the same "error" into your notes as a site that refused you. In one sweep a target was recorded as failing when the fault was a string operation in the probe. Before adding a refusal to a journal, confirm the request actually left the machine.
+
+This happens inside Actors too, and the item looks identical to a block. A `pageFunction` that called `response.status()` on an Actor whose response object exposes `status` as a plain property produced `#error: true` items reading `TypeError: response.status is not a function`, which is a bug in the probe and not an opinion of the site. Read `#debug.errorMessages` before recording anything: a refusal names a status code, your own bug names your own code.
+
+### The diagnosis is traffic too
+
+A burst of probes is a pattern the target counts, and the answer can move under you while you measure. Prefer one run carrying every URL you want to compare over one run per URL, keep repeats deliberate, and when a source's answer changes mid-investigation, check your own request volume before concluding the site escalated against you.
+
+## Cost
+
+- A browser costs one to two orders of magnitude more per page than an HTTP request. Rung 5 is a budget decision, not a technical preference.
+- Residential proxy traffic is billed by volume. Run it once as a probe when two same-class egresses have refused; adopt it for a whole crawl only after it has proved to be the variable that mattered. On one site it changed a `403` into a full page; on another it returned a byte-identical page for more money.
+- Change one variable at a time: group, then country. Two changes at once buy an improvement you cannot attribute or reproduce.
+- Sample before scaling: a handful of URLs, confirm the outcome moved, then run the full set. Confirm with the user before any run whose estimated cost is significant.
+
+## Recovery
+
+- **Track failure rate per source and alert on it.** A source that quietly degrades from 2% to 60% failures produces a dataset that still looks like a dataset. You want to hear about it from a graph, not from a hole in the data.
+- **Keep the raw response of the first failure.** Status, headers, first kilobyte of the body. Every diagnosis above is made from that artefact, and it is gone by the time anyone asks.
+- **Three rungs with no change means the diagnosis is wrong**, not that the tooling is weak. Go back to the classification table. This only applies over a real sample; on a single URL there is no rate to compare.

--- a/skills/apify-blocked-scrape-triage/references/rungs-1-3.md
+++ b/skills/apify-blocked-scrape-triage/references/rungs-1-3.md
@@ -1,0 +1,53 @@
+# Rungs 1 to 3 in detail: rate, fidelity, tokens
+
+`SKILL.md` keeps each of these to a paragraph, because classification decides the outcome and remediation only carries it out. This is the detail you need once you already know which rung you are on.
+
+## Rung 1: rate and IP spread
+
+### Choosing `proxyRotation`
+
+| Value | Rotates | Use when |
+|---|---|---|
+| `RECOMMENDED` (default) | evenly, drops blocked proxies | independent, stateless page fetches |
+| `PER_REQUEST` | new proxy every request | the site bans an IP quickly and requests share no state |
+| `UNTIL_FAILURE` | one proxy until it fails | **the flow carries state**: cookies, a cart, a search session, a token bound to an IP |
+
+The common failure is a stateful flow running under `PER_REQUEST`: every request arrives from a new IP carrying a session issued to a different one, which looks far more suspicious than a steady crawler. Use `sessionPoolName` to keep sessions separate between runs that must not share state.
+
+**Once residential works, the flow has probably become stateful.** A WAF that lets you through usually issues a persistence cookie on the way (`__cf_bm`, `BIGipServer…`, `incap_ses_…`). That cookie is bound to the address that earned it, so switch to `UNTIL_FAILURE` for the crawl rather than staying on the default rotation, and expect the first rotation after expiry to look like a fresh block.
+
+### `maxRequestRetries` does not always cap how many times you touch the site
+
+It bounds retries of a *request*; session-level errors rotate the session on a separate counter. Against a **host that never answers** this diverges badly: measured, `maxRequestRetries: 0` produced eleven upstream attempts and `retryCount: 10`. Against a host that answers, including one that answers `403`, the count matches what you asked for. Check `retryCount` when the target is unreachable rather than assuming.
+
+### Verifying that a change did something
+
+With one URL you have an outcome, not a rate, so say which single change moved it. Six identical requests to one challenged platform returned three clean pages and three refusals from the same pool in the same minute, which is what an unlucky single probe looks like from the inside. Only over a real sample does a difference in block rate mean anything, and only then does the "three rungs, no change" stop rule in `SKILL.md` apply. The sample size that makes the rate countable is in `gotchas.md`.
+
+### Diagnosing on a budget
+
+A diagnosis that needs more than one run per egress is usually asking the wrong question. Two patterns keep the spend flat:
+
+- Put every URL you want to compare into one run's `startUrls` rather than starting a run per URL. The per-run overhead dominates at this size, and one run gives you a matrix instead of a list.
+- Repeat one URL with distinct `uniqueKey` values when you need a rate rather than an outcome. Same target, one run, six data points.
+
+## Rung 2: request fidelity
+
+Reproduce what a real client sends, in the order it sends it.
+
+- **Headers and their order.** A default HTTP client's header set is itself a fingerprint. `Accept`, `Accept-Language`, `Accept-Encoding`, `User-Agent` and `Referer` should form one plausible client, and the `Referer` chain should match the path a human would take. `curl -H` appends in the order you pass and cannot reproduce a browser's ordering, so it cannot test this rung at all: set the headers in the Actor's `preNavigationHooks`, where you are writing the request options object directly.
+- **Cookies the site sets before the page you want.** Pass them via `initialCookies`, or collect them in `preNavigationHooks`.
+- **Coherence.** Match `Accept-Language` to the proxy country. A US residential IP asking for `ru-RU` is a contradiction the edge can see, and the same applies to timezone and locale once a browser is involved.
+
+**The boundary of this rung, stated honestly.** Below the header layer sits the TLS and HTTP/2 fingerprint: cipher ordering, extensions, ALPN, HTTP/2 SETTINGS. A default Go or Node client is distinguishable from Chrome there, and no header work fixes it. If the evidence points at that layer, the tool class is uTLS or curl-impersonate, neither of which is an Apify Actor, or you accept the cost and move to Rung 5.
+
+## Rung 3: tokens and edge cookies from a legitimate flow
+
+Many "blocks" are a missing credential the site issues earlier: a build id, a CSRF token, a search token, a signed URL with a TTL, or the edge cookies a WAF sets on first contact.
+
+- Find where it is issued, request it the way the site does, then reuse it.
+- Bind it to the session and the address that obtained it. A token replayed from another IP is a stronger bot signal than no token at all.
+- Respect TTLs. Refresh on expiry rather than on every request.
+- **If Step 2 saw a sensor script or edge cookies on an otherwise clean page, this is where they matter.** Carry them into Rung 4: the page was open, the API behind it usually is not.
+
+**Where this rung stops.** A value the site hands to anyone who loads the page is a parameter, and it belongs here. A value issued to a person, or one that gates records the site does not otherwise publish, is a credential you do not own: that is Step 0, and the answer is to stop and say so. The test is in `SKILL.md` under Step 2.


### PR DESCRIPTION
## Skill

- **Name:** `apify-blocked-scrape-triage`
- **What it does:** Works out why a scrape came back blocked or empty, and fixes it in cost order, so that a 403 doesn't turn straight into residential proxies plus a browser.
- **Author:** Mikhail Koviazin ([@mikhail-koviazin](https://github.com/mikhail-koviazin))

## Checklist

- [x] PR adds **one** skill in `skills/apify-<name>/` and changes nothing outside that directory
- [x] `SKILL.md` frontmatter has `name` (matches the folder, `apify-` prefix), `description` (≤ 1024 chars) and `metadata.keywords`
- [x] I read CONTRIBUTING.md (agents: agents/AGENTS.md)
- [x] Tested the skill end-to-end at least once

## Notes

**Why I wrote this one.** The skills here answer "how do I get this data", and they do that well. None of them answers "the run came back with nothing, now what", and that is where most of my scraping time actually goes. I went and checked `apify/agent-skills` as well, and `apify-ultimate-scraper` doesn't mention 403, 429, challenges, proxies or fingerprints anywhere either. So an agent that hits a block has nothing to go on, and it reaches for the most expensive thing available.

**What it argues against.** The reflex answer to a 403 is residential proxies and a browser. That is one to two orders of magnitude more per page, and half the time it is not even the problem. This skill makes you classify first and then escalate in cost order: rate and IP spread, request fidelity, session tokens, the site's own internal API, browser last.

**The diagnostic was blind on the one case it exists for, and that is fixed here.** Crawlee treats 401, 403 and 429 as blocking and throws before your page function runs, so the item lands in the dataset carrying none of your fields: no status, no headers, nothing to classify with. Six identical requests to a challenged site, three of them back as empty error items, and no way to tell what they were. A one-line hook in `preNavigationHooks` retires the blocked session but stops the throw, and the same six came back six for six with status and headers on them. The flag people reach for first, `throwHttpErrors`, changes nothing here, and dropping the retire call unblinds the run while letting nothing through. Browser Actors have the identical problem.

**A 403 is two different situations, and the header that separates them belongs to one vendor only.** A hard block and a managed challenge arrive as the same status. On Cloudflare the challenge carries `cf-mitigated` and an interstitial body, the hard block carries neither, and they route in opposite directions: one needs a different address, the other needs a better client and a few seconds. Without the fix above you cannot see either header from inside the Actor, which is why the two were one row in my earlier draft. The trap I walked into next was treating that header as universal. It cannot appear on any other edge, so on an Akamai 403 its absence is guaranteed and carries no information, while the rule that reads it happily returns "your address was judged" for every non-Cloudflare refusal and is right only by luck. The skill now names the edge first, from `server` and `cf-ray`, or from `ak_p` and `X-Reference-Error`, and applies that vendor's discriminator rather than one vendor's header everywhere.

**A refusal is a measurement, not a property of the site.** That same Akamai 403 arrived with `Server-Timing: cdn-cache; desc=HIT` on a response whose own `Cache-Control` said `max-age=0`, so the error object came out of the edge cache and never reached the origin. Thirty-eight minutes later the same URL from the same address answered 200 with 81 KB, three times running, with nothing changed on my side. Firewall rules by ASN do sit there for years, so this is not a promise that refusals dissolve; it is an argument about cost. One repeat request either turns a single observation into a fact or stops you buying proxies against a refusal that had already expired.

**The cheapest step in the whole document is the one nobody takes: look at your own egress before you look at the site.** One free request gives you the address, the network and whether it is a hosting range, and that single fact explains most "this site blocks me" reports. Skip it and the reflex on a 403 from a US county site is to buy residential proxies, which is the purchase this skill exists to prevent. The same goes for DNS: on a machine running a proxy client in fake-ip mode every UDP lookup answers out of `198.18.0.0/15` whichever resolver you address, so a reachability check that trusts DNS will report live hosts as dead. I had that exact setup and did not know until a clean host disagreed with me.

**Two egresses of the same class disagreeing is a diagnosis, not noise.** One county refused my hosting address three different ways on three of its hosts, a silent timeout, a CDN block and a 399-byte `Access Denied`, and answered a datacenter proxy with `200` on the same hosts minutes later. That means the rule is about my specific address rather than about datacenter ranges, and the fix is another datacenter egress I already have rather than residential traffic I would have to buy.

**Escalating to a browser made it worse, measured.** Same URL, same proxy pool, one minute apart: the browser Actor was answered with a hard block page while the plain HTTP Actor got a challenge twice and a clean 200 on the third request. A Crawlee browser Actor also aborts on the challenge's 403 before the page can clear, so it never reaches the point where a challenge solves itself; a desktop Chrome on the same platform sat through "Verifying you are human" and loaded the page. Three requests cost 0.0011 compute units through the HTTP Actor and 0.0131 through the browser one.

**I tested it.** Every worked example in the skill is a measurement rather than something I remembered, and this is the one the ordering came from. Same URL, a large US county assessor site behind a CDN, four requests:

| Egress | Client | Result |
|---|---|---|
| hosting provider, non-US | default HTTP client | `403`, CDN error page |
| same IP | live desktop Chrome | `403`, identical |
| Apify Proxy, datacenter | `apify/cheerio-scraper` | `200`, 92 KB, real page, `retryCount` 0 |
| Apify Proxy, residential, US | `apify/cheerio-scraper` | `200`, same byte length |

So the site is not refusing automation: the request that got through ran no JavaScript and was not a browser. It is not refusing datacenter addresses either, because the ones that worked came from a datacenter. And residential, the reflex, gave me the same page byte for byte and cost more. That experiment is the reason the skill leads with classification instead of escalation.

The same run gave me one of the gotchas for free. It returned a `200` titled `Page not found`, with the full site navigation on it. A soft 404 looks like success in the status, in the headers and in the size, only the content gives it away, so a crawler counts it as a page and a diff calls it a change instead of a dead link.

**What I checked instead of assuming.** Actor ids come from the Store API. Every input field named in `references/actor-index.md` was read from that Actor's own input schema. The `proxyRotation` part comes from the enum and its documented behaviour; the bit I added is which value you actually want when the flow carries state, because that is the one people set backwards.

**What I left out on purpose,** and the skill says so out loud: antidetect browsers, account warming, CAPTCHA solving. TLS level impersonation is named as the right class of tool when the evidence points below the header layer, but it is not routed here, since those aren't Actors. The skill also opens with when not to use it at all: login walls, paywalls, and sources that publish a real API.

