### PR TITLE
Add apify-paylocity-jobs-api skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -97,7 +97,7 @@
       "name": "apify-buying-signal-detection",
       "source": "./skills/apify-buying-signal-detection",
       "skills": "./",
-      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types — job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) — then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture — Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says \"find companies with buying signals\", \"detect intent signals for outbound\", \"set up a weekly lead pipeline\", \"monitor hiring signals for lead gen\", \"track startup funding leads\", \"find LinkedIn buying signals\", \"schedule Apify Actors for prospecting\", \"build a signals-based lead list\", or \"set up buying-intent monitoring for my ICP\".",
+      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types \u2014 job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) \u2014 then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture \u2014 Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says \"find companies with buying signals\", \"detect intent signals for outbound\", \"set up a weekly lead pipeline\", \"monitor hiring signals for lead gen\", \"track startup funding leads\", \"find LinkedIn buying signals\", \"schedule Apify Actors for prospecting\", \"build a signals-based lead list\", or \"set up buying-intent monitoring for my ICP\".",
       "keywords": [
         "buying-signals",
         "intent-data",
@@ -191,7 +191,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors. Use when the user asks who collabs with a brand, which brands a creator has done paid posts for, wants to audit an influencer's branded-content history, or wants to scope a brand's sponsorship roster. **Triggers:** - \"who collabs with [brand] on Instagram?\" - \"what brands has [creator] done sponsored posts for?\" - \"find paid partnerships / branded content for [handle]\" - \"audit [influencer]'s brand deals\" - \"show me [brand]'s influencer roster\" Works in either direction — brand → creators or creator → brands — and detects direction from the data, so don't ask the user to declare it. Requires Apify MCP tools.",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors. Use when the user asks who collabs with a brand, which brands a creator has done paid posts for, wants to audit an influencer's branded-content history, or wants to scope a brand's sponsorship roster. **Triggers:** - \"who collabs with [brand] on Instagram?\" - \"what brands has [creator] done sponsored posts for?\" - \"find paid partnerships / branded content for [handle]\" - \"audit [influencer]'s brand deals\" - \"show me [brand]'s influencer roster\" Works in either direction \u2014 brand \u2192 creators or creator \u2192 brands \u2014 and detects direction from the data, so don't ask the user to declare it. Requires Apify MCP tools.",
       "keywords": [
         "influencer",
         "brand",
@@ -209,7 +209,7 @@
       "name": "apify-lead-scoring-enrichment",
       "source": "./skills/apify-lead-scoring-enrichment",
       "skills": "./",
-      "description": "Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper → AI Web Scraper → Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. \"uses Shopify → send Shopify install guide\"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
+      "description": "Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper \u2192 AI Web Scraper \u2192 Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. \"uses Shopify \u2192 send Shopify install guide\"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
       "keywords": [
         "lead-scoring",
         "lead-enrichment",
@@ -231,7 +231,7 @@
       "name": "apify-link-prospecting-outreach",
       "source": "./skills/apify-link-prospecting-outreach",
       "skills": "./",
-      "description": "Find sites ranking for target keywords, score every prospect with Ahrefs domain authority and page-level traffic, identify the strongest pitch angle per row (\"links to competitor\", \"mentions brand without linking\", \"top-3 SERP\", \"resource page\", \"outdated content\"), generate brand-voice-matched outreach emails using an outreach-type-aware template (unlinked-mention claim, competitor-link replacement, resource-page inclusion, outdated-content replacement, topical niche-edit), and propose a concrete in-article link placement as three artifacts — the verbatim source sentence, the same sentence rewritten with the link spliced in, or a fully-drafted new insertion if no natural fit exists. Use when user asks to find link building opportunities, prospect link partners, recover unlinked brand mentions, replace competitor links, build a tiered outreach list, or run cold email outreach for SEO link building.",
+      "description": "Find sites ranking for target keywords, score every prospect with Ahrefs domain authority and page-level traffic, identify the strongest pitch angle per row (\"links to competitor\", \"mentions brand without linking\", \"top-3 SERP\", \"resource page\", \"outdated content\"), generate brand-voice-matched outreach emails using an outreach-type-aware template (unlinked-mention claim, competitor-link replacement, resource-page inclusion, outdated-content replacement, topical niche-edit), and propose a concrete in-article link placement as three artifacts \u2014 the verbatim source sentence, the same sentence rewritten with the link spliced in, or a fully-drafted new insertion if no natural fit exists. Use when user asks to find link building opportunities, prospect link partners, recover unlinked brand mentions, replace competitor links, build a tiered outreach list, or run cold email outreach for SEO link building.",
       "keywords": [
         "link-building",
         "seo",
@@ -295,7 +295,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Builds a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed. Use when user asks to find verified emails, build a leads list, scrape emails from Maps or SERP, verify emails for a URL list, or find an Apollo / Hunter alternative.",
+      "description": "Builds a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed. Use when user asks to find verified emails, build a leads list, scrape emails from Maps or SERP, verify emails for a URL list, or find an Apollo / Hunter alternative.",
       "keywords": [
         "email",
         "verification",
@@ -314,7 +314,7 @@
       "name": "apify-x402-agentic-wallet",
       "source": "./skills/apify-x402-agentic-wallet",
       "skills": "./",
-      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) — no Apify account or API key. You buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs with it. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, mentions \"x402\", \"awal\", \"agentic wallet\", \"Coinbase wallet\", \"pay with USDC\", \"no API key\", or asks to pull live web data (social media, search, maps, marketplaces, news) while paying on-chain per use.",
+      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) \u2014 no Apify account or API key. You buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs with it. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, mentions \"x402\", \"awal\", \"agentic wallet\", \"Coinbase wallet\", \"pay with USDC\", \"no API key\", or asks to pull live web data (social media, search, maps, marketplaces, news) while paying on-chain per use.",
       "keywords": [
         "x402",
         "awal",
@@ -330,6 +330,22 @@
         "web-data"
       ],
       "category": "data-extraction"
+    },
+    {
+      "name": "apify-paylocity-jobs-api",
+      "source": "./skills/apify-paylocity-jobs-api",
+      "skills": "./",
+      "description": "Pull live structured job postings (title, salary, location, description) from any Paylocity recruiting board. A paylocity jobs api, no key, MCP-ready.",
+      "keywords": [
+        "apify",
+        "paylocity",
+        "paylocity jobs api",
+        "ats",
+        "jobs api",
+        "mcp"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-paylocity-jobs-api/SKILL.md
+++ b/skills/apify-paylocity-jobs-api/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: apify-paylocity-jobs-api
+description: "Pull live jobs from any Paylocity recruiting board with the Apify Paylocity Jobs API Actor (johnvc/paylocity-jobs-api). Returns job rows as JSON: title, company, board GUID, department, full street address with city, state and ZIP, remote flag, published date, apply URL, the employer's own published pay as flat salaryMin, salaryMax, salaryCurrency and salaryPeriod columns, and the description as source HTML plus optional Markdown or plain text. Takes Paylocity board GUIDs, recruiting.paylocity.com URLs, or company names; filters by title, department, location, remote and employment type before billing; newerThan turns a daily schedule into a new-postings feed. Use when someone wants paylocity jobs data, a paylocity jobs api, to scrape a Paylocity career site or recruiting board, paylocity salary data, or postings from any employer that hires through Paylocity. No API key, billed per job delivered, and MCP-ready for Claude and other AI agents."
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+  keywords: ["paylocity", "paylocity jobs api", "paylocity jobs", "paylocity careers", "ats jobs", "job postings api", "jobs api", "job scraper", "mcp"]
+---
+
+# Paylocity Jobs, as Rows You Can Query
+
+Board GUIDs, board URLs, or company names in, live Paylocity jobs out as structured rows, each with the employer's own published salary already flattened into numbers.
+
+## When to use this skill
+
+- Someone wants a Paylocity jobs API and found only the employer-side HR and payroll APIs they cannot sign up for.
+- You are filling a job board, a market-intel dashboard, or a sourcing tool with roles from Paylocity-hosted recruiting boards.
+- You need salary as numbers the employer actually published, not a string a human has to read or a model has to guess.
+- You want a daily new-postings feed for a set of Paylocity boards.
+
+Not for: finding which companies use Paylocity in the first place. Use the companion `apify-companies-using-paylocity` skill, built on the same Actor but shaped for discovery. See `references/actor-index.md`.
+
+## What you get
+
+One dataset row per job. `resultType` separates `job` rows from `error` rows.
+
+Core fields:
+
+- `id`, `url` (canonical, safe as a dedupe key), `applyUrl`, `title`
+- `companyName`, `boardGuid`, `boardUrl`
+- `department`, `location`, `address` (street, city, state, zip, county), `isRemote`, `indeedRemoteType`, `employmentType`, `isInternal`
+- `datePublished`, `datePosted`
+- flat `salaryMin`, `salaryMax`, `salaryCurrency`, `salaryPeriod`, `salaryUnit`, and `salaryRaw` (structured, verbatim)
+- `snippet` (short listing preview), `descriptionHtml` (source, in the base row), `descriptionMarkdown`, `descriptionText` (opt-in add-ons)
+- `source` (always `paylocity`), `sourceType` (`ats`), `scrapedAt`
+
+The Actor ships dataset views for the console: `overview`, `salaries` (sortable pay columns), `companies`, and `newPostings`.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/paylocity-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/paylocity-jobs-api`
+- Pricing: pay per event, no start fee, no API key. See the cost section below and `references/gotchas.md` for the live-price command.
+
+## Run it with the Apify CLI
+
+Every open job on one board, capped at 25, with Markdown descriptions:
+
+```bash
+apify actors call "johnvc/paylocity-jobs-api" -i '{"companies":["0062c37f-a34c-479c-978c-bd800d23f223"],"includeDescriptionMarkdown":true,"maxJobs":25}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-paylocity-jobs-api \
+  2>/dev/null
+```
+
+Remote roles across several boards, descriptions off for cheaper metadata rows:
+
+```bash
+apify actors call "johnvc/paylocity-jobs-api" -i '{"companies":["Indiana Health Centers","TAS Environmental Services"],"remoteOnly":true,"includeDescriptionMarkdown":false,"maxJobs":100}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-paylocity-jobs-api \
+  2>/dev/null
+```
+
+Only postings added in the last day, the shape to put on a daily schedule:
+
+```bash
+apify actors call "johnvc/paylocity-jobs-api" -i '{"companies":["0062c37f-a34c-479c-978c-bd800d23f223"],"newerThan":"25h","maxJobs":200}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-paylocity-jobs-api \
+  2>/dev/null
+```
+
+Confirm the live schema and prices before a large batch:
+
+```bash
+apify actors info "johnvc/paylocity-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-paylocity-jobs-api \
+  2>/dev/null
+```
+
+Read the rows back from a finished run:
+
+```bash
+apify datasets get-items <DATASET_ID> --format json \
+  --user-agent apify-awesome-skills/apify-paylocity-jobs-api \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json` (or `--format json`), `--user-agent apify-awesome-skills/apify-paylocity-jobs-api`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/paylocity-jobs-api`
+
+Then ask, for example: "Pull the open jobs from this Paylocity board with published salary ranges, and rank them by salaryMax." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Start with one board and `maxJobs` around 25. Look at the row shape before you pay for a wide crawl.
+2. Input a board GUID, a full `recruiting.paylocity.com/recruiting/jobs/All/{guid}/{slug}` URL, or a company name. Company names are resolved through discovery; an unresolved name returns a clear `error` row rather than guessing.
+3. Filter at the source, not downstream. `titleKeywords`, `departments`, `locationKeywords`, `remoteOnly`, `employmentTypes`, and `newerThan` all drop jobs before they are billed.
+4. Keep `includeDescriptionMarkdown` on for LLM pipelines; the base row already carries the source HTML description, so leave the add-ons off for lean rows.
+5. For salary work, read the flat columns. `salaryMin` is null when the employer does not display pay; `salaryUnit` tells you hourly versus annual.
+6. Check `resultType` before treating a row as a job. An `error` row carries a sanitized `errorMessage`.
+7. Dedupe downstream on `url`. It is canonical and survives a company editing the title.
+
+## Inputs
+
+- `companies` (array): Paylocity board GUIDs, `recruiting.paylocity.com` URLs, or company names, mixed freely.
+- `startUrls` (array): the same values in URL-list form; merged with `companies`.
+- `titleKeywords`, `departments`, `locationKeywords` (arrays): keep-only filters, run before billing.
+- `remoteOnly` (boolean, default false), `employmentTypes` (array)
+- `newerThan` (string): `24h`, `7d`, `2w`, or an ISO date, compared against each posting's own timestamp.
+- `cutoffField` (enum `posted`, `updated`): which timestamp `newerThan` uses.
+- `includeDescriptionMarkdown`, `includeDescriptionText` (booleans, default false): per-row add-ons.
+- `report` (enum `none`, `markdown`, `html`): a whole-run digest in the key-value store.
+- `maxJobs` (integer, default 100): the primary spend cap. `maxJobsPerCompany`, `maxConcurrency` refine it.
+- `proxyConfiguration` (object): off by default; direct connections work.
+
+## Cost
+
+Billing is pay per event with no start fee, so a run that returns nothing costs almost nothing. Confirm live prices with the info command above rather than trusting a number copied here.
+
+The base `job-result` event fires once per delivered job row, source-HTML description and salary included. Add-on events fire only on rows that carry the extra: `job-description-markdown`, `job-description-text`, and a flat `run-report`. Jobs removed by your filters, and expired postings, are never charged.
+
+Suggested confirmation thresholds: mention the estimate under about $5, warn the user over about $5, get explicit confirmation over about $20. Present cost as "around $X", never as a guarantee.
+
+## Honest limits
+
+- Salary appears only when the employer displays compensation on the posting. Nothing is inferred by a model.
+- Public recruiting-board data only. No applicant data, no recruiter contacts, nothing behind a login.
+- Company-name input depends on the board being discoverable in the public web archive. A brand-new board may need its GUID or URL until the archive catches up.
+- One board is read live per run, so the rows reflect the board right now, not an index from last week.
+
+## Troubleshooting
+
+- An `error` row with a not-public message: the board GUID no longer resolves. Confirm the GUID from the live careers page.
+- A company name that does not resolve: paste the board GUID or the full `recruiting.paylocity.com` URL instead.
+- Zero rows and no error row: your filters removed everything. Relax `newerThan` or `titleKeywords` first.
+- Duplicates across runs: dedupe on `url`, never on title.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Greenhouse Job Board API: https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Workday Careers API: https://apify.com/johnvc/workday-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- iCIMS Careers API: https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Oracle and Taleo Jobs API: https://apify.com/johnvc/oracle-taleo-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-paylocity-jobs-api/references/actor-index.md
+++ b/skills/apify-paylocity-jobs-api/references/actor-index.md
@@ -1,0 +1,19 @@
+# Actor routing table
+
+One Actor, `johnvc/paylocity-jobs-api`, backs two skills. Route by the job at hand.
+
+| The job | Skill | Actor input shape |
+|---|---|---|
+| Get the open jobs from named Paylocity boards | `apify-paylocity-jobs-api` (this one) | `companies` = GUIDs / URLs / names, filters, `maxJobs` |
+| A daily new-postings feed for boards you track | `apify-paylocity-jobs-api` (this one) | add `newerThan: "25h"` on a schedule |
+| Find which companies hire on Paylocity | `apify-companies-using-paylocity` | `discoverAll: true`, `discoverOnly: true`, `discoveryQuery` |
+
+Store page: https://apify.com/johnvc/paylocity-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+Hosted MCP server: `https://mcp.apify.com/?tools=actors,docs,johnvc/paylocity-jobs-api`
+
+## Related job-data Actors
+
+- Greenhouse Job Board API: https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Workday Careers API: https://apify.com/johnvc/workday-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- iCIMS Careers API: https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Ashby Job Board API: https://apify.com/johnvc/ashby-job-board-scraper?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-paylocity-jobs-api/references/gotchas.md
+++ b/skills/apify-paylocity-jobs-api/references/gotchas.md
@@ -1,0 +1,24 @@
+# Cost guardrails and error recovery
+
+## Cost guardrails
+
+- `maxJobs` is the primary spend cap. Start at 25 for a first look, then raise it once the row shape is confirmed.
+- The base `job-result` event carries the source-HTML description and salary. The `job-description-markdown` and `job-description-text` add-ons bill only on rows that carry them, so leave them off unless a pipeline needs converted text.
+- Filters (`titleKeywords`, `departments`, `locationKeywords`, `remoteOnly`, `employmentTypes`, `newerThan`) run before billing. Filtered jobs and expired postings cost nothing.
+- Confirm live prices before a wide crawl:
+
+```bash
+apify actors info "johnvc/paylocity-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-paylocity-jobs-api \
+  2>/dev/null
+```
+
+- Rough confirmation thresholds: mention the estimate under about $5, warn over about $5, get explicit confirmation over about $20. Present cost as "around $X", never a guarantee.
+
+## Error recovery
+
+- `error` rows are in-band, so a pipeline sees them without reading logs. Each carries a sanitized `errorMessage` and its context. They are never charged.
+- A board GUID that no longer resolves reports that it is not public. Confirm the GUID from the live `recruiting.paylocity.com` careers page.
+- A company name that does not resolve: pass the board GUID or the full board URL instead of the name.
+- Zero rows and no error row means your filters removed everything. Relax `newerThan` or `titleKeywords`.
+- Dedupe across runs on `url`, never on title; a company can edit a title without changing the posting.


### PR DESCRIPTION
Adds one skill, `apify-paylocity-jobs-api`, wrapping the public Apify Actor johnvc/paylocity-jobs-api (a Paylocity Jobs API). One skill, one marketplace.json entry, four files changed. Pulls live structured job postings from any Paylocity recruiting board.