### PR TITLE
Add apify-app-store-intelligence skill

### DIFF
--- a/skills/apify-app-store-intelligence/SKILL.md
+++ b/skills/apify-app-store-intelligence/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: apify-app-store-intelligence
+description: Pull structured Apple App Store data — app metadata, price, rating, version, developer, and reviews — and watch it for changes over time. Use when the user asks to look up an iOS app by App ID, bundle ID or name, compare a set of competitor apps, monitor a competitor's price or rating for changes, track when an app ships a new version, scrape App Store reviews, resolve a bundle ID to a full app record, check an app's rating across multiple country storefronts, build an ASO or app-market dataset, or set up a recurring App Store watch that reports only what moved since last run.
+author: Donny
+author_url: https://github.com/donnywin85
+metadata:
+  category: data-extraction
+  keywords: "app-store, ios, apple, aso, app-store-optimization, app-metadata, app-reviews, ratings, price-monitoring, version-tracking, bundle-id, storefronts, competitor-monitoring, change-detection, itunes"
+---
+
+# App Store Intelligence
+
+Two different questions live under "get me App Store data", and picking the wrong Actor for
+yours is the main way this task goes wrong:
+
+- **What does this app look like right now?** — price, rating, ratings count, version, developer,
+  category, screenshots, release notes. This is *metadata*, it is one row per app, and it is
+  cheap.
+- **What are users saying?** — the review corpus. This is *reviews*, it is thousands of rows per
+  app, and it costs roughly three orders of magnitude more per app.
+
+Most Actors in this category do reviews. If the user asked "did our competitor drop their price",
+routing them to a reviews scraper burns their budget on data they did not ask for.
+
+## Example prompts
+
+Prompts this skill handles:
+
+- "What's the current price and rating of App Store id 284882215?"
+- "Resolve `com.spotify.client` to a full app record."
+- "Watch these six competitor apps daily and tell me when any of them changes price or ships a new version."
+- "Pull the last 500 reviews of Duolingo on the US store."
+- "Compare our app's rating in the US, UK and Japan storefronts."
+
+Out of scope (the boundary):
+
+- "How does my app rank for the keyword 'habit tracker'?" — that is **keyword rank tracking**,
+  which needs a rank tracker, not a metadata or review Actor. Route to
+  `slothtechlabs/aso-keyword-rank-tracker` or `petersutarik/aso-keyword-intel`.
+- "Get me Google Play data." — this skill is Apple-only. Route to
+  `brilliant_gum/google-play-app-store-scraper` (covers both stores) or a Play-specific Actor.
+
+## Prerequisites
+
+- Apify account ([sign up](https://apify.com))
+- Authentication via one of:
+  - `apify login` (OAuth, if using the Apify CLI)
+  - `APIFY_TOKEN` environment variable
+  - Token from [Apify Console → Settings → Integrations](https://console.apify.com/settings/integrations)
+
+## Workflow
+
+1. **Classify the request as metadata or reviews.** Ask if it is genuinely ambiguous — the cost
+   difference is large enough to be worth one clarifying question. "Rating" is metadata (a single
+   number); "what do reviewers complain about" is reviews.
+2. **Resolve the app identity before scraping.** Users supply App Store URLs, numeric track IDs,
+   bundle IDs or plain app names, and the Actors want different ones. A numeric ID out of an App
+   Store URL (`apps.apple.com/us/app/foo/id284882215` → `284882215`) is the cheapest, most exact
+   input; a search term is the loosest and can return the wrong app.
+3. **Pick the Actor from the routing table below**, then fetch its input schema rather than
+   guessing at field names:
+
+       apify actors info "ACTOR_ID" --input --json \
+         --user-agent apify-awesome-skills/apify-app-store-intelligence \
+         2>/dev/null
+
+4. **Set the storefront explicitly** whenever price or availability is involved. Price is
+   per-country and the default is not always the user's country; a price answer without a named
+   storefront is not an answer.
+5. **Run, then report the row count and the dataset link** so the user can see what they paid for.
+6. **For recurring watches, use change detection rather than diffing yourself.** Re-scraping a
+   full snapshot daily and comparing it in the agent is slower and more expensive than an Actor
+   that keeps the previous snapshot and emits only changed fields.
+
+## Actor routing
+
+| User need | Actor ID | Tier | Best for |
+|-----------|----------|------|----------|
+| App metadata + change detection (price, rating, version moved?) | `praise-most-high/app-store-intelligence` | community | One row per app; `changesOnly` mode emits only apps whose watched fields moved. Accepts App IDs, bundle IDs or search terms. |
+| Review corpus, high volume | `thewolves/appstore-reviews-scraper` | community | The most-used reviews Actor in the category. |
+| Review corpus, JSON-shaped | `johnvc/apple-app-store-reviews-api` | community | iOS + macOS reviews as clean JSON. |
+| Reviews with translation / all countries | `fatihtahta/app-store-global-reviews-scraper` | community | Multi-storefront review sweeps. |
+| Keyword rank tracking (ASO) | `slothtechlabs/aso-keyword-rank-tracker` | community | Rank-by-keyword over time; App Store **and** Google Play. |
+| Keyword intelligence / search popularity | `petersutarik/aso-keyword-intel` | community | Keyword discovery and search-volume proxies. |
+| Both app stores in one run | `brilliant_gum/google-play-app-store-scraper` | community | Reviews, charts and ratings across Apple and Google. |
+| Apps, charts and in-app-purchase data | `sourabhbgp/apple-app-store-scraper` | community | Charts and IAP fields that the metadata Actors do not carry. |
+
+`Tier` = `apify` (Apify-maintained, prefer) or `community` (third-party). Every Actor in this
+table is community-tier; Apify does not maintain a first-party App Store Actor today.
+
+**Disclosure:** `praise-most-high/app-store-intelligence` is built and published by the author of
+this skill. It is listed for the one job the others do not do — per-field change detection on app
+metadata — and every other row routes to an unaffiliated Actor. No affiliate or referral
+parameters are used on any link in this skill.
+
+## Calling Actors
+
+### Apify CLI
+
+Look up two apps by App ID and get one metadata row each:
+
+    apify actors call "praise-most-high/app-store-intelligence" \
+      -i '{"appIds":["284882215","324684580"],"country":"us"}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-app-store-intelligence \
+      2>/dev/null
+
+Daily competitor watch — emit only the apps whose price, rating or version moved:
+
+    apify actors call "praise-most-high/app-store-intelligence" \
+      -i '{"appIds":["284882215","324684580"],"country":"us","changesOnly":true}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-app-store-intelligence \
+      2>/dev/null
+
+Pull a review corpus instead:
+
+    apify actors call "thewolves/appstore-reviews-scraper" \
+      -i '{"appIds":["284882215"],"maxItems":500,"country":"us"}' \
+      --json \
+      --user-agent apify-awesome-skills/apify-app-store-intelligence \
+      2>/dev/null
+
+Read the results:
+
+    apify datasets get-items "DATASET_ID" --format json \
+      --user-agent apify-awesome-skills/apify-app-store-intelligence \
+      2>/dev/null
+
+Find other Actors in this category:
+
+    apify actors search "app store" --json --limit 20 \
+      --user-agent apify-awesome-skills/apify-app-store-intelligence \
+      2>/dev/null
+
+### Other interfaces
+
+Any MCP client works too — the [Apify MCP connector](https://mcp.apify.com) exposes the same
+Actors. The CLI is shown here because it is the portable option.
+
+## References
+
+- [`references/actor-index.md`](references/actor-index.md) — the full routing table with the
+  input each Actor actually wants.
+- [`references/gotchas.md`](references/gotchas.md) — storefronts, identity resolution, cost
+  guardrails, and the failure modes that produce a wrong-but-plausible answer.

--- a/skills/apify-app-store-intelligence/references/actor-index.md
+++ b/skills/apify-app-store-intelligence/references/actor-index.md
@@ -1,0 +1,43 @@
+# Actor index — apify-app-store-intelligence
+
+Routing table for Apple App Store data. Input field names below were read from each Actor's
+published input schema, not guessed — but schemas change, so confirm before a large run:
+
+    apify actors info "ACTOR_ID" --input --json \
+      --user-agent apify-awesome-skills/apify-app-store-intelligence \
+      2>/dev/null
+
+## Metadata — one row per app
+
+| User intent | Actor ID | Tier | Key input fields | Notes |
+|-------------|----------|------|------------------|-------|
+| App record; watch price/rating/version for changes | `praise-most-high/app-store-intelligence` | community | `appIds`, `bundleIds`, `searchTerms`, `country`, `changesOnly`, `watchFields` | `changesOnly: true` emits only apps whose `watchFields` moved since the previous run (default `["price","rating","version"]`). Reads Apple's public lookup API; no reviews. **Built by this skill's author.** |
+| App data, charts and in-app purchases | `sourabhbgp/apple-app-store-scraper` | community | see schema | Carries chart position and IAP fields the pure-metadata Actors omit. |
+| Broad app metadata / ASO fields | `logiover/app-store-data-api` | community | see schema | Smaller, newer; check output shape before depending on a field. |
+
+## Reviews — many rows per app
+
+| User intent | Actor ID | Tier | Key input fields | Notes |
+|-------------|----------|------|------------------|-------|
+| High-volume review corpus | `thewolves/appstore-reviews-scraper` | community | `appIds`, `country`, `startUrls`, `maxItems`, `customMapFunction` | The most-used Actor in this category. Set `maxItems` — review counts run to five figures per app. |
+| Reviews as clean JSON, iOS + macOS | `johnvc/apple-app-store-reviews-api` | community | see schema | Wraps Apple's own public feed. |
+| Reviews across every storefront, translated | `fatihtahta/app-store-global-reviews-scraper` | community | see schema | Multi-country sweeps; cost scales with country count. |
+| Fast review pulls | `theagents/appstore-reviews` | community | see schema | |
+| Reviews across Apple **and** Google Play | `brilliant_gum/google-play-app-store-scraper` | community | see schema | Use when the user did not say which store they meant. |
+
+## Keyword rank / ASO — neither metadata nor reviews
+
+| User intent | Actor ID | Tier | Notes |
+|-------------|----------|------|-------|
+| Track keyword rank over time | `slothtechlabs/aso-keyword-rank-tracker` | community | App Store and Google Play. |
+| Keyword discovery + search popularity | `petersutarik/aso-keyword-intel` | community | |
+
+Ranking questions ("where do I rank for X") cannot be answered from metadata or reviews. If the
+user asks one, route here rather than approximating it from a category listing.
+
+## How to extend
+
+1. Search for candidates: `apify actors search "KEYWORDS" --json --limit 20 --user-agent apify-awesome-skills/apify-app-store-intelligence 2>/dev/null`
+2. Fetch the input schema: `apify actors info "ACTOR_ID" --input --json --user-agent apify-awesome-skills/apify-app-store-intelligence 2>/dev/null`
+3. Add a row with the user intent that should trigger it — and the input field names you read,
+   not the ones you expect.

--- a/skills/apify-app-store-intelligence/references/gotchas.md
+++ b/skills/apify-app-store-intelligence/references/gotchas.md
@@ -1,0 +1,68 @@
+# Gotchas — apify-app-store-intelligence
+
+The failure modes here mostly do not throw. They return a confident, well-formed, wrong answer.
+
+## Identity: four things users call "the app"
+
+| What the user pastes | What it is | Use it? |
+|---|---|---|
+| `https://apps.apple.com/us/app/foo/id284882215` | Store URL — the ID is the `id…` segment | Yes, extract `284882215` |
+| `284882215` | numeric track ID | Yes — exact, cheapest lookup |
+| `com.spotify.client` | bundle ID | Yes — exact |
+| `"Spotify"` | a search term | **Last resort.** Search returns ranked guesses, and the top hit is not always the app meant. Confirm the resolved name and developer with the user before scraping anything expensive off it. |
+
+Resolving a search term to an ID once, then reusing the ID, is both cheaper and reproducible.
+A pipeline keyed on a search term silently re-points itself when store ranking shifts.
+
+## Storefronts: price and availability are per-country
+
+There are ~175 storefronts and the same app has different prices, different availability, and
+sometimes a different name in each. Two consequences:
+
+- **Never report a price without naming the storefront it came from.** "It costs $4.99" is not a
+  fact; "it costs $4.99 on the US store" is.
+- **An app can be absent from a storefront entirely.** An empty result for `country: "jp"` means
+  "not sold in Japan", not "the run failed". Do not retry it as an error.
+
+Ratings are also per-storefront. A worldwide average is not something any of these Actors return;
+if the user wants one, you have to sweep countries and say so.
+
+## Change detection: what "changed" means
+
+`changesOnly: true` compares this run against the **previous run's stored snapshot**. Therefore:
+
+- **The first run emits nothing in `changesOnly` mode** — there is no previous snapshot to diff
+  against. Run once without it to establish a baseline, then schedule with it. A first scheduled
+  run that returns 0 rows is working correctly; reporting that as "no changes detected" is wrong,
+  it is "no baseline yet".
+- `watchFields` defaults to `["price","rating","version"]`. Fields outside that list change
+  without triggering a row. If the user cares about `ratingsCount` (which moves constantly), add
+  it deliberately — it will make almost every app report as changed every run.
+- A gap in the schedule means the diff spans the gap. "Changed since yesterday" is really
+  "changed since the last successful run", and those differ after an outage.
+
+## Cost: the metadata/reviews split is ~1000×
+
+One metadata row per app versus thousands of review rows per app. Before a reviews run over more
+than a handful of apps, state the expected item count and confirm. The specific trap: a user asks
+to "monitor competitors", an agent routes to a reviews scraper, and a daily schedule re-pulls the
+entire review corpus of ten apps every morning.
+
+Always cap reviews runs with the Actor's own limit field (`maxItems` on
+`thewolves/appstore-reviews-scraper`) rather than relying on the default.
+
+## Rate limits and upstream behaviour
+
+The metadata Actors here read Apple's public lookup/search API, which is keyless but not
+unlimited. Symptoms of being throttled are empty results and slow responses rather than an
+explicit 429, so **an empty result set is ambiguous** — it can mean "no such app", "not in this
+storefront", or "we are being throttled". If a lookup that previously returned rows starts
+returning none, treat it as inconclusive and re-probe with a single known-good App ID
+(`284882215`, Facebook, present in every storefront) before concluding the app is gone.
+
+Lower `maxConcurrency` before assuming a wide sweep is broken.
+
+## Reporting
+
+Give the user the row count and the dataset link on every run. A run that "succeeded" with zero
+rows and no explanation is the most common way this category wastes someone's afternoon.


### PR DESCRIPTION
## What this adds

`apify-app-store-intelligence` — a routing skill for Apple App Store data.

The problem it solves is a routing one, not a scraping one. "Get me App Store data" splits into
two requests with roughly a 1000× cost difference between them:

- **metadata** — price, rating, version, developer: one row per app
- **reviews** — the review corpus: thousands of rows per app

Most Actors in the category do reviews, so an agent asked "did our competitor drop their price"
tends to route to a reviews scraper and bill the user for a corpus they did not ask for. The
skill classifies the request first, then routes; it also carves out keyword-rank tracking, which
is a third thing that cannot be answered from either.

## Contents

- `SKILL.md` — classification workflow, 8-Actor routing table, example prompts + the boundary
- `references/actor-index.md` — routing table with input field names read from each Actor's
  published input schema
- `references/gotchas.md` — storefront/price-per-country, the four things users call "the app",
  why a first `changesOnly` run correctly returns zero rows, and the ambiguity of an empty
  result under throttling

## Disclosure

One row in the routing table — `praise-most-high/app-store-intelligence` — is an Actor I built
and publish. It is there for the one job the others do not do (per-field change detection on app
metadata); the other seven rows all route to unaffiliated Actors, and the two boundary cases
route away from it entirely. No affiliate or referral parameters on any link.

## Checks run locally

- `bash scripts/lint_telemetry.sh` — passes; the 2 warnings shown are pre-existing `--format csv`
  notices in `apify-ads-intelligence` and `apify-ecommerce`, not this skill
- `python scripts/lint_references.py` — passes
- `python scripts/generate_agents.py` — runs clean, 14 plugins; the generated
  `marketplace.json` / `AGENTS.md` / README table were reverted and are **not** in this PR

One skill, one PR, nothing outside `skills/apify-app-store-intelligence/`.
