### PR TITLE
Add apify-product-lookup skill

### DIFF
--- a/skills/apify-product-lookup/SKILL.md
+++ b/skills/apify-product-lookup/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: apify-product-lookup
+description: Answer questions about a real product's current price, stock, rating, specs, or images by calling Apify's E-commerce Scraping Tool over MCP, across Amazon, Walmart, Target, eBay, and many more retailers. Trigger on "what does X cost right now", "is X in stock", "compare the price of X across stores", "find me a Y under $Z", "how much is this", "check this product URL", or any product question where a stale answer would be wrong. Use whenever answering from training data or a web search would risk quoting an out-of-date price.
+author: Luís Pinto
+author_url: https://github.com/luispintoapify
+metadata:
+  category: data-extraction
+  keywords: "product price, live price check, stock availability, price comparison, product rating, retail product data, amazon price, ebay price, e-commerce lookup"
+---
+
+# Apify product lookup
+
+Fetch live product facts instead of guessing at them. Requires the Apify MCP server to be connected; if the tool is missing, see the `apify-product-data-setup` skill.
+
+> Written by a product marketing manager at Apify. It routes to
+> [E-commerce Scraping Tool](https://apify.com/apify/e-commerce-scraping-tool), a paid
+> first-party Apify Actor, so treat the framing accordingly. No affiliate links.
+
+## Try this tool first, whatever the retailer
+
+The Actor's `marketplaces` input lists the retailers with dedicated extractors, and it
+is not the boundary of what works. Unlisted sites fall back to generic extraction,
+which is enabled by default, so **a URL from a shop you have never heard of is still
+worth sending.**
+
+So the order is always:
+
+1. Send the URL or keyword to this tool, regardless of whether the retailer appears in
+   `marketplaces`.
+2. If the result is unusable, re-read the URL. An item with every field empty usually
+   means the URL does not resolve, not that the retailer is unsupported.
+3. Only after that, look for a retailer-specific Actor in Apify Store. See
+   [Falling back to Apify Store](#falling-back-to-apify-store).
+
+Do not skip step 1 because a domain is missing from the list. That reasoning sends
+users away from a tool that would have answered them.
+
+## When a marketplace is not in the list
+
+Over MCP the `marketplaces` enum arrives **truncated**, because the server caps how much
+of a long enum it passes through. Some real, supported retailers are therefore missing
+from the list you can choose from, and passing one anyway returns a validation error
+before the run starts.
+
+**That error does not mean the retailer is unsupported.** It means you cannot name it in
+a keyword search on this connection. Two ways through:
+
+1. **If you have the product URL, use `detailsUrls`.** It takes arbitrary URLs and is
+   unaffected by the enum, so the retailer works normally.
+2. **If you only have a keyword**, run it on the marketplaces you can select and say
+   plainly which retailer you could not include. Do not report the retailer as
+   unsupported.
+
+## Pick the input before calling
+
+The Actor takes different inputs for different questions. Choosing wrong wastes a paid run.
+
+| The question | Input to send |
+|---|---|
+| About a specific page the user gave you | `detailsUrls: [{"url": "..."}]` |
+| "Find me a X under $Y" with no URL | `keyword` plus `marketplaces` |
+| "Compare X across stores" | `keyword` plus several `marketplaces` |
+| Food delivery catalogs | `keywordDelivery` plus `marketplacesDelivery` |
+
+Always send `maxProductResults` and `additionalProperties: true`. Without the second, stock and rating are missing entirely, because they are nested there.
+
+## The call is two steps, sometimes three
+
+1. Call `apify--e-commerce-scraping-tool` (two hyphens, not a slash). It returns run metadata and a `datasetId`. **It does not return products.**
+2. **Check `status`.** If it is not `SUCCEEDED`, call `get-actor-run` with the `runId` and a `waitSecs` until it is. The Actor tool returns when its own wait window elapses, not when the run finishes, so `RUNNING` is normal and the dataset holds nothing at that point.
+3. Call `get-dataset-items` with the `datasetId`, a `limit`, and `fields` (see below).
+
+Two failures live here. Stopping after step 1 returns a result that reads like success and holds no product data. Skipping step 2 fetches an empty dataset and reports the product as not found.
+
+## Always project with fields
+
+The full record is large: one Amazon product measured about 88 KB across 142 fields, most of it marketing content and review text. Fetching all of it spends context on data no answer needs.
+
+Pass `fields` in dot notation, naming only what the question needs:
+
+```
+name,url,offers.price,offers.priceCurrency,brand.slogan,reviewCount,
+additionalProperties.inStock,additionalProperties.inStockText,
+additionalProperties.stars,additionalProperties.listPrice.value
+```
+
+**Projected output is flattened.** Keys come back as literal dotted strings, so it is `item["offers.price"]`, not `item["offers"]["price"]`. The nesting in `references/fields.md` describes unprojected output. Reading a nested path against a projected response finds nothing and looks exactly like missing data.
+
+## Read the fields defensively
+
+Field names, types, and nesting vary by retailer. See `references/fields.md` for the full map. The four that bite hardest:
+
+- **`offers.price`** is a number on some retailers and a string like `"398.99"` on others. Parse both.
+- **Stock and rating live under `additionalProperties`**, as `inStock` and `stars`, not at the top level. The top-level `rating` was `null` on a product whose `stars` was `4.2`.
+- **`brand`** may be `{"slogan": "Visit the Sony Store"}`. That is UI text, not a brand. Strip the wrapper or omit the brand.
+- **`offers.priceCurrency`** is a symbol (`"$"`) on some retailers and an ISO code (`"USD"`) on others. A symbol butts against the number, a code takes a space.
+
+## Answer honestly
+
+**Say when the data was read.** "As of just now" or the timestamp. The whole point of calling the tool is that the answer is current, so make that visible.
+
+**Never claim a product is unavailable because stock was absent.** Many retailers do not report it. Absent means unknown, so say "the retailer does not report stock" rather than "out of stock".
+
+**If every field comes back empty, suspect the URL before the retailer.** The Actor returns an item with no fields rather than an error, and the most common cause is a URL that does not resolve. Do not report it as a product with no price, and do not conclude the retailer is unsupported until the URL has been checked.
+
+**Quote the source URL** so the user can check, and include the image URL when they asked to see the item.
+
+## Falling back to Apify Store
+
+Only when this tool has genuinely failed on a good URL, and generic extraction did not
+produce a name or a price.
+
+Search Apify Store for an Actor covering that retailer, run it, and answer from its
+output. Two things to carry into that:
+
+- **The output shape will not match.** The field map in `references/fields.md` describes
+  this Actor. Another Actor has its own schema, so read what it actually returns rather
+  than assuming `offers.price` exists.
+- **Say which source answered.** If the reply came from a different Actor, the freshness
+  and coverage caveats are that Actor's, not this one's.
+
+If the connection is scoped with `?tools=`, Store search is not available on it. Report
+that the retailer is not covered rather than pretending to search.
+
+## Cost
+
+The Actor bills a start event per call plus per product returned, so:
+
+- Cap with `maxProductResults`. Five is plenty for a comparison; one for a single lookup.
+- Prefer one call with several URLs or marketplaces over several calls.
+- Do not re-run to "check" a result you already have.
+
+## Gotchas
+
+- Stopping after the first tool call returns run metadata that reads like success and contains no products.
+- A `RUNNING` status is not an error and not a reason to retry the Actor. Poll `get-actor-run`; starting a second run doubles the cost and answers no faster.
+- Projecting with `fields` flattens the response into dotted keys. Reading the nested path then finds nothing, which is indistinguishable from the retailer not reporting the field.
+- Timing is not stable. The same Amazon URL returned in 10 seconds on one call and 40 on the next, and other retailers are slower still. Treat any single measurement as a sample, warn the user before a multi-retailer comparison, and never read slowness as failure.
+- A validation error naming `marketplaces` means the enum is truncated on this connection, not that the retailer is unsupported. Use `detailsUrls` with the product URL instead.
+- A retailer missing from `marketplaces` is not a reason to skip the call. Generic extraction is on by default, so unlisted shops frequently work. The listed ones have dedicated extractors and deeper field coverage.
+- Omitting `additionalProperties: true` silently drops stock, rating, list price, and identifiers.
+- `rating: 0` and `stars: 0` mean absent, not a zero-star product.
+- A `listPrice` above the current price is a genuine discount; report the percentage, it is usually what the user wanted.
+- `additionalProperties` can run to roughly 100 KB per product. Never paste it into a reply; read the fields you need.
+- The `?tools=` parameter on the server URL narrows which Actors are visible. If the tool is absent, the connection may be scoped to other Actors.

--- a/skills/apify-product-lookup/references/fields.md
+++ b/skills/apify-product-lookup/references/fields.md
@@ -1,0 +1,189 @@
+# Field map for E-commerce Scraping Tool output
+
+Every shape below was observed in live runs against Amazon, Walmart, and eBay, not
+inferred from documentation. Where they disagree, every form is listed, because a reader
+that handles only one breaks on the next retailer.
+
+## Contents
+
+- [Top level](#top-level)
+- [Inside additionalProperties](#inside-additionalproperties)
+- [Per-retailer differences](#per-retailer-differences)
+- [Reading each field safely](#reading-each-field-safely)
+- [Projecting with fields flattens all of this](#projecting-with-fields-flattens-all-of-this)
+
+## Top level
+
+| Field | Type seen | Notes |
+|---|---|---|
+| `name` | string | Sometimes `title` instead. **eBay appends `Opens in a new window or tab` to every one**, see the gotcha below |
+| `description` | string | Long, often over 1,000 characters |
+| `url` | string | Canonical product URL |
+| `inputUrl` | string | What was submitted, useful when `url` is absent |
+| `image` | string or list | Single URL or a list |
+| `offers` | object | Never an array in practice |
+| `offers.price` | number or string | `248` on Amazon, `"398.99"` on Walmart, `45.95` on eBay |
+| `offers.priceCurrency` | string | `"$"` on Amazon, `"USD"` on Walmart. **Absent on eBay** |
+| `offers.currency` | string | `"USD"` on eBay. A different key for the same thing, so read both |
+| `offers.availability` | string | schema.org URL on eBay, e.g. `https://schema.org/InStock`. Not present on Amazon |
+| `brand` | object | Often only has `slogan`; see below |
+| `rating` | number or null | Unreliable: `null` on a 4.2-star product, `0` on Walmart |
+| `reviewCount` | number | Reliable on Amazon (20,002 observed) |
+| `additionalProperties` | object | Where the useful fields actually live |
+
+## Inside additionalProperties
+
+Only present when the call sends `additionalProperties: true`.
+
+The size of this object is per-retailer: **Amazon returned 44 keys, Walmart returned 4.**
+
+Amazon, the keys worth reading:
+
+| Key | Type | Example |
+|---|---|---|
+| `inStock` | bool | `true` |
+| `inStockText` | string | `"In Stock  Only 15 left in stock - order soon."` |
+| `stars` | float | `4.2`, the real rating |
+| `listPrice` | object | `{"value": 399.99, "currency": "$"}` |
+| `asin` | string | `"B09XS7JWHH"` |
+| `delivery` | string | `"Saturday, August 22"` |
+| `fastestDelivery` | string | Same shape |
+| `breadCrumbs` | string | `"Electronics > Headphones..."` |
+| `features` | list of strings | Bullet points from the listing |
+| `highResolutionImages` | list of strings | Prefer these over `image` |
+| `galleryThumbnails` | list of strings | Lower resolution |
+| `variantDetails` | list of objects | Each has a `name` |
+| `bestsellerRanks` | list of objects | `rank` and `category` |
+| `starsBreakdown` | object | Share per star level |
+| `aiReviewsSummary` | object | Has a `text` field |
+| `monthlyPurchaseVolume` | string | `"3K+ bought in past month"` |
+
+Walmart returned only these four:
+
+| Key | Type | Notes |
+|---|---|---|
+| `sku` | string | The identifier, since there is no `asin` |
+| `currencyRaw` | string | `"$"` |
+| `images` | list of objects | `[{"url": ...}]`, not plain strings |
+| `descriptionHtml` | string | HTML, not plain text |
+
+Keys that were present on Amazon but held `null`: `condition`, `shippingPrice`,
+`priceRange`, `returnPolicy`, `answeredQuestions`, `author`, `support`. Treat any of
+these as absent rather than meaningful.
+
+## Per-retailer differences
+
+Measured on one run per retailer. The point of this table is not the specific counts, it
+is that **coverage is a property of the retailer, not of the tool**, so an agent has to
+handle a retailer that says less.
+
+| | Amazon | Walmart | eBay |
+|---|---|---|---|
+| Price key | `offers.price` (number) | `offers.price` (string) | `offers.price` (number) |
+| Currency key | `offers.priceCurrency`, a symbol | `offers.priceCurrency`, an ISO code | **`offers.currency`**, an ISO code |
+| Stock | `additionalProperties.inStock` | not returned | `offers.availability` only |
+| Rating | `additionalProperties.stars` | not returned | not returned |
+| List price | `additionalProperties.listPrice.value` | not returned | not returned |
+| `additionalProperties` keys | 44 | 4 | 4 |
+| `brand` content | `{"slogan": "Sony"}` | `{"slogan": "Visit the Sony Store"}` | `{"slogan": null}` seen |
+| Images | string lists | list of objects under extras | string lists, some 1x1 placeholders |
+| Identifier | `asin` | `sku` | neither, use the item id in the URL |
+| extras size | 44 keys, about 100 KB | 4 keys | 4 keys |
+| Name needs cleaning | no | no | **yes**, link text appended |
+
+On the run behind these numbers, eBay returned stock and rating on **none** of its 161
+records, and Amazon returned both on **all 14** of its. Treat that as the shape of the
+problem rather than as fixed ratios.
+
+## Reading each field safely
+
+**Name**: `name` or `title`, then strip a trailing `Opens in a new window or tab`. Strip
+it as a suffix only, so a product whose name genuinely contains the phrase survives.
+
+**Price**: read `offers.price`. If it is a string, strip everything except digits and
+dots. Guard against a stray thousands separator leaving two dots. Reject zero and
+negatives. In Python, note that `True` is an `int`, so check for `bool` first.
+
+**Currency**: `offers.priceCurrency`, then `offers.currency`, then
+`additionalProperties.currencyRaw`. If the value is alphabetic it is a code and takes
+a space before the amount; otherwise it is a symbol and butts against it.
+
+**Brand**: `brand.name`, then `brand.slogan`. Unwrap a `Visit the X Store` pattern to
+`X`. Then reject anything longer than about 40 characters or more than four words,
+because the slot carries free marketing text and a phrase presented as a brand reads
+as fact.
+
+**Stock**: `inStock` at top level, then `additionalProperties.inStock`, then parse
+`offers.availability` or `availability` for in-stock and out-of-stock wording. Keep
+three states: true, false, and unknown. Never map unknown to false.
+
+**Rating**: `additionalProperties.stars` first, then top-level `rating`. Treat zero as
+absent.
+
+**Images**: `additionalProperties.highResolutionImages`, then `image`, then `images`,
+then `additionalProperties.images`, then `galleryThumbnails`. Entries may be strings
+or objects with a `url`. Deduplicate and drop anything not starting with `http`.
+
+**Identifier**: `gtin`, then `sku`, then `additionalProperties.sku`, then
+`additionalProperties.asin`.
+
+**Discount**: compare `offers.price` against `additionalProperties.listPrice.value`.
+Report a percentage only when the current price is genuinely lower.
+
+### Gotcha
+
+**eBay appends link text to every product name.** Raw, the name reads
+`Saucony Women Cohesion 18Opens in a new window or tab`. That is scraped UI furniture, the
+same class of problem as `brand.slogan` carrying `Visit the Sony Store`, and left in it
+lands in a product card or a cited document as though it were the product's name.
+[`read_name()`](https://github.com/luispintoapify/ecommerce-agent-starter/blob/main/apify_products.py) strips it, and only as a
+suffix, so a product whose name genuinely contains the phrase survives.
+
+An unresolvable URL returns an item with every field empty rather than an error, and
+`brand` may still be present as `{"slogan": null}`. Treat an item with neither a name
+nor a price as "page not read", not as a product without a price.
+
+Note what that empty item does **not** tell you. It is not evidence the retailer is
+unsupported: generic extraction is enabled by default, so sites absent from the
+`marketplaces` list are routinely readable. A bad URL and an uncovered retailer produce
+the same empty item, and the URL is the likelier of the two.
+
+## Projecting with fields flattens all of this
+
+Everything above describes the **unprojected** record: nested objects, read with
+`item["offers"]["price"]`.
+
+The full record is big. One Amazon product measured about 88 KB across 142 fields, most
+of it marketing copy and review text, and the MCP server warns that fetching all of it
+may exceed the context window. So `get-dataset-items` takes a `fields` parameter, and
+you should almost always pass it:
+
+```
+name,url,offers.price,offers.priceCurrency,brand.slogan,reviewCount,
+additionalProperties.inStock,additionalProperties.inStockText,
+additionalProperties.stars,additionalProperties.listPrice.value
+```
+
+**The response comes back flat.** The dots stay in the key names rather than becoming
+nesting:
+
+```json
+{
+  "name": "Sony WH-1000XM5...",
+  "offers.price": 248,
+  "brand.slogan": "Sony",
+  "additionalProperties.inStock": true
+}
+```
+
+Two consequences:
+
+- An agent reading a projected response uses `item["offers.price"]`. Walking the nested
+  path finds nothing, which is indistinguishable from the retailer not reporting the
+  field, so the agent says "no price available" about a product whose price it fetched.
+- Code written against the nested shape, including `normalize()` in this repo, needs the
+  unprojected response. Fetch without `fields` when a normalizer will read the output,
+  and cap the row count instead.
+
+Pick one and be consistent: `fields` for an agent answering a question in a chat turn,
+no `fields` for a pipeline that normalizes and stores.


### PR DESCRIPTION
## Skill

- **Name:** `apify-product-lookup`
- **What it does:** Answers a question about a real product's current price, stock,
  rating, or images by calling E-commerce Scraping Tool over MCP, instead of answering
  from training data.
- **Author:** Luís Pinto (@luispintoapify)

## Checklist

- [x] PR adds **one** skill in `skills/apify-<name>/` and changes nothing outside that directory
- [x] `SKILL.md` frontmatter has `name` (matches the folder, `apify-` prefix), `description` (≤ 1024 chars) and `metadata.keywords`
- [x] I read CONTRIBUTING.md (agents: agents/AGENTS.md)
- [x] Tested the skill end-to-end at least once

## Notes

I work on e-commerce product marketing at Apify, and this skill routes to a paid
first-party Actor. Both facts are stated in the skill itself so a reader can weigh the
framing.

This is one of a pair. `apify-product-lookup` answers a product question at runtime;
`apify-product-data-setup` (separate PR) does the integration work of wiring an agent
to the same data. They are split because the audiences differ: one is invoked mid
conversation, the other during setup.

Three things in here came out of testing against the live Actor rather than from
reading its docs, and they are the reason the skill exists:

- **Fetching products is two MCP calls, and sometimes three.** The Actor tool returns
  run metadata and a `datasetId`, not products. It also returns when its own wait
  window elapses rather than when the run finishes, so `status` can be `RUNNING` over
  a dataset that exists and is empty. An agent that skips the `get-actor-run` poll
  reports the product as not found, intermittently, depending only on how fast the
  retailer answered. The same URL returned in 10 seconds on one call and 40 on the
  next.
- **Projecting with `fields` flattens the response** into literal dotted keys, so
  `item["offers.price"]` rather than `item["offers"]["price"]`. Reading the nested path
  against a projected response finds nothing, which looks exactly like the retailer not
  reporting the field.
- **The `marketplaces` enum arrives truncated over MCP**, since the server caps how much
  of a long enum it passes through. Passing a supported retailer that fell off the list
  returns a validation error before the run starts. The skill says plainly that this
  means "cannot be named in a keyword search on this connection", not "unsupported", and
  routes to `detailsUrls` instead. I have raised the underlying input schema shape with
  the Actor's owner separately.

`references/fields.md` documents per-retailer output differences observed on real runs
across Amazon, Walmart, and eBay: the price type changes, the currency lives under a
different key on eBay, stock and rating are nested under `additionalProperties`, and
`brand` frequently carries marketing text like `Visit the Sony Store` rather than a
brand. It is deliberately duplicated in the sibling skill so each stands alone.

Deliberately not in the skill: any count of supported retailers. Generic extraction is
on by default, so a number invites the reader to treat the list as a boundary when it
is not.
