### PR TITLE
Add apify-companies-using-paylocity skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "apify-ads-intelligence",
       "source": "./skills/apify-ads-intelligence",
       "skills": "./",
-      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter — promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
+      "description": "Research, spy on, and analyze ads across Meta (Facebook & Instagram), Google (Ads Transparency Center + paid search results), TikTok (Ads Library + Creative Center), LinkedIn Ad Library, and X (Twitter \u2014 promoted tweets, best-effort) using Apify Actors. Use when user asks about competitor ads, ad library research, winning creatives, ad copy analysis, landing page audits from ads, cross-platform ad audits, brand transparency checks, or any task involving paid ad creatives, advertiser data, or ad targeting from public ad libraries.",
       "keywords": [
         "ads",
         "advertising",
@@ -97,7 +97,7 @@
       "name": "apify-buying-signal-detection",
       "source": "./skills/apify-buying-signal-detection",
       "skills": "./",
-      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types — job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) — then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture — Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says \"find companies with buying signals\", \"detect intent signals for outbound\", \"set up a weekly lead pipeline\", \"monitor hiring signals for lead gen\", \"track startup funding leads\", \"find LinkedIn buying signals\", \"schedule Apify Actors for prospecting\", \"build a signals-based lead list\", or \"set up buying-intent monitoring for my ICP\".",
+      "description": "Set up a recurring buying-signal detection pipeline that finds companies showing buying intent across three signal types \u2014 job postings (hiring for the persona), fundraising events (recent raises), and LinkedIn content (pain-point posts, hiring announcements) \u2014 then aggregates results into a deduplicated leads.csv with the signal source, evidence URL, and detection timestamp per row. Split-schedule architecture \u2014 Apify Actor Tasks pull raw data on their own cadence, a Claude-side aggregation task normalizes, deduplicates against a blacklist, and appends new leads with a weekly-idempotent guard. Use when the user says \"find companies with buying signals\", \"detect intent signals for outbound\", \"set up a weekly lead pipeline\", \"monitor hiring signals for lead gen\", \"track startup funding leads\", \"find LinkedIn buying signals\", \"schedule Apify Actors for prospecting\", \"build a signals-based lead list\", or \"set up buying-intent monitoring for my ICP\".",
       "keywords": [
         "buying-signals",
         "intent-data",
@@ -191,7 +191,7 @@
       "name": "apify-influencer-brand-collabs",
       "source": "./skills/apify-influencer-brand-collabs",
       "skills": "./",
-      "description": "Discover Instagram brand–creator partnerships by chaining Apify Actors. Use when the user asks who collabs with a brand, which brands a creator has done paid posts for, wants to audit an influencer's branded-content history, or wants to scope a brand's sponsorship roster. **Triggers:** - \"who collabs with [brand] on Instagram?\" - \"what brands has [creator] done sponsored posts for?\" - \"find paid partnerships / branded content for [handle]\" - \"audit [influencer]'s brand deals\" - \"show me [brand]'s influencer roster\" Works in either direction — brand → creators or creator → brands — and detects direction from the data, so don't ask the user to declare it. Requires Apify MCP tools.",
+      "description": "Discover Instagram brand\u2013creator partnerships by chaining Apify Actors. Use when the user asks who collabs with a brand, which brands a creator has done paid posts for, wants to audit an influencer's branded-content history, or wants to scope a brand's sponsorship roster. **Triggers:** - \"who collabs with [brand] on Instagram?\" - \"what brands has [creator] done sponsored posts for?\" - \"find paid partnerships / branded content for [handle]\" - \"audit [influencer]'s brand deals\" - \"show me [brand]'s influencer roster\" Works in either direction \u2014 brand \u2192 creators or creator \u2192 brands \u2014 and detects direction from the data, so don't ask the user to declare it. Requires Apify MCP tools.",
       "keywords": [
         "influencer",
         "brand",
@@ -209,7 +209,7 @@
       "name": "apify-lead-scoring-enrichment",
       "source": "./skills/apify-lead-scoring-enrichment",
       "skills": "./",
-      "description": "Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper → AI Web Scraper → Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. \"uses Shopify → send Shopify install guide\"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
+      "description": "Score and enrich a CSV of B2B leads using Apify Actors. Takes a CSV with company URLs, free-text scoring rules, and an enrichment preference; runs BuiltWith (tech stack), Website Content Crawler (content classification), and Contact Info Scraper (company metadata) for scoring; enriches with either department-specific contacts (Contact Info Scraper + Bulk Email Finder fallback) or copywriter discovery (Google Search Scraper \u2192 AI Web Scraper \u2192 Bulk Email Finder). Outputs an enriched CSV with a numeric score and a per-lead outreach_hook column that personalizes cold email copy (e.g. \"uses Shopify \u2192 send Shopify install guide\"). Use when user asks to score leads, qualify leads, enrich a lead list, detect a company's tech stack for outreach, find marketing/sales/engineering contacts at a list of companies, hunt down blog copywriters for guest-post pitches, personalize cold email at scale, or turn a raw domain list into a ready-to-pitch account list.",
       "keywords": [
         "lead-scoring",
         "lead-enrichment",
@@ -231,7 +231,7 @@
       "name": "apify-link-prospecting-outreach",
       "source": "./skills/apify-link-prospecting-outreach",
       "skills": "./",
-      "description": "Find sites ranking for target keywords, score every prospect with Ahrefs domain authority and page-level traffic, identify the strongest pitch angle per row (\"links to competitor\", \"mentions brand without linking\", \"top-3 SERP\", \"resource page\", \"outdated content\"), generate brand-voice-matched outreach emails using an outreach-type-aware template (unlinked-mention claim, competitor-link replacement, resource-page inclusion, outdated-content replacement, topical niche-edit), and propose a concrete in-article link placement as three artifacts — the verbatim source sentence, the same sentence rewritten with the link spliced in, or a fully-drafted new insertion if no natural fit exists. Use when user asks to find link building opportunities, prospect link partners, recover unlinked brand mentions, replace competitor links, build a tiered outreach list, or run cold email outreach for SEO link building.",
+      "description": "Find sites ranking for target keywords, score every prospect with Ahrefs domain authority and page-level traffic, identify the strongest pitch angle per row (\"links to competitor\", \"mentions brand without linking\", \"top-3 SERP\", \"resource page\", \"outdated content\"), generate brand-voice-matched outreach emails using an outreach-type-aware template (unlinked-mention claim, competitor-link replacement, resource-page inclusion, outdated-content replacement, topical niche-edit), and propose a concrete in-article link placement as three artifacts \u2014 the verbatim source sentence, the same sentence rewritten with the link spliced in, or a fully-drafted new insertion if no natural fit exists. Use when user asks to find link building opportunities, prospect link partners, recover unlinked brand mentions, replace competitor links, build a tiered outreach list, or run cold email outreach for SEO link building.",
       "keywords": [
         "link-building",
         "seo",
@@ -295,7 +295,7 @@
       "name": "apify-verified-email-finder",
       "source": "./skills/apify-verified-email-finder",
       "skills": "./",
-      "description": "Builds a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run — no third-party verifier needed. Use when user asks to find verified emails, build a leads list, scrape emails from Maps or SERP, verify emails for a URL list, or find an Apollo / Hunter alternative.",
+      "description": "Builds a list of verified business emails from Google Maps, Google SERPs, or a user-supplied URL list. Verification happens inside the same Apify run \u2014 no third-party verifier needed. Use when user asks to find verified emails, build a leads list, scrape emails from Maps or SERP, verify emails for a URL list, or find an Apollo / Hunter alternative.",
       "keywords": [
         "email",
         "verification",
@@ -314,7 +314,7 @@
       "name": "apify-x402-agentic-wallet",
       "source": "./skills/apify-x402-agentic-wallet",
       "skills": "./",
-      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) — no Apify account or API key. You buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs with it. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, mentions \"x402\", \"awal\", \"agentic wallet\", \"Coinbase wallet\", \"pay with USDC\", \"no API key\", or asks to pull live web data (social media, search, maps, marketplaces, news) while paying on-chain per use.",
+      "description": "Discover, pay for, and run any Apify Actor by paying USDC on Base over the x402 protocol with a Coinbase Agentic Wallet (awal) \u2014 no Apify account or API key. You buy one small, spend-capped prepaid Apify token, then run as many Actors as the request needs with it. Use when the user wants to use Apify tools without signing up, pay per use with crypto / USDC, set up an agentic wallet, mentions \"x402\", \"awal\", \"agentic wallet\", \"Coinbase wallet\", \"pay with USDC\", \"no API key\", or asks to pull live web data (social media, search, maps, marketplaces, news) while paying on-chain per use.",
       "keywords": [
         "x402",
         "awal",
@@ -330,6 +330,22 @@
         "web-data"
       ],
       "category": "data-extraction"
+    },
+    {
+      "name": "apify-companies-using-paylocity",
+      "source": "./skills/apify-companies-using-paylocity",
+      "skills": "./",
+      "description": "Find companies using Paylocity: enumerate recruiting boards from the public web archive with live open-jobs counts, for sales and sourcing. No key, MCP-ready.",
+      "keywords": [
+        "apify",
+        "paylocity",
+        "companies using paylocity",
+        "lead generation",
+        "prospecting",
+        "mcp"
+      ],
+      "category": "data-extraction",
+      "version": "1.0.0"
     }
   ]
 }

--- a/skills/apify-companies-using-paylocity/SKILL.md
+++ b/skills/apify-companies-using-paylocity/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: apify-companies-using-paylocity
+description: "Find companies that hire on Paylocity with the Apify Paylocity Jobs API Actor (johnvc/paylocity-jobs-api) in discovery mode. Enumerates Paylocity recruiting boards from the public web archive and returns one row per company: company name, board GUID, board URL, live open-jobs count, locations, and departments. Filter the set with a discovery query, live-verify each board, and cap the run. Use when someone wants a list of companies using Paylocity, companies hiring through Paylocity, Paylocity customer or prospect lists for sales and sourcing, or a directory of Paylocity career sites to feed lead generation or market research. No API key, billed per company row delivered, and MCP-ready for Claude and other AI agents."
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+  keywords: ["paylocity", "companies using paylocity", "companies hiring on paylocity", "paylocity customers", "lead generation", "sales prospecting", "ats discovery", "job board directory", "mcp"]
+---
+
+# Companies Using Paylocity, as a List You Can Work
+
+Turn on discovery and get a directory of employers that hire on Paylocity: one row per company, each with a live open-jobs count, straight from the public web archive.
+
+## When to use this skill
+
+- You want a list of companies that use Paylocity, for a prospect list, a market map, or a partner search.
+- Hiring is a buying signal, and you want to see who on Paylocity is actively posting roles in your niche.
+- You are building a directory of Paylocity career sites to feed a sourcing tool or a CRM.
+- You need the board GUID for a set of companies before pulling their jobs.
+
+Not for: pulling the actual job postings from a board you already know. Use the companion `apify-paylocity-jobs-api` skill, built on the same Actor but shaped for extraction. See `references/actor-index.md`.
+
+## What you get
+
+One dataset row per company. `resultType` is `company` (with `error` rows for boards that could not be read).
+
+Core fields:
+
+- `companyName`, `boardGuid`, `boardUrl`
+- `jobCount` (live open roles when `verifyLive` is on), `status` (`live`, `empty`, `dead`, or `unverified`)
+- `locations` (the board's declared locations), `departments`
+- `slugSource` (how the board was found), `discoveredAt`
+
+Pair a discovered `boardGuid` with the `apify-paylocity-jobs-api` skill to pull that company's jobs.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authentication via `apify login`, or an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/paylocity-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/paylocity-jobs-api`
+- Pricing: pay per event, no start fee, no API key. Discovered live or empty boards are one cheap event each; unverified, dead, and error rows are free. See `references/gotchas.md`.
+
+## Run it with the Apify CLI
+
+Discover up to 25 Paylocity boards, live-verified, company rows only:
+
+```bash
+apify actors call "johnvc/paylocity-jobs-api" -i '{"discoverAll":true,"discoverOnly":true,"verifyLive":true,"maxCompanies":25}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-companies-using-paylocity \
+  2>/dev/null
+```
+
+Narrow the discovery to boards whose slug matches a term (for example a sector or a name fragment):
+
+```bash
+apify actors call "johnvc/paylocity-jobs-api" -i '{"discoverAll":true,"discoverOnly":true,"discoveryQuery":"health","verifyLive":true,"maxCompanies":50}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-companies-using-paylocity \
+  2>/dev/null
+```
+
+Widen the archive coverage by unioning more monthly snapshots:
+
+```bash
+apify actors call "johnvc/paylocity-jobs-api" -i '{"discoverAll":true,"discoverOnly":true,"crawlDepth":4,"maxCompanies":100}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-companies-using-paylocity \
+  2>/dev/null
+```
+
+Confirm the live schema and prices before a large sweep:
+
+```bash
+apify actors info "johnvc/paylocity-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-companies-using-paylocity \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json` (or `--format json`), `--user-agent apify-awesome-skills/apify-companies-using-paylocity`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/paylocity-jobs-api`
+
+Then ask, for example: "Discover healthcare companies hiring on Paylocity, keep the boards with at least five open roles, and give me the company name plus board URL." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Set `discoverAll: true` and `discoverOnly: true` to get company rows and skip job scraping.
+2. Keep `verifyLive: true` so each row carries a real open-jobs count and a `status`. Turn it off for a faster, cheaper first pass that skips the live probe.
+3. Use `discoveryQuery` to narrow the set to a slug fragment, then raise `maxCompanies` once the shape looks right.
+4. Raise `crawlDepth` to union more monthly web-archive snapshots when you want broader coverage; the trade-off is a slower sweep.
+5. Filter downstream on `jobCount` and `status` to keep only boards that are actively posting.
+6. Feed a chosen `boardGuid` into the `apify-paylocity-jobs-api` skill to pull that company's jobs.
+
+## Inputs
+
+- `discoverAll` (boolean): enumerate Paylocity boards from the public web archive.
+- `discoverOnly` (boolean): return the company directory only, skip jobs.
+- `discoveryQuery` (string): text match over discovered board slugs.
+- `crawlDepth` (integer, default 2): how many monthly web-archive snapshots to union.
+- `verifyLive` (boolean, default true): live-probe each board for a current open-jobs count and status.
+- `includeInactive` (boolean, default false): also return dead boards.
+- `maxCompanies` (integer, default 25): the primary spend cap for a discovery run.
+- `maxConcurrency` (integer): parallel verification requests.
+
+## Cost
+
+Billing is pay per event with no start fee. Each live or empty company row is one cheap `company-result` event; unverified, dead, and error rows are delivered free. `maxCompanies` is the spend cap. Confirm live prices with the info command above rather than trusting a number copied here.
+
+Suggested confirmation thresholds: mention the estimate under about $5, warn the user over about $5, get explicit confirmation over about $20. Present cost as "around $X", never as a guarantee.
+
+## Honest limits
+
+- Discovery reads the public web archive, so a brand-new board can lag by a few weeks until the archive catches up. Known GUIDs and URLs always work immediately in the extraction skill.
+- The archive is broad but not a guaranteed census; `crawlDepth` widens coverage at the cost of a slower run.
+- `jobCount` reflects the live board at run time when `verifyLive` is on; with it off, the row is the archive record without a fresh count.
+- Public recruiting-board data only. No applicant data and nothing behind a login.
+
+## Troubleshooting
+
+- Few rows on a narrow `discoveryQuery`: broaden the term or raise `crawlDepth`.
+- Many `unverified` rows: turn `verifyLive` on to get counts and a real `status`.
+- A discovered board returns no jobs later: its `status` was `empty`; the company has no open roles right now.
+- Duplicates across sweeps: dedupe on `boardGuid`.
+
+See `references/gotchas.md` for cost guardrails and error recovery, and `references/actor-index.md` for the Actor routing table.
+
+## Related Actors
+
+- Greenhouse Job Board API: https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Workday Career Sites API: https://apify.com/johnvc/workday-career-sites-api?fpr=9n7kx3&fp_sid=awesomeskills
+- iCIMS Careers API: https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Ashby Job Board API: https://apify.com/johnvc/ashby-job-board-scraper?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-companies-using-paylocity/references/actor-index.md
+++ b/skills/apify-companies-using-paylocity/references/actor-index.md
@@ -1,0 +1,20 @@
+# Actor routing table
+
+One Actor, `johnvc/paylocity-jobs-api`, backs two skills. Route by the job at hand.
+
+| The job | Skill | Actor input shape |
+|---|---|---|
+| Find which companies hire on Paylocity | `apify-companies-using-paylocity` (this one) | `discoverAll: true`, `discoverOnly: true`, `discoveryQuery`, `verifyLive` |
+| Get the open jobs from named boards | `apify-paylocity-jobs-api` | `companies` = GUIDs / URLs / names, filters, `maxJobs` |
+| A daily new-postings feed for boards you track | `apify-paylocity-jobs-api` | add `newerThan: "25h"` on a schedule |
+
+Discovery gives you the `boardGuid`; hand it to `apify-paylocity-jobs-api` to pull that company's jobs.
+
+Store page: https://apify.com/johnvc/paylocity-jobs-api?fpr=9n7kx3&fp_sid=awesomeskills
+Hosted MCP server: `https://mcp.apify.com/?tools=actors,docs,johnvc/paylocity-jobs-api`
+
+## Related discovery and job-data Actors
+
+- Greenhouse Job Board API: https://apify.com/johnvc/greenhouse-job-board-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Workday Career Sites API: https://apify.com/johnvc/workday-career-sites-api?fpr=9n7kx3&fp_sid=awesomeskills
+- iCIMS Careers API: https://apify.com/johnvc/icims-careers-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-companies-using-paylocity/references/gotchas.md
+++ b/skills/apify-companies-using-paylocity/references/gotchas.md
@@ -1,0 +1,24 @@
+# Cost guardrails and error recovery
+
+## Cost guardrails
+
+- `maxCompanies` is the primary spend cap for a discovery run. Start at 25, then raise it once the row shape is confirmed.
+- Each live or empty `company-result` row is one cheap event; unverified, dead, and error rows are delivered free, so a `verifyLive: false` first pass is nearly free.
+- `crawlDepth` widens web-archive coverage but makes the sweep slower; raise it only when you need broader discovery.
+- Confirm live prices before a wide sweep:
+
+```bash
+apify actors info "johnvc/paylocity-jobs-api" --json \
+  --user-agent apify-awesome-skills/apify-companies-using-paylocity \
+  2>/dev/null
+```
+
+- Rough confirmation thresholds: mention the estimate under about $5, warn over about $5, get explicit confirmation over about $20. Present cost as "around $X", never a guarantee.
+
+## Error recovery
+
+- `error` rows are in-band and never charged; each carries a sanitized `errorMessage`.
+- Few rows on a narrow `discoveryQuery`: broaden the term or raise `crawlDepth`.
+- Many `unverified` rows: turn `verifyLive` on for a real `jobCount` and `status`.
+- A discovered board with no jobs later carried `status: empty`; the company has no open roles right now.
+- Dedupe across sweeps on `boardGuid`, never on company name.


### PR DESCRIPTION
Adds one skill, `apify-companies-using-paylocity`, wrapping the public Apify Actor johnvc/paylocity-jobs-api in discovery mode. One skill, one marketplace.json entry, four files changed. Discovers companies hiring on Paylocity for sales and sourcing.