### PR TITLE
Add apify-companies-using-isolved skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -97,7 +97,7 @@
       "name": "apify-buying-signal-detection",
       "source": "./skills/apify-buying-signal-detection",
       "skills": "./",
-      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types — job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) — then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture — Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says \"find companies with buying signals\", \"detect intent signals for outbound\", \"set up a weekly lead pipeline\", \"monitor hiring signals for lead gen\", \"track startup funding leads\", \"find LinkedIn buying signals\", \"schedule Apify Actors for prospecting\", \"build a signals-based lead list\", or \"set up buying-intent monitoring for my ICP\".",
+      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types \u2014 job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) \u2014 then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture \u2014 Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says \"find companies with buying signals\", \"detect intent signals for outbound\", \"set up a weekly lead pipeline\", \"monitor hiring signals for lead gen\", \"track startup funding leads\", \"find LinkedIn buying signals\", \"schedule Apify Actors for prospecting\", \"build a signals-based lead list\", or \"set up buying-intent monitoring for my ICP\".",
       "keywords": [
         "buying-signals",
         "intent-data",
@@ -191,7 +191,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors. Use when the user asks who collabs with a brand, which brands a creator has done paid posts for, wants to audit an influencer's branded-content history, or wants to scope a brand's sponsorship roster. **Triggers:** - \"who collabs with [brand] on Instagram?\" - \"what brands has [creator] done sponsored posts for?\" - \"find paid partnerships / branded content for [handle]\" - \"audit [influencer]'s brand deals\" - \"show me [brand]'s influencer roster\" Works in either direction — brand → creators or creator → brands — and detects direction from the data, so don't ask the user to declare it. Requires Apify MCP tools.",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors. Use when the user asks who collabs with a brand, which brands a creator has done paid posts for, wants to audit an influencer's branded-content history, or wants to scope a brand's sponsorship roster. **Triggers:** - \"who collabs with [brand] on Instagram?\" - \"what brands has [creator] done sponsored posts for?\" - \"find paid partnerships / branded content for [handle]\" - \"audit [influencer]'s brand deals\" - \"show me [brand]'s influencer roster\" Works in either direction \u2014 brand \u2192 creators or creator \u2192 brands \u2014 and detects direction from the data, so don't ask the user to declare it. Requires Apify MCP tools.",
       "keywords": [
         "influencer",
         "brand",
@@ -209,7 +209,7 @@
       "name": "apify-lead-scoring-enrichment",
       "source": "./skills/apify-lead-scoring-enrichment",
       "skills": "./",
-      "description": "Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper → AI Web Scraper → Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. \"uses Shopify → send Shopify install guide\"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
+      "description": "Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper \u2192 AI Web Scraper \u2192 Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. \"uses Shopify \u2192 send Shopify install guide\"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
       "keywords": [
         "lead-scoring",
         "lead-enrichment",
@@ -231,7 +231,7 @@
       "name": "apify-link-prospecting-outreach",
       "source": "./skills/apify-link-prospecting-outreach",
       "skills": "./",
-      "description": "Find sites ranking for target keywords, score every prospect with Ahrefs domain authority and page-level traffic, identify the strongest pitch angle per row (\"links to competitor\", \"mentions brand without linking\", \"top-3 SERP\", \"resource page\", \"outdated content\"), generate brand-voice-matched outreach emails using an outreach-type-aware template (unlinked-mention claim, competitor-link replacement, resource-page inclusion, outdated-content replacement, topical niche-edit), and propose a concrete in-article link placement as three artifacts — the verbatim source sentence, the same sentence rewritten with the link spliced in, or a fully-drafted new insertion if no natural fit exists. Use when user asks to find link building opportunities, prospect link partners, recover unlinked brand mentions, replace competitor links, build a tiered outreach list, or run cold email outreach for SEO link building.",
+      "description": "Find sites ranking for target keywords, score every prospect with Ahrefs domain authority and page-level traffic, identify the strongest pitch angle per row (\"links to competitor\", \"mentions brand without linking\", \"top-3 SERP\", \"resource page\", \"outdated content\"), generate brand-voice-matched outreach emails using an outreach-type-aware template (unlinked-mention claim, competitor-link replacement, resource-page inclusion, outdated-content replacement, topical niche-edit), and propose a concrete in-article link placement as three artifacts \u2014 the verbatim source sentence, the same sentence rewritten with the link spliced in, or a fully-drafted new insertion if no natural fit exists. Use when user asks to find link building opportunities, prospect link partners, recover unlinked brand mentions, replace competitor links, build a tiered outreach list, or run cold email outreach for SEO link building.",
       "keywords": [
         "link-building",
         "seo",
@@ -295,7 +295,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Builds a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed. Use when user asks to find verified emails, build a leads list, scrape emails from Maps or SERP, verify emails for a URL list, or find an Apollo / Hunter alternative.",
+      "description": "Builds a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed. Use when user asks to find verified emails, build a leads list, scrape emails from Maps or SERP, verify emails for a URL list, or find an Apollo / Hunter alternative.",
       "keywords": [
         "email",
         "verification",
@@ -314,7 +314,7 @@
       "name": "apify-x402-agentic-wallet",
       "source": "./skills/apify-x402-agentic-wallet",
       "skills": "./",
-      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) — no Apify account or API key. You buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs with it. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, mentions \"x402\", \"awal\", \"agentic wallet\", \"Coinbase wallet\", \"pay with USDC\", \"no API key\", or asks to pull live web data (social media, search, maps, marketplaces, news) while paying on-chain per use.",
+      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) \u2014 no Apify account or API key. You buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs with it. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, mentions \"x402\", \"awal\", \"agentic wallet\", \"Coinbase wallet\", \"pay with USDC\", \"no API key\", or asks to pull live web data (social media, search, maps, marketplaces, news) while paying on-chain per use.",
       "keywords": [
         "x402",
         "awal",
@@ -330,6 +330,21 @@
         "web-data"
       ],
       "category": "data-extraction"
+    },
+    {
+      "name": "apify-companies-using-isolved",
+      "source": "./skills/apify-companies-using-isolved",
+      "skills": "./",
+      "description": "Find companies that use isolved and check whether an employer has an isolved job board, as a live directory of tenants with open-jobs counts.",
+      "keywords": [
+        "apify",
+        "isolved",
+        "companies",
+        "leads",
+        "mcp"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-companies-using-isolved/SKILL.md
+++ b/skills/apify-companies-using-isolved/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: apify-companies-using-isolved
+description: "Find companies that use isolved, and check whether a specific employer has an isolved job board, with the isolved Jobs API Actor (johnvc/isolved-jobs-api). Discovery mode returns one row per employer hiring through isolved: tenant slug, careers URL, and a live open-jobs count, drawn from a directory rebuilt from isolved's own public sitemap index of every tenant and re-probed at run time so dead tenants are skipped and never billed. Feed it your own prospect list instead and tenant slugs or URLs are verified live, and a miss returns a clear not-found row. Use when someone asks for companies that use isolved, a list of employers using isolvedhire, isolved customers, who hires through isolved, to check if a company uses isolved or ApplicantPro, or to build ATS-based sales intelligence and recruiting target lists. isolved skews to United States small and mid-market employers, so the directory doubles as an SMB lead list. Billed per verified tenant row, no start fee, MCP-ready for AI agents."
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# Companies That Use isolved, as a Live Directory
+
+A query or a prospect list in, live-verified employers on isolved out, each with its careers URL and a current open-jobs count.
+
+## When to use this skill
+
+- Someone asks which companies use isolved, for a lead list, market map, or recruiting target list.
+- You have a prospect list and need to know who hires through isolved before pointing a jobs pipeline at them.
+- You want hiring as a buying signal: isolved skews to US small and mid-market employers, and open-roles counts show where headcount is going.
+- You need to verify one employer: does it have an isolved career site at all, and what is the URL?
+
+Not for: pulling the job postings themselves. Use the companion `apify-isolved-jobs-api` skill, built on the same Actor but shaped for job rows. See `references/actor-index.md`.
+
+## What you get
+
+One dataset row per tenant. `resultType` separates `tenant` rows from `error` rows.
+
+- `organization`: the employer name, from the posting or derived from the tenant.
+- `tenant`: the tenant slug, the subdomain before `.isolvedhire.com`.
+- `tenantUrl`: the public careers site.
+- `jobCount`: the current live open-jobs count from the tenant's sitemap.
+- `live`: whether the tenant was verified against its live sitemap this run.
+- `region`, `verifiedAt`, `scrapedAt`.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/isolved-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/isolved-jobs-api`
+- Pricing: pay per event, no start fee. See the cost section below and `references/gotchas.md` for the live-price command.
+
+## Run it with the Apify CLI
+
+The largest tenants first, verified live, capped at 50:
+
+```bash
+apify actors call "johnvc/isolved-jobs-api" -i '{"outputMode":"tenantsOnly","maxTenants":50}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-companies-using-isolved \
+  2>/dev/null
+```
+
+Scope the directory to a query:
+
+```bash
+apify actors call "johnvc/isolved-jobs-api" -i '{"outputMode":"tenantsOnly","discoveryQuery":"oil","maxTenants":25}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-companies-using-isolved \
+  2>/dev/null
+```
+
+Verify your own prospect list of tenant slugs:
+
+```bash
+apify actors call "johnvc/isolved-jobs-api" -i '{"outputMode":"tenantsOnly","tenants":["davidsonoil","goflyingstar","isolved"]}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-companies-using-isolved \
+  2>/dev/null
+```
+
+Confirm the live schema and prices before a large sweep:
+
+```bash
+apify actors info "johnvc/isolved-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-companies-using-isolved \
+  2>/dev/null
+```
+
+Read the rows back from a finished run:
+
+```bash
+apify datasets get-items <DATASET_ID> --format json \
+  --user-agent apify-awesome-skills/apify-companies-using-isolved \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json` (or `--format json`), `--user-agent apify-awesome-skills/apify-companies-using-isolved`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/isolved-jobs-api`
+
+Then ask, for example: "List employers hiring through isolved with the most open roles, and give me their careers URLs." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. For a market map, run `tenantsOnly` with no `tenants` and a `maxTenants` cap; the directory returns largest tenants first.
+2. For a prospect check, pass your own `tenants` list. Each is verified against its live sitemap; a miss returns a `board_not_found` error row rather than a false positive.
+3. `discoveryQuery` scopes the sweep by a substring of the tenant slug or name.
+4. Keep `verifyTenants` on (default) for live open-jobs counts; turn it off to list the directory snapshot without network checks, faster and cheaper.
+5. Read `jobCount` as a hiring-volume signal; `live: true` confirms the tenant answered this run.
+6. Check `resultType` before treating a row as a tenant. An `error` row carries `errorCode` and `errorMessage`.
+7. To pull the actual postings for a tenant you found, hand its slug to `apify-isolved-jobs-api`.
+
+## Inputs
+
+- `outputMode` (enum): set to `tenantsOnly` for this skill.
+- `tenants` (array): your own tenant slugs or URLs to verify; empty sweeps the bundled directory.
+- `discoveryQuery` (string): substring match over tenant slug and name.
+- `verifyTenants` (boolean, default true): live-probe each tenant for a current open-jobs count.
+- `maxTenants` (integer, default 25): the primary spend cap for discovery.
+- `proxyConfiguration` (object): off by default; direct connections work.
+
+## Cost
+
+Billing is pay per event with no start fee. The `tenant-row` event fires once per live-verified tenant returned; dead tenants are skipped and never billed. Confirm live prices with the info command above rather than trusting a number copied here.
+
+Suggested confirmation thresholds: mention the estimate under about $5, warn the user over about $5, get explicit confirmation over about $20. Present cost as "around $X", never as a guarantee.
+
+## Honest limits
+
+- The directory is rebuilt from isolved's public sitemap index, so it reflects tenants that publish a public job sitemap. An employer on isolved with no public postings may not appear.
+- `jobCount` is the live count at run time and moves as employers post and close roles.
+- Public career-site data only. No applicant data, no recruiter contacts, nothing behind a login.
+- US-focused. isolved career sites are almost entirely United States employers.
+
+## Troubleshooting
+
+- `board_not_found` on a prospect check: that tenant has no public job sitemap; confirm the slug or paste the tenant URL.
+- `http_error`: transient upstream answer; retry once before assuming anything.
+- Zero rows: the `discoveryQuery` matched nothing, or `maxTenants` is too low. Widen the query.
+- Duplicates: dedupe on `tenant`, the stable slug.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Greenhouse Job Board API: https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Ashby Job Board API: https://apify.com/johnvc/ashby-job-board-scraper?fpr=9n7kx3&fp_sid=awesomeskills
+- iCIMS Careers API: https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Workday Careers API: https://apify.com/johnvc/workday-careers-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-companies-using-isolved/references/actor-index.md
+++ b/skills/apify-companies-using-isolved/references/actor-index.md
@@ -1,0 +1,15 @@
+# Actor routing table
+
+One Actor powers both isolved skills; the skills differ in which output mode and question they are shaped for.
+
+| Question | Skill | Actor input shape |
+|---|---|---|
+| Which employers use isolved | apify-companies-using-isolved | `outputMode: "tenantsOnly"`, directory sweep |
+| Does this employer have an isolved site | apify-companies-using-isolved | `outputMode: "tenantsOnly"`, your `tenants` list |
+| Job rows from named tenants | apify-isolved-jobs-api | default `jobs` mode, `tenants` list, filters |
+| New or changed postings since yesterday | apify-isolved-jobs-api | `updatedAfter: "25h"` on a schedule |
+| Cheapest full index of a tenant | either | `outputMode: "urlsOnly"` |
+
+- Actor: https://apify.com/johnvc/isolved-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/isolved-jobs-api`
+- Related family: Greenhouse Job Board API (https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills) and iCIMS Careers API (https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills) share the row shape for cross-ATS sales maps.

--- a/skills/apify-companies-using-isolved/references/gotchas.md
+++ b/skills/apify-companies-using-isolved/references/gotchas.md
@@ -1,0 +1,30 @@
+# Cost guardrails and error recovery
+
+## Live prices, not remembered ones
+
+```bash
+apify actors info "johnvc/isolved-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-companies-using-isolved \
+  2>/dev/null
+```
+
+Read `pricingInfos` from the output. The `tenant-row` event is per live-verified tenant; dead tenants are skipped and never charged, and there is no start fee.
+
+## Guardrails
+
+- Cap every exploratory sweep: `maxTenants: 25` until the row shape is confirmed.
+- `discoveryQuery` narrows the sweep before billing; use it instead of pulling the whole directory and filtering downstream.
+- `verifyTenants: false` lists the directory snapshot without live probes, faster and cheaper, at the cost of a live `jobCount`.
+- Dead tenants (no public sitemap) are skipped silently and never billed, so a stale prospect list costs only for the ones that resolve.
+
+## Error recovery
+
+- `board_not_found` on a prospect check: that tenant has no public job sitemap; confirm the slug or paste the tenant URL.
+- `http_error`: transient upstream answer; the row says the HTTP status. Retry once, then check the tenant site in a browser.
+- `invalid_url`: the entry is not an isolved tenant slug, tenant URL, or job URL.
+- Errors are in-band dataset rows with `resultType: "error"`; pipelines should branch on `resultType`, not on run status.
+
+## Freshness facts worth knowing
+
+- The bundled tenant directory is rebuilt from isolved's public sitemap index, which lists every tenant, so a sweep re-enumerates the live universe rather than a frozen snapshot. New employers appear on their own.
+- `jobCount` is the live count at run time and moves as employers post and close roles.


### PR DESCRIPTION
Adds one skill: apify-companies-using-isolved, powered by the public Apify Actor johnvc/isolved-jobs-api (discovery mode). Lists employers hiring through isolved with live open-jobs counts. Diff is 4 files: SKILL.md, two references, and one marketplace.json entry. If generate_agents.py flags an unrelated skill, that is upstream main being briefly out of sync, not this change.