### PR TITLE
Add apify-successfactors-jobs-api skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -88,7 +88,7 @@
       "skills": [
         "./skills"
       ],
-      "description": "Financial company intelligence — news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
+      "description": "Financial company intelligence \u2014 news monitoring (33 sources), social listening (Reddit, Twitter/X, Trustpilot), and public registry lookups (11 European countries). 3 skills + portfolio-sweep command.",
       "keywords": [
         "finance",
         "news",
@@ -130,7 +130,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed.",
+      "description": "Build a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed.",
       "keywords": [
         "email",
         "verification",
@@ -171,7 +171,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors against Meta's Ad Library. Audit influencer branded-content history, scope a brand's sponsorship roster, and surface paid collaborations in either direction",
       "keywords": [
         "influencer",
         "brand",
@@ -204,6 +204,21 @@
         "traderinfo",
         "contact-enrichment",
         "b2b"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
+    },
+    {
+      "name": "apify-successfactors-jobs-api",
+      "source": "./skills/apify-successfactors-jobs-api",
+      "skills": "./",
+      "description": "Pull live SAP SuccessFactors job postings to a structured feed via the Apify SuccessFactors Jobs API.",
+      "keywords": [
+        "apify",
+        "successfactors",
+        "jobs",
+        "ats",
+        "mcp"
       ],
       "category": "data-extraction",
       "version": "1.0.0"

--- a/skills/apify-successfactors-jobs-api/SKILL.md
+++ b/skills/apify-successfactors-jobs-api/SKILL.md
@@ -6,6 +6,7 @@ author_url: https://github.com/johnisanerd
 license: MIT
 metadata:
   version: "1.0"
+  keywords: ["successfactors", "successfactors jobs", "successfactors api", "ats", "jobs", "mcp"]
 ---
 
 # SAP SuccessFactors Jobs, as Rows You Can Query

--- a/skills/apify-successfactors-jobs-api/SKILL.md
+++ b/skills/apify-successfactors-jobs-api/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: apify-successfactors-jobs-api
+description: "Pull live SAP SuccessFactors job postings from any public SuccessFactors career site with the Apify SAP SuccessFactors Jobs API Actor (johnvc/sap-successfactors-jobs-api). Returns job rows as JSON: title, company, employer, requisition ID, job function, location and country code, expiration date, remote flag, and the description as Markdown by default, with optional HTML or plain text. Turn on the detail add-on for the posted date, department, facility, shift type, and travel that only the job page carries. Takes a career-site host like jobs.sap.com, a full career-site URL, a single job URL, or a company name; filters by title, job function, location, remote, and active-only before billing. Use when someone wants successfactors jobs, a successfactors jobs api, a successfactors api without a key, to scrape SAP SuccessFactors career sites, or to feed a job board, aggregator, or sourcing tool with enterprise postings. Billed per job delivered with no start fee, and MCP-ready for Claude and other AI agents."
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# SAP SuccessFactors Jobs, as Rows You Can Query
+
+A career-site host, URL, or company name in, live SAP SuccessFactors jobs out as structured rows, read straight from the public feed each career site already publishes.
+
+## When to use this skill
+
+- Someone wants SuccessFactors jobs and does not want to read career sites like jobs.sap.com by hand.
+- You are filling a job board, a market-intel dashboard, or a sourcing tool with roles from SuccessFactors-hosted careers pages.
+- You went looking for a SuccessFactors API and found only the employer-side OData APIs you cannot sign up for.
+- You need the whole career site in one pull, not page after page of search results.
+
+Not for: using the data live from inside Claude or another MCP client. Use the companion `apify-successfactors-mcp` skill, built on the same Actor. See `references/actor-index.md`.
+
+## What you get
+
+One dataset row per job. `resultType` separates `job` rows from `error` rows.
+
+Core fields:
+
+- `requisitionId`, `url` (canonical, safe as a dedupe key), `applyUrl`, `title`
+- `companyName`, `employer`, `tenant`, `careerSiteUrl`
+- `jobFunction`, `location`, `countryCode`, `isRemote`
+- `validThrough` (expiration date), and `datePosted` with the detail add-on
+- `salaryDerived` plus flat `salaryMin`, `salaryMax`, `salaryCurrency`, `salaryPeriod` (parsed from the posting text when present)
+- `descriptionMarkdown` (default add-on), `descriptionHtml`, `descriptionText` (opt-in add-ons)
+- `source` (always `successfactors`), `sourceType`, `flavor`, `scrapedAt`
+
+With `includeDetailFields` on, each row also carries `datePosted`, `department`, `facility`, `shiftType`, `travel`, and any employer `customFields`, fetched from the job page.
+
+The Actor ships dataset views for the console: `overview`, `details`, and `tenants`.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/sap-successfactors-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/sap-successfactors-jobs-api`
+- Pricing: pay per event, no start fee. See the cost section below and `references/gotchas.md` for the live-price command.
+
+## Run it with the Apify CLI
+
+Pull the first 100 live jobs from a career site, descriptions as Markdown:
+
+```bash
+apify actors call "johnvc/sap-successfactors-jobs-api" \
+  -i '{"companies":["jobs.sap.com"],"maxJobs":100,"includeDescriptionMarkdown":true}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-successfactors-jobs-api \
+  2>/dev/null
+```
+
+Read a run's dataset by id:
+
+```bash
+apify datasets get-items <DATASET_ID> --format json \
+  --user-agent apify-awesome-skills/apify-successfactors-jobs-api 2>/dev/null
+```
+
+Inspect the input schema:
+
+```bash
+apify actors info "johnvc/sap-successfactors-jobs-api" --input --json \
+  --user-agent apify-awesome-skills/apify-successfactors-jobs-api 2>/dev/null
+```
+
+## Run it from Claude (MCP)
+
+Add the hosted Apify MCP server and call the Actor as a tool:
+
+```
+https://mcp.apify.com/?tools=actors,docs,johnvc/sap-successfactors-jobs-api
+```
+
+Docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Identify the target career sites: a host such as `jobs.sap.com`, a full career-site URL, a single job URL, or a company name to match against the bundled directory.
+2. Decide the output: `jobs` for full records, `urlsOnly` for the cheapest index, or `tenantsOnly` to list career sites.
+3. Pick description formats (Markdown is on by default) and turn on `includeDetailFields` if you need the posted date or department.
+4. Set filters (`titleKeywords`, `jobFunctions`, `locationKeywords`, `remoteOnly`, `activeOnly`) so filtered rows never bill.
+5. Cap the run with `maxJobs` (and `maxJobsPerTenant`, `maxTenants`).
+6. Call the Actor, then read the dataset. Dedupe on `url` or `requisitionId` across runs.
+
+## Inputs
+
+- `companies`: career-site hosts, full URLs, single-job URLs, or company names.
+- `startUrls`: the same values as a URL list; merged with `companies`.
+- `outputMode`: `jobs` (default), `urlsOnly`, or `tenantsOnly`.
+- `titleKeywords`, `jobFunctions`, `locationKeywords`: keep-only filters, applied before billing.
+- `activeOnly` (default true), `remoteOnly`: further pre-billing filters.
+- `includeDescriptionMarkdown` (default true), `includeDescriptionHtml`, `includeDescriptionText`: per-format add-ons.
+- `includeDetailFields`: posted date, department, facility, shift type, travel, custom fields (one extra request per job).
+- `report`: write a Markdown or HTML run digest to the key-value store.
+- `maxJobs`, `maxJobsPerTenant`, `maxTenants`, `maxConcurrency`: cost and scope caps.
+
+## Cost guardrails
+
+- Billing is per delivered row. Filters run before billing, so filtered jobs cost nothing.
+- The base job record is one event; description formats, the detail fields, and the run report are separate add-ons billed only on rows that carry them.
+- Start small: `maxJobs` of 10 to 25 while you shape filters, then raise it.
+- Read the live price before a big run (see `references/gotchas.md`).
+
+## Honest limits
+
+- Salary is a best-effort regex over the posting text; many SuccessFactors postings publish no pay, so salary fields are often null.
+- The public feed carries no posted date; `datePosted` comes only with the detail add-on.
+- Coverage is the public career-site feed, so unlisted or gated postings are not returned.
+
+## Troubleshooting
+
+- An `error` row with `tenant_not_found` means the company could not be resolved to a live feed; pass the career-site URL directly and check the `didYouMean` suggestions.
+- `job_not_found` on a single-job URL means the posting closed or expired.
+- Zero rows usually means filters are too tight or `activeOnly` dropped expired postings; widen the filters.
+
+## Related Actors
+
+See `references/actor-index.md` for the companion `apify-successfactors-mcp` skill and the other ATS job APIs on this account (Workday, Greenhouse, Ashby, iCIMS, Oracle Taleo).

--- a/skills/apify-successfactors-jobs-api/references/actor-index.md
+++ b/skills/apify-successfactors-jobs-api/references/actor-index.md
@@ -1,0 +1,21 @@
+# Actor index
+
+## This skill's Actor
+- `johnvc/sap-successfactors-jobs-api` - SAP SuccessFactors Jobs API. Reads the public jobs feed each SuccessFactors career site publishes.
+- Store: https://apify.com/johnvc/sap-successfactors-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+
+## Modes (outputMode)
+- `jobs`: full job records (default)
+- `urlsOnly`: the job index without descriptions (cheapest)
+- `tenantsOnly`: one row per career site with a live job count (discovery)
+
+## Companion skills (same Actor)
+- `apify-successfactors-jobs-api`: bulk pull to a structured feed, from a script or pipeline.
+- `apify-successfactors-mcp`: use the same Actor live from Claude and other MCP clients.
+
+## Related ATS job APIs on this account
+- Workday Careers API: https://apify.com/johnvc/workday-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Greenhouse Job Board API: https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Ashby Job Board API: https://apify.com/johnvc/ashby-job-board-scraper?fpr=9n7kx3&fp_sid=awesomeskills
+- iCIMS Careers API: https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Oracle Taleo Jobs API: https://apify.com/johnvc/oracle-taleo-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-successfactors-jobs-api/references/gotchas.md
+++ b/skills/apify-successfactors-jobs-api/references/gotchas.md
@@ -1,0 +1,23 @@
+# Gotchas: cost guardrails and error recovery
+
+## Read the live price before a big run
+```bash
+apify actors info "johnvc/sap-successfactors-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-successfactors-jobs-api 2>/dev/null
+```
+Look at the pay-per-event events; the base job plus per-format and detail add-ons.
+
+## Cost control
+- Billing is per delivered row. Filters (title, jobFunction, location, remote, activeOnly) run before billing, so filtered rows cost nothing.
+- The base job record is one event. Add-ons (descriptionMarkdown, descriptionHtml, descriptionText, detail fields, run report) bill only on rows that carry them.
+- Caps: `maxJobs` (whole run), `maxJobsPerTenant`, `maxTenants`. Start with `maxJobs` of 10 to 25 while shaping filters.
+- `includeDetailFields` adds one request per job; leave it off unless you need the posted date, department, facility, shift type, or travel.
+
+## Error rows (resultType=error)
+- `tenant_not_found`: the company did not resolve to a live feed. Pass the career-site URL and check `didYouMean`.
+- `job_not_found`: a single-job URL pointed at a closed or expired posting.
+- `http_error`: the career site answered abnormally; retry later.
+
+## Empty results
+- Filters may be too tight, or `activeOnly` dropped expired postings. Widen the filters or set `activeOnly` to false.
+- A bare company name may not be in the bundled directory; pass the career-site host or URL directly.


### PR DESCRIPTION
Adds one skill, `apify-successfactors-jobs-api`, that pulls live SAP SuccessFactors job postings to a structured feed via the public Apify Actor `johnvc/sap-successfactors-jobs-api`.

Diff is exactly 4 files: the SKILL.md, two references, and one appended marketplace.json entry. Telemetry flags present on every apify CLI call (--user-agent apify-awesome-skills/apify-successfactors-jobs-api, --json, 2>/dev/null). One skill per PR.