### PR TITLE
Add apify-plan-hotel-stays skill

### DIFF
--- a/skills/apify-plan-hotel-stays/SKILL.md
+++ b/skills/apify-plan-hotel-stays/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: apify-plan-hotel-stays
+description: Plan hotel stays for a trip. Given one or more destinations, travel dates, party size, budget, and an optional rewards program, return a ranked, de-duplicated comparison of hotels and vacation rentals with nightly and total prices, ratings, review counts, and booking links, plus an email-ready HTML price table. Built on the Apify Google Hotels Search Scraper (johnvc/google-hotels-search-scraper). Use whenever someone wants to find a hotel, compare hotels in a city, decide where to stay, price lodging for specific dates, find Marriott or Hilton or Hyatt or IHG hotels for a stay, or asks "where should we stay" or "best hotel for these dates". It detects sold-out dates and offers to widen to a larger nearby city, normalizes per-night versus total price, and can price specific Airbnb listings too.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+  keywords: "plan hotel stays, hotel search, compare hotels, where to stay, hotel prices, vacation rentals, rewards program, trip planning, google hotels, apify"
+---
+
+# Plan Hotel Stays: a ranked hotel and rental comparison with prices
+
+Turn a destination and travel dates into a decision. This skill gathers the trip details, prices live hotels and vacation rentals across every location and date, ranks them, flags sold-out dates, respects a rewards program when the traveler has one, and hands back a comparison plus an email-ready price table people can actually book from.
+
+## When to use this skill
+
+- The traveler wants to find a hotel or compare hotels in a city for specific dates.
+- They ask "where should we stay", "what is the best hotel for these dates", or "how much is lodging for this trip".
+- They want to stay within a hotel loyalty program (Marriott, Hilton, Hyatt, IHG, Wyndham, and so on) and see which of that chain's properties fit.
+- They want vacation rentals compared alongside hotels, or want a specific Airbnb priced for the dates.
+- They want a shareable price table (Markdown or an email-ready HTML table) rather than a wall of search results.
+
+Not for: making reservations (this reads prices, it does not book), flight search (use `apify-plan-flights`), or planning a whole multi-stop trip with logistics (use `apify-plan-a-trip`).
+
+## Gather the trip details first, then map them to the search
+
+Ask for what you are missing before searching. These map straight onto the Actor's inputs:
+
+| Trip detail | Actor input |
+|-------------|-------------|
+| Destination(s) | `q` (for example "hotels near Denver International Airport", "hotels in Santa Fe, New Mexico") |
+| Check-in and check-out dates | `check_in_date`, `check_out_date` (YYYY-MM-DD) |
+| Party size and rooms | `adults`, `children`, `children_ages`; run per room if the group splits rooms |
+| Budget range | `min_price`, `max_price` (pass as strings, for example "120") |
+| Quality bar | `guest_rating` (string, for example "4.0"), `hotel_class` or `stars` |
+| Airport vs city center | phrasing in `q` ("near the airport" vs "downtown") |
+| Include rentals | `vacation_rentals: true` (a second run; see the workflow) |
+| Rewards program | see the next section |
+| Search locale | `gl`, `hl`, `currency` |
+
+If dates come from a flight itinerary, use the arrival and departure days as the first and last nights.
+
+## Rewards programs (search within a loyalty program)
+
+The Actor has no loyalty filter, so approximate honestly with `scripts/rewards.py`:
+
+```bash
+python3 scripts/rewards.py "Marriott Bonvoy"
+```
+
+For a hotel program it returns the chain's brand family (Marriott returns Courtyard, Fairfield, SpringHill, Residence Inn, Westin, Sheraton, and the rest). Use that list two ways: brand-bias the query where it helps (`q: "Marriott hotels near Denver airport"`), and after the search keep or flag rows whose `name` contains one of the brand substrings. Be honest about the limit: this Actor reads public cash rates, not your loyalty account, and does not show points or award pricing. It tells the traveler which of their chain's properties exist and what they cost in cash, so they can book the award stay through their own program.
+
+## What you get back (one object per results page)
+
+Each dataset item is one page of results (about 18 to 20 properties). Each property in the `properties` array carries `name`, `type` (hotel or vacation rental), `rate_per_night` and `total_rate` (a display string `lowest` plus a numeric `extracted_lowest`), `overall_rating`, `reviews` count, `amenities`, `gps_coordinates`, `link` (booking URL), and `property_token` (the dedupe key, and the input for photos or reviews). When present: `hotel_class` and `extracted_hotel_class`, `deal`, a per-vendor `prices` array, and `reviews_breakdown`.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authenticate with `apify login`, or set an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+- Optional: the Chrome MCP tools, only if you want to price specific Airbnb listings.
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/google-hotels-search-scraper?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/google-hotels-search-scraper`
+- Pricing: pay per page of results processed plus a small per-run setup fee (see `references/gotchas.md`).
+
+## Run it with the Apify CLI
+
+One search for a city and stay date:
+
+```bash
+apify actors call "johnvc/google-hotels-search-scraper" -i '{"search_type":"search","q":"hotels near Denver International Airport","check_in_date":"2026-10-15","check_out_date":"2026-10-16","adults":3,"currency":"USD","max_pages":1}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-hotel-stays \
+  2>/dev/null
+```
+
+Filtered: 4-star and up, guest rating at least 4.0, under 200 USD a night:
+
+```bash
+apify actors call "johnvc/google-hotels-search-scraper" -i '{"search_type":"search","q":"hotels in Santa Fe, New Mexico","check_in_date":"2026-10-16","check_out_date":"2026-10-18","adults":3,"hotel_class":"4,5","guest_rating":"4.0","max_price":"200","currency":"USD","max_pages":1}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-hotel-stays \
+  2>/dev/null
+```
+
+Include vacation rentals (a separate run):
+
+```bash
+apify actors call "johnvc/google-hotels-search-scraper" -i '{"search_type":"search","q":"vacation rentals in Albuquerque, New Mexico","check_in_date":"2026-10-16","check_out_date":"2026-10-18","adults":3,"vacation_rentals":true,"max_pages":1}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-hotel-stays \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-plan-hotel-stays`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/google-hotels-search-scraper`
+
+Then ask, for example: "Price hotels near Denver airport for Oct 15 to 16 for 3 adults, and the ten best-rated four-star options under 200 dollars a night." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Gather and confirm the trip details above. Fill gaps by asking, not guessing.
+2. Map each location and date pair to one search input. Remember the schema quirks: `min_price`, `max_price`, and `guest_rating` are strings, not numbers. Requiredness is enforced in code, not the schema; a query search needs `q` plus `check_in_date`.
+3. Run one search per location and date. Add one `vacation_rentals: true` run per location if rentals are wanted (rentals and `hotel_class` are not compatible; drop the class filter on the rentals run).
+4. Availability guard. A property with no `rate_per_night` for the date is not available, not free. If most well-rated properties in a small town come back with no rate, say so and offer to widen the search to a larger nearby city (Socorro sold out for an event night points you to Albuquerque). See `references/gotchas.md`.
+5. Parse in a subagent. A single search is 50 to 85 KB of minified JSON that lands in a tool-results file, not inline; `properties` is an array, so field projection with `fields="properties.name"` returns empty objects (request `fields="properties"` or the whole item). Hand the saved file paths to one subagent that extracts compact rows (name, class, rating, reviews, per-night, total, coords, link, property_token) and verifies the numbers. This keeps hundreds of KB of raw JSON out of the main context.
+6. Normalize and rank. For a one-night stay `total_rate` equals `rate_per_night`. Hotel rates are per room for the party; rental totals fold in cleaning and service fees, which make a single-night rental look expensive per night, so label the basis (per night vs total) in the output. Rank on rating and review count and price. Show `hotel_class` but do not rank on it; it is occasionally wrong.
+7. Apply the rewards filter or flag if a program was given.
+8. Optional Airbnb. Airbnb is never in Google Hotels results, even with `vacation_rentals: true`. If the traveler supplies Airbnb room URLs or asks for Airbnb, price each with the Chrome MCP routine in `references/airbnb-and-parsing.md`.
+9. Render the deliverables. Build the row set and run `scripts/render_price_table.py` to produce both a Markdown table and an email-ready HTML table with booking links and a "verify before booking" footer.
+
+## Inputs (Actor parameters)
+
+- `search_type` (enum: `search`, `autocomplete`, `photos`, `reviews`; default `search`)
+- `q` (destination or hotel query; required for a query search)
+- `check_in_date` / `check_out_date` (YYYY-MM-DD)
+- `adults` (default 2), `children` (default 0), `children_ages` (required if children above 0)
+- `min_price`, `max_price`, `currency` (prices are strings)
+- `stars`, `hotel_class` (2 to 5), `guest_rating` (string), `amenities`, `property_type` (filters)
+- `vacation_rentals` (boolean) plus `rental_type`, `bedrooms`, `bathrooms`
+- `gl`, `hl` (country and language)
+- `max_pages` (default 1, 0 = all pages; the cost cap)
+- `property_token` (single-property mode; also required for photos and reviews)
+
+## Cost guardrails
+
+Pay per event: a per-run setup fee plus a fee per page of results processed. A one-page search lands around $0.04. `max_pages` is the hard cost cap; never run `max_pages: 0` on a broad city query without an estimate. Full thresholds are in `references/gotchas.md`.
+
+## Honest limits
+
+- Read-only. The Actor reads prices; it does not make reservations.
+- Cash rates only, not points or award pricing, and not your loyalty account balance.
+- One dataset item per results page, not per hotel; flatten the `properties` array.
+- Airbnb is not in Google Hotels; price it separately (see references).
+- Star class is noisy; use it as a label, not a ranking key.
+
+## Troubleshooting
+
+See `references/gotchas.md` for empty results, the children-ages validation error, the rentals-plus-class incompatibility, currency defaults, and the availability guard. See `references/airbnb-and-parsing.md` for the subagent parse routine and the Airbnb scraping routine. See `references/actor-index.md` for the Actor routing table.
+
+## Bundled scripts
+
+- `scripts/render_price_table.py`: rows in, a Markdown table and an email-ready HTML table out.
+- `scripts/rewards.py`: a rewards program name in, airline codes or hotel brand families out.
+
+## Related travel skills and Actors
+
+- Plan flights for the same trip: the `apify-plan-flights` skill, built on https://apify.com/johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search?fpr=9n7kx3&fp_sid=awesomeskills
+- Plan the whole trip (flights, lodging, and logistics): the `apify-plan-a-trip` skill.
+- Export raw hotel data as JSON: the `apify-scrape-hotel-prices` skill.
+- Destination discovery: https://apify.com/johnvc/google-travel-explore-api?fpr=9n7kx3&fp_sid=awesomeskills
+- Restaurants and attractions near a property: https://apify.com/johnvc/google-local-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-plan-hotel-stays/references/actor-index.md
+++ b/skills/apify-plan-hotel-stays/references/actor-index.md
@@ -1,0 +1,24 @@
+# Actor index: plan hotel stays
+
+The primary Actor for this skill, plus the travel-data Actors worth chaining when a task needs more than hotel listings. Read this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| Google Hotels | Price and compare hotels and rentals for a destination and stay date | `johnvc/google-hotels-search-scraper` | community | Pay per page (about 20 properties per page) plus a per-run setup fee. Modes via `search_type`: `search` (default), `autocomplete`, `photos`, `reviews`. A query search needs `q` plus `check_in_date`; photos and reviews need a `property_token`. One page object per dataset item. |
+
+## Chain with other travel-data Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Flight prices and route data for the same trip | `johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search` | Pair lodging with airfare for a total trip cost. See the `apify-plan-flights` skill. |
+| A whole event or destination trip with logistics | both Actors | See the `apify-plan-a-trip` skill; it reuses this lodging workflow. |
+| Destination discovery and trip ideas | `johnvc/google-travel-explore-api` | Find where to search before pricing hotels. |
+| Restaurants and attractions near a property | `johnvc/google-local-api` | Feed a property's `gps_coordinates` area into local search. |
+
+## How to extend
+
+1. Search candidates: `apify actors search "google hotels" --json --limit 20 2>/dev/null`
+2. Fetch the input schema: `apify actors info "johnvc/google-hotels-search-scraper" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-plan-hotel-stays/references/airbnb-and-parsing.md
+++ b/skills/apify-plan-hotel-stays/references/airbnb-and-parsing.md
@@ -1,0 +1,31 @@
+# Parsing large results, and pricing Airbnb directly
+
+Two routines the workflow points to: how to parse big hotel result files without flooding the main context, and how to price specific Airbnb listings that Google Hotels never returns.
+
+## Parse hotel results in a subagent
+
+Why: one search returns 50 to 85 KB of minified, single-line JSON. It exceeds the inline tool-result cap, so it is written to a tool-results file (often under a path like `/var/folders/...`). Those files open with the `Read` tool but not from a bash sandbox, and line-based chunking does not help because the JSON is one line. Pulling several of these into the main context burns hundreds of KB fast.
+
+The efficient pattern:
+
+1. Run all the searches you need first. Collect the saved file path from each run.
+2. Hand the paths to one subagent with a tight instruction: read each file, pull the `properties` array, and return a compact table with one row per property.
+3. Ask the subagent for exactly these fields: `name`, `type`, `extracted_hotel_class`, `overall_rating`, `reviews`, `rate_per_night.extracted_lowest`, `total_rate.extracted_lowest`, `gps_coordinates`, `link`, `property_token`. Sorted by price ascending.
+4. Tell the subagent to verify the numbers it reports against the file, not to estimate, and to mark any property with no `rate_per_night` as "no rate returned" rather than dropping it silently.
+
+Field projection note: requesting `fields="properties.name"` returns empty objects, because `properties` is an array, not a nested object. Request `fields="properties"` (the whole array) or the whole item. `omit` does not trim nested array subfields either, so there is no server-side way to slim these; trim client-side in the subagent.
+
+The subagent returns a small ranked table. Feed those rows to `scripts/render_price_table.py`.
+
+## Price a specific Airbnb listing (Chrome MCP)
+
+Why: the Actor's `vacation_rentals: true` returns Vrbo, Whimstay, and property-manager sites, never airbnb.com. To price a real Airbnb listing you scrape airbnb.com directly.
+
+Routine:
+
+1. Strip tracking parameters from any user-supplied Airbnb URL. Keep only the room id.
+2. Navigate to `https://www.airbnb.com/rooms/ROOM_ID?check_in=YYYY-MM-DD&check_out=YYYY-MM-DD&adults=N` with the Chrome MCP tools.
+3. Read the page text and extract: title, location, beds and baths, guest capacity, rating, review count, the all-in total for the dates, cancellation policy, and house rules.
+4. Record the total as a "2-night total, all fees included" style figure and compute a per-night figure for context. Label the basis so it compares fairly against per-room hotel rates.
+
+Add each Airbnb row to the same row set you pass to `render_price_table.py`, in its own section, with the booking URL as the link.

--- a/skills/apify-plan-hotel-stays/references/gotchas.md
+++ b/skills/apify-plan-hotel-stays/references/gotchas.md
@@ -1,0 +1,48 @@
+# Gotchas: plan hotel stays (johnvc/google-hotels-search-scraper)
+
+Cost guardrails, the availability guard, error recovery, and input quirks. Read this on demand when building inputs, interpreting results, or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event. At the time of writing: about $0.018 per page of hotel search results processed (BRONZE tier), plus a $0.02 one-time setup fee per run, $0.00001 per dataset result, and a tiny per-start charge. Prices differ by usage tier; confirm the live price on the Store card or with `apify actors info "johnvc/google-hotels-search-scraper" --json 2>/dev/null` (look at pricing).
+
+Estimate before running: cost is roughly the setup fee plus `max_pages` times the per-page price. One page carries about 20 properties.
+
+- 1 city, 1 page: about $0.04.
+- 5 cities, 1 page each: about $0.12.
+- 5 cities, 5 pages each: about $0.55.
+
+Suggested confirmation thresholds:
+
+- Rough estimate over $5: warn the traveler.
+- Rough estimate over $20: get explicit confirmation before running.
+- Always present cost as "around $X", not a guarantee.
+
+`max_pages` is the hard cost cap. The dangerous value is 0: it means fetch every available page, and a broad city query can report thousands of results. Never run `max_pages: 0` on a city-level query without an explicit go-ahead. For most trip planning, 1 page per city and date is plenty; the top ~20 results cover the bookable set.
+
+## The availability guard (a signal, not an error)
+
+Many properties return no `rate_per_night` for a given date. That means no availability for those dates, not a price of $0. Treat it as a signal:
+
+1. When you flatten results, separate "priced" from "no rate returned".
+2. If a large share of the well-rated properties in a small town come back with no rate, the town is likely selling out (common around events). Say so plainly.
+3. Offer to widen the search to a larger nearby city and re-run. Example: Socorro, New Mexico sold out for a Trinity Site open-house night while only motels remained, so the search widened to Albuquerque, about an hour north.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Empty `properties` array | Query too narrow, filters too tight, or dates invalid | Broaden the query, drop filters, check `check_in_date` is in the future and `check_out_date` is after it. |
+| Validation error on children | `children` above 0 without `children_ages` | Pass `children_ages` as a comma-separated string, for example "5,8". |
+| No results with class filter on rentals | `hotel_class` combined with `vacation_rentals: true` | The schema marks them incompatible; drop the class filter on the rentals run. |
+| Prices look wrong for the market | Currency defaulted from country | Set `currency` explicitly (ISO 4217, like "USD" or "EUR"). |
+| Fewer pages than expected | Google had fewer results, or `max_pages` capped it | Check `search_metadata.pagination_limit_reached`; raise `max_pages` if true. |
+
+## Actor-specific notes
+
+- One dataset item per results page, not per hotel. Flatten `properties` into rows client-side.
+- Compute on the numeric fields (`rate_per_night.extracted_lowest`, `total_rate.extracted_lowest`, `extracted_hotel_class`); the unprefixed twins are display strings like "$171" or "4-star hotel".
+- For a one-night stay `total_rate` equals `rate_per_night`. For longer stays compare on total, then show per-night for context. Hotel rates are per room for the party; rental totals include cleaning and service fees, so a single-night rental looks expensive per night. Label the basis.
+- Star class (`extracted_hotel_class`) is occasionally wrong (a budget brand showing 5 stars). Show it, do not rank on it. Rank on rating, review count, and price.
+- `property_token` is the stable dedupe key across runs and the input for `reviews`, `photos`, and single-property detail pulls. It is marked secret in the schema, so the Console masks it; passing it via API or CLI works normally.
+- `min_price`, `max_price`, and `guest_rating` are strings in the schema, for example "120" and "4.0". The schema declares no required fields; requiredness is enforced in code (a query search needs `q` and `check_in_date`).

--- a/skills/apify-plan-hotel-stays/scripts/render_price_table.py
+++ b/skills/apify-plan-hotel-stays/scripts/render_price_table.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Render a travel price comparison as an email-ready HTML table plus Markdown.
+
+Turns normalized rows (hotels, rentals, or flights) into two deliverables:
+a standalone HTML file that renders correctly when pasted into Gmail or Outlook,
+and a Markdown version for docs and chat. The HTML styling mirrors a working
+lodging price table (navy headers, zebra striping, right-aligned numbers,
+booking links), so the output is ready to send without extra formatting.
+
+Stdlib only. No third-party dependencies.
+
+Input JSON schema (pass a file with --in, or pipe on stdin):
+
+{
+  "title": "Trip lodging options",
+  "subtitles": ["Dates: Thu Oct 15 to Mon Oct 19, 2026", "Party: 3 travelers"],
+  "note": "Rates are per night for the party unless a column says total.",
+  "sections": [
+    {
+      "heading": "Denver options (near airport)",
+      "subheading": "Thursday, Oct 15 (arrival night)",   // optional H3
+      "note": "Entire homes, priced as a 2-night total.",  // optional
+      "columns": [
+        {"key": "name",  "label": "Hotel", "link_key": "link"},
+        {"key": "class", "label": "Class", "num": true},
+        {"key": "rating","label": "Rating","num": true},
+        {"key": "price", "label": "Per night", "num": true, "price": true}
+      ],
+      "rows": [
+        {"name": "Example Inn", "link": "https://example.com", "class": "3",
+         "rating": "4.1", "price": "$124"}
+      ]
+    }
+  ],
+  "footer": "Prices pulled from Google Hotels via johnvc/google-hotels-search-scraper. Verify before booking."
+}
+
+Usage:
+  python3 render_price_table.py --in table.json --out /path/to/basename
+    writes /path/to/basename.html and /path/to/basename.md
+  python3 render_price_table.py --in table.json --format html
+    prints HTML to stdout
+"""
+
+import argparse
+import html
+import json
+import sys
+
+CSS = """  body { font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; color: #1a1a1a; background: #ffffff; margin: 0; padding: 24px; line-height: 1.45; }
+  .wrap { max-width: 820px; margin: 0 auto; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 17px; margin: 30px 0 8px; padding-bottom: 5px; border-bottom: 2px solid #33526e; color: #33526e; }
+  h3 { font-size: 14px; margin: 18px 0 6px; color: #333; }
+  p.sub { margin: 0 0 6px; color: #444; }
+  p.note { font-size: 13px; color: #555; margin: 6px 0 0; }
+  table { border-collapse: collapse; width: 100%; margin: 8px 0 4px; font-size: 14px; }
+  th, td { border: 1px solid #cccccc; padding: 7px 9px; text-align: left; vertical-align: top; }
+  th { background: #33526e; color: #ffffff; font-weight: 600; }
+  tbody tr:nth-child(even) { background: #f4f6f8; }
+  td.num, th.num { text-align: right; white-space: nowrap; }
+  .price { font-weight: 700; white-space: nowrap; }
+  a { color: #1a5fb4; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .foot { font-size: 12px; color: #666; margin-top: 24px; border-top: 1px solid #ddd; padding-top: 10px; }"""
+
+
+def _cell_text(row, col):
+    val = row.get(col["key"], "")
+    if val is None:
+        val = ""
+    return str(val)
+
+
+def render_html(data):
+    out = []
+    out.append("<!DOCTYPE html>")
+    out.append('<html lang="en">')
+    out.append("<head>")
+    out.append('<meta charset="utf-8">')
+    out.append('<meta name="viewport" content="width=device-width, initial-scale=1">')
+    out.append("<title>%s</title>" % html.escape(data.get("title", "Price table")))
+    out.append("<style>")
+    out.append(CSS)
+    out.append("</style>")
+    out.append("</head>")
+    out.append("<body>")
+    out.append('<div class="wrap">')
+    out.append("")
+    out.append("  <h1>%s</h1>" % html.escape(data.get("title", "")))
+    for sub in data.get("subtitles", []):
+        out.append('  <p class="sub">%s</p>' % html.escape(sub))
+    if data.get("note"):
+        out.append('  <p class="note">%s</p>' % html.escape(data["note"]))
+
+    for section in data.get("sections", []):
+        out.append("")
+        out.append("  <h2>%s</h2>" % html.escape(section.get("heading", "")))
+        if section.get("subheading"):
+            out.append("  <h3>%s</h3>" % html.escape(section["subheading"]))
+        cols = section.get("columns", [])
+        out.append("  <table>")
+        head = "    <thead><tr>"
+        for col in cols:
+            cls = ' class="num"' if col.get("num") else ""
+            head += "<th%s>%s</th>" % (cls, html.escape(col.get("label", "")))
+        head += "</tr></thead>"
+        out.append(head)
+        out.append("    <tbody>")
+        for row in section.get("rows", []):
+            line = "      <tr>"
+            for col in cols:
+                classes = []
+                if col.get("num"):
+                    classes.append("num")
+                if col.get("price"):
+                    classes.append("price")
+                cls = ' class="%s"' % " ".join(classes) if classes else ""
+                text = html.escape(_cell_text(row, col))
+                link_key = col.get("link_key")
+                href = row.get(link_key) if link_key else None
+                if href:
+                    cell = '<a href="%s">%s</a>' % (html.escape(str(href)), text)
+                else:
+                    cell = text
+                line += "<td%s>%s</td>" % (cls, cell)
+            line += "</tr>"
+            out.append(line)
+        out.append("    </tbody>")
+        out.append("  </table>")
+        if section.get("note"):
+            out.append('  <p class="note">%s</p>' % html.escape(section["note"]))
+
+    if data.get("footer"):
+        out.append("")
+        out.append('  <p class="foot">%s</p>' % html.escape(data["footer"]))
+    out.append("")
+    out.append("</div>")
+    out.append("</body>")
+    out.append("</html>")
+    return "\n".join(out) + "\n"
+
+
+def render_markdown(data):
+    out = []
+    out.append("# %s" % data.get("title", ""))
+    out.append("")
+    for sub in data.get("subtitles", []):
+        out.append("**%s**  " % sub)
+    if data.get("note"):
+        out.append("")
+        out.append("_%s_" % data["note"])
+    for section in data.get("sections", []):
+        out.append("")
+        out.append("## %s" % section.get("heading", ""))
+        if section.get("subheading"):
+            out.append("")
+            out.append("### %s" % section["subheading"])
+        cols = section.get("columns", [])
+        out.append("")
+        out.append("| " + " | ".join(c.get("label", "") for c in cols) + " |")
+        out.append("| " + " | ".join("---:" if c.get("num") else "---" for c in cols) + " |")
+        for row in section.get("rows", []):
+            cells = []
+            for col in cols:
+                text = _cell_text(row, col).replace("|", "\\|")
+                link_key = col.get("link_key")
+                href = row.get(link_key) if link_key else None
+                if href:
+                    cells.append("[%s](%s)" % (text, href))
+                else:
+                    cells.append(text)
+            out.append("| " + " | ".join(cells) + " |")
+        if section.get("note"):
+            out.append("")
+            out.append("_%s_" % section["note"])
+    if data.get("footer"):
+        out.append("")
+        out.append("---")
+        out.append("")
+        out.append(data["footer"])
+    return "\n".join(out) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render a travel price table to HTML and Markdown.")
+    ap.add_argument("--in", dest="infile", help="Input JSON file (default: stdin)")
+    ap.add_argument("--out", dest="out", help="Output basename; writes .html and .md")
+    ap.add_argument("--format", choices=["html", "md", "both"], default="both",
+                    help="What to emit to stdout when --out is not given (default both)")
+    args = ap.parse_args()
+
+    raw = open(args.infile).read() if args.infile else sys.stdin.read()
+    data = json.loads(raw)
+
+    html_doc = render_html(data)
+    md_doc = render_markdown(data)
+
+    if args.out:
+        with open(args.out + ".html", "w") as f:
+            f.write(html_doc)
+        with open(args.out + ".md", "w") as f:
+            f.write(md_doc)
+        print("Wrote %s.html and %s.md" % (args.out, args.out))
+    else:
+        if args.format in ("html", "both"):
+            sys.stdout.write(html_doc)
+        if args.format == "both":
+            sys.stdout.write("\n")
+        if args.format in ("md", "both"):
+            sys.stdout.write(md_doc)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/apify-plan-hotel-stays/scripts/rewards.py
+++ b/skills/apify-plan-hotel-stays/scripts/rewards.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Map a loyalty or rewards program to concrete search filters.
+
+Neither the Google Hotels nor the Google Flights Actor filters by loyalty
+program directly, so this helper turns a program name into filters the Actors
+DO understand:
+
+  Flights: a list of airline codes for the program's own airline plus its
+           alliance partners, ready for the Actor's `airlines` input (CSV).
+  Hotels:  a list of brand-name substrings for the program's chain family,
+           used to keep or flag matching rows from a normal search (the Actor
+           has no loyalty filter, so match on each property's `name`).
+
+Honest limit: these Actors read public cash prices, not your loyalty account.
+They surface which chain or alliance properties exist at what cash rate; they
+do not show points or award pricing. Book award stays through your own program.
+
+Usage:
+  python3 rewards.py "Marriott Bonvoy"        # -> JSON with hotel brands
+  python3 rewards.py "United MileagePlus"      # -> JSON with airline codes
+  python3 rewards.py --list                    # list known programs
+"""
+
+import json
+import sys
+
+# Airline alliance member codes (IATA). Not exhaustive; the common carriers.
+STAR_ALLIANCE = ["UA", "AC", "LH", "NH", "SQ", "TK", "LX", "OS", "SN", "TP",
+                 "SK", "OZ", "TG", "CA", "ZH", "SA", "ET", "AV", "CM", "NZ",
+                 "MS", "BR", "AI", "LO", "A3", "JP"]
+ONEWORLD = ["AA", "BA", "QF", "CX", "JL", "IB", "AY", "QR", "MH", "RJ",
+            "UL", "AT", "AS", "WY", "S7", "FJ"]
+SKYTEAM = ["DL", "AF", "KL", "KE", "AZ", "SU", "MU", "CZ", "CI", "GA",
+           "SV", "ME", "KQ", "AR", "AM", "RO", "VN", "OK", "UX", "VS"]
+
+# Program -> filter definition. `aliases` are lowercase substrings for matching.
+PROGRAMS = {
+    # Airline programs (kind: air)
+    "United MileagePlus": {"kind": "air", "airlines": STAR_ALLIANCE,
+                           "aliases": ["united", "mileageplus", "mileage plus"]},
+    "Air Canada Aeroplan": {"kind": "air", "airlines": STAR_ALLIANCE,
+                            "aliases": ["aeroplan", "air canada"]},
+    "Lufthansa Miles & More": {"kind": "air", "airlines": STAR_ALLIANCE,
+                               "aliases": ["miles & more", "miles and more", "lufthansa"]},
+    "American AAdvantage": {"kind": "air", "airlines": ONEWORLD,
+                            "aliases": ["american", "aadvantage", "aa "]},
+    "British Airways Executive Club": {"kind": "air", "airlines": ONEWORLD,
+                                       "aliases": ["british airways", "executive club", "avios"]},
+    "Alaska Mileage Plan": {"kind": "air", "airlines": ONEWORLD,
+                            "aliases": ["alaska", "mileage plan"]},
+    "Delta SkyMiles": {"kind": "air", "airlines": SKYTEAM,
+                       "aliases": ["delta", "skymiles"]},
+    "Air France-KLM Flying Blue": {"kind": "air", "airlines": SKYTEAM,
+                                   "aliases": ["flying blue", "air france", "klm"]},
+    "Southwest Rapid Rewards": {"kind": "air", "airlines": ["WN"],
+                                "aliases": ["southwest", "rapid rewards"]},
+    "JetBlue TrueBlue": {"kind": "air", "airlines": ["B6"],
+                         "aliases": ["jetblue", "trueblue"]},
+
+    # Hotel programs (kind: hotel). Brand substrings match against property name.
+    "Marriott Bonvoy": {"kind": "hotel", "aliases": ["marriott", "bonvoy"],
+                        "hotel_brands": ["Marriott", "Courtyard", "Fairfield", "SpringHill",
+                                         "Residence Inn", "TownePlace", "Ritz-Carlton", "Westin",
+                                         "Sheraton", "W Hotels", "Aloft", "Element", "Four Points",
+                                         "Le Meridien", "St. Regis", "Autograph", "Moxy", "AC Hotels",
+                                         "Delta Hotels", "Gaylord", "Renaissance", "Tribute",
+                                         "JW Marriott"]},
+    "Hilton Honors": {"kind": "hotel", "aliases": ["hilton", "honors"],
+                      "hotel_brands": ["Hilton", "Hampton", "Home2", "Homewood", "Garden Inn",
+                                       "Embassy Suites", "DoubleTree", "Waldorf Astoria", "Conrad",
+                                       "Canopy", "Curio", "Tapestry", "Tru", "Motto", "LXR",
+                                       "Signia", "Tempo", "Spark"]},
+    "IHG One Rewards": {"kind": "hotel", "aliases": ["ihg", "one rewards"],
+                        "hotel_brands": ["Holiday Inn", "avid", "Garner", "Candlewood", "Staybridge",
+                                         "Crowne Plaza", "InterContinental", "Kimpton", "Hotel Indigo",
+                                         "EVEN", "Regent", "Six Senses", "voco", "Atwell", "Iberostar"]},
+    "World of Hyatt": {"kind": "hotel", "aliases": ["hyatt"],
+                       "hotel_brands": ["Hyatt", "Andaz", "Thompson", "Caption", "Alila", "Miraval",
+                                        "Grand Hyatt", "Park Hyatt", "Hyatt Regency", "Hyatt Place",
+                                        "Hyatt House", "Destination", "Dream", "The Unbound"]},
+    "Wyndham Rewards": {"kind": "hotel", "aliases": ["wyndham"],
+                        "hotel_brands": ["Wyndham", "Days Inn", "Super 8", "La Quinta", "Baymont",
+                                         "Ramada", "Howard Johnson", "Microtel", "Travelodge",
+                                         "Wingate", "AmericInn", "Dolce", "Dazzler", "Esplendor"]},
+    "Choice Privileges": {"kind": "hotel", "aliases": ["choice", "privileges"],
+                          "hotel_brands": ["Comfort", "Quality Inn", "Sleep Inn", "Clarion", "Cambria",
+                                           "Ascend", "Econo Lodge", "Rodeway", "MainStay", "WoodSpring",
+                                           "Suburban", "Everhome"]},
+    "Best Western Rewards": {"kind": "hotel", "aliases": ["best western"],
+                             "hotel_brands": ["Best Western", "SureStay", "Aiden", "Sadie", "Glo",
+                                              "Vib", "Executive Residency"]},
+    "Accor Live Limitless": {"kind": "hotel", "aliases": ["accor", "all ", "live limitless"],
+                             "hotel_brands": ["Sofitel", "Novotel", "Mercure", "ibis", "Pullman",
+                                              "Fairmont", "Raffles", "Swissotel", "Movenpick",
+                                              "MGallery", "Grand Mercure", "Adagio"]},
+}
+
+
+def lookup(name):
+    """Return the program definition best matching a free-text name, or None."""
+    if not name:
+        return None
+    q = name.strip().lower()
+    # Exact key match first.
+    for key, val in PROGRAMS.items():
+        if key.lower() == q:
+            return dict(val, program=key)
+    # Alias substring match.
+    for key, val in PROGRAMS.items():
+        for alias in val.get("aliases", []):
+            if alias in q:
+                return dict(val, program=key)
+    return None
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__)
+        return
+    if args[0] == "--list":
+        for key, val in sorted(PROGRAMS.items()):
+            print("%-32s %s" % (key, val["kind"]))
+        return
+    name = " ".join(args)
+    result = lookup(name)
+    if result is None:
+        print(json.dumps({"query": name, "match": None,
+                          "note": "No known program matched. Run with --list to see known programs, "
+                                  "or brand-bias the search query by hand."}, indent=2))
+        return
+    print(json.dumps({"query": name, **result}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## apify-plan-hotel-stays

A consumer trip-planning agent skill built on the Apify Google Hotels Search Scraper (`johnvc/google-hotels-search-scraper`). Given one or more destinations, travel dates, party size, budget, and an optional hotel rewards program, it returns a ranked, de-duplicated comparison of hotels and vacation rentals with nightly and total prices, ratings, review counts, and booking links, plus an email-ready HTML price table.

- One skill per PR: this adds only `skills/apify-plan-hotel-stays/` and one `.claude-plugin/marketplace.json` entry.
- Bundles two helper scripts (`render_price_table.py`, `rewards.py`) and reference docs.
- Telemetry flags present on every apify CLI call; validated locally with `lint_telemetry.sh` and `generate_agents.py`.
- `agents/AGENTS.md` and the README skills table left for post-merge regeneration.

Canonical repo: https://github.com/johnisanerd/claude-skill-plan-hotel-stays