### PR TITLE
Add apify-plan-flights skill

### DIFF
--- a/skills/apify-plan-flights/SKILL.md
+++ b/skills/apify-plan-flights/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: apify-plan-flights
+description: Plan flights for a trip. Given an origin and destination (or several), travel dates, party size, budget, and an optional airline or rewards program, return ranked flight options with price, number of stops, airlines, total duration, and layovers, plus a comparison table. Built on the Apify Google Flights Data Scraper (johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search). Use whenever someone wants to find flights, compare airfare, price a route for specific dates, search one-way, round-trip, or multi-city itineraries, fly within an airline alliance or miles program (United, American, Delta, Alaska, and partners), or asks "how much are flights" or "what is the cheapest flight". It reads Google Flights price insights so you can say whether a fare is a good deal, and can fetch booking links on request.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+  keywords: "plan flights, flight search, compare airfare, cheapest flight, round trip flights, multi-city, airline miles, price insights, trip planning, google flights, apify"
+---
+
+# Plan Flights: ranked flight options with prices and stops
+
+Turn a route and dates into a shortlist. This skill gathers the trip details, prices live flights for one-way, round-trip, or multi-city itineraries, ranks them by price and convenience, respects an airline or miles program when the traveler has one, reads Google Flights price insights so you can say if a fare is high or low, and hands back a clean comparison table.
+
+## When to use this skill
+
+- The traveler wants to find flights or compare airfare for a route and dates.
+- They ask "how much are flights", "what is the cheapest flight", or "what are my options" for a trip.
+- They want to fly within an alliance or miles program (United and Star Alliance, American and Oneworld, Delta and SkyTeam, Alaska and partners).
+- They want a round-trip, one-way, or multi-city itinerary priced.
+- They want to know whether a fare is a good deal right now (price insights).
+
+Not for: booking tickets (this reads prices, it does not book), hotel search (use `apify-plan-hotel-stays`), or planning a whole multi-stop trip with lodging and logistics (use `apify-plan-a-trip`).
+
+## Gather the trip details first, then map them to the search
+
+| Trip detail | Actor input |
+|-------------|-------------|
+| Origin and destination airports | `departure_id`, `arrival_id` (IATA codes; comma-separate to search several, for example "CDG,ORY") |
+| Outbound and return dates | `outbound_date`, `return_date` (YYYY-MM-DD; omit return for one-way) |
+| Multi-city itinerary | `multi_city_json` (replaces the three fields above) |
+| Party size | `adults`, `children`, `infants` |
+| Budget ceiling | `max_price` (an integer here, for example 600) |
+| Nonstop preference | `max_stops` (0 = nonstop only, 1 = one stop max) |
+| Airline or rewards program | `airlines` (CSV of codes); see the next section |
+| Cabin quality | `exclude_basic` (drop basic economy) |
+| Booking links | `fetch_booking_options` (bills per option; see cost) |
+| Search locale | `gl`, `hl`, `currency` |
+
+If the traveler gives cities rather than airports, resolve to IATA codes first (and offer nearby-airport alternatives via the comma-separated form).
+
+## Rewards programs (fly within a miles program)
+
+Use `scripts/rewards.py` to turn a program into an `airlines` filter:
+
+```bash
+python3 scripts/rewards.py "United MileagePlus"
+```
+
+For an airline program it returns the airline plus its alliance partner codes (United returns the Star Alliance set). Pass those as the `airlines` input so results stay bookable and creditable to that program. Southwest and JetBlue return just their own code (no alliance). Honest limit: this Actor reads cash fares, not award (miles) pricing or your account balance. It shows which flights on your program's airlines exist and what they cost in cash, so you can then price the award seat in your own program.
+
+## What you get back
+
+The Apify dataset item carries, at the top level, `best_flights` (Google's curated shortlist), `other_flights` (the long tail), a pre-flattened `all_flights` view (one row per flight, the easiest to parse), `price_insights`, and `airports`. Each option in `best_flights` and `other_flights` carries `flights` (the legs), `layovers`, `total_duration` (minutes), `carbon_emissions`, `price` (a number), `type` (Round trip or One way), and a `departure_token`. Each leg carries `departure_airport`, `arrival_airport`, `duration`, `airline`, `flight_number`, `travel_class`, `airplane`, and `legroom`. The `all_flights` rows carry `airlines`, `route`, `stops`, `stops_label`, `price`, `duration`, `departure_time`, and `arrival_time` already flattened. `price_insights` carries `lowest_price`, `price_level` (low, typical, high), `typical_price_range`, and `price_history`. Booking links appear in `booking_options` only when `fetch_booking_options` is true. Note: when the Actor saves a local JSON file via `output_file`, the same content is nested under a `results` object; from the dataset (API, CLI, or MCP) it is at the top level.
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills).
+- Authenticate with `apify login`, or set an `APIFY_TOKEN` environment variable (Apify Console, Settings, Integrations).
+
+## The Actor
+
+- Store page: https://apify.com/johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search?fpr=9n7kx3&fp_sid=awesomeskills
+- Actor ID: `johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search`
+- Pricing: pay per page of results processed plus a small per-run setup fee; booking options bill separately (see `references/gotchas.md`).
+
+## Run it with the Apify CLI
+
+Round-trip search for 3 adults:
+
+```bash
+apify actors call "johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search" -i '{"departure_id":"IAD","arrival_id":"DEN","outbound_date":"2026-10-15","return_date":"2026-10-19","adults":3,"currency":"USD","max_pages":1}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-flights \
+  2>/dev/null
+```
+
+Nonstop only, on a miles program, under a budget:
+
+```bash
+apify actors call "johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search" -i '{"departure_id":"IAD","arrival_id":"DEN","outbound_date":"2026-10-15","return_date":"2026-10-19","adults":3,"max_stops":0,"airlines":"UA,AC,LH","max_price":600,"exclude_basic":true,"currency":"USD"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-flights \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-plan-flights`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+The Actor is MCP-ready. Add the hosted server URL:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search`
+
+Then ask, for example: "Price round-trip flights IAD to DEN Oct 15 to 19 for 3 adults, nonstop preferred, and tell me if the fare is a good deal." MCP setup docs: https://docs.apify.com/platform/integrations/mcp
+
+## Workflow
+
+1. Gather and confirm the trip details above. Resolve cities to IATA codes.
+2. Map to the search input. Remember the quirk: `max_price` is an integer here (the hotels Actor uses strings). The schema declares no required fields; a one-way or round-trip search needs `departure_id`, `arrival_id`, and `outbound_date`, or use `multi_city_json` instead.
+3. Run the search. Keep `max_pages` at 1 for a normal trip; raise it only when you need deep coverage.
+4. Parse in a subagent when the result is large. Prefer the pre-flattened `all_flights` array (one row per flight, with `airlines`, `route`, `stops_label`, `price`, `duration`, and times already extracted); fall back to `best_flights` and `other_flights` (count `layovers` for stops, read each leg's `airline`, convert `total_duration` minutes to hours and minutes). Verify numbers against the data. See `references/gotchas.md`.
+5. Rank by price first, then by stops, then by total duration. Surface the best nonstop and the cheapest overall separately when they differ.
+6. Read `price_insights`. Tell the traveler whether the current `lowest_price` sits below, inside, or above the `typical_price_range`, and mention the `price_level`. This is what turns a list into advice.
+7. Apply the airlines filter for a rewards program (step done at input time via `airlines`).
+8. Booking links, only if asked. Set `fetch_booking_options: true`; it makes extra requests and bills per booking option, so confirm first.
+9. Render the deliverable. Build the row set and run `scripts/render_price_table.py` for a Markdown table and an email-ready HTML table.
+
+## Inputs (Actor parameters)
+
+- `departure_id`, `arrival_id` (IATA codes; comma-separated for multiple)
+- `outbound_date`, `return_date` (YYYY-MM-DD; omit return for one-way)
+- `multi_city_json` (JSON string; replaces the route and date fields)
+- `adults` (default 1), `children` (default 0), `infants` (default 0)
+- `max_price` (integer), `max_stops` (0 = nonstop), `airlines` (CSV codes)
+- `exclude_basic` (boolean), `fetch_booking_options` (boolean; bills per option)
+- `gl`, `hl` (country and language enums), `currency`
+- `max_pages` (default 1, 0 = no limit)
+
+## Cost guardrails
+
+Pay per event: a per-run setup fee plus a fee per page of results processed (around $0.02 per page at BRONZE tier). Booking options are billed per option returned, so leave `fetch_booking_options` off unless the traveler wants links. Full thresholds are in `references/gotchas.md`.
+
+## Honest limits
+
+- Read-only. The Actor reads fares; it does not book tickets.
+- Cash fares only, not award or miles pricing, and not your account balance.
+- `total_duration` and leg `duration` are minutes; convert for display.
+- Number of stops is the length of the `layovers` array, not a separate field.
+- Fares move; a quote is for the moment it was pulled.
+
+## Troubleshooting
+
+See `references/gotchas.md` for empty results, airport-code issues, the multi-city format, the booking-options cost, and the subagent parse routine. See `references/actor-index.md` for the Actor routing table.
+
+## Bundled scripts
+
+- `scripts/render_price_table.py`: rows in, a Markdown table and an email-ready HTML table out.
+- `scripts/rewards.py`: a rewards program name in, airline codes or hotel brand families out.
+
+## Related travel skills and Actors
+
+- Plan lodging for the same trip: the `apify-plan-hotel-stays` skill, built on https://apify.com/johnvc/google-hotels-search-scraper?fpr=9n7kx3&fp_sid=awesomeskills
+- Plan the whole trip (flights, lodging, and logistics): the `apify-plan-a-trip` skill.
+- Use the flights data as a raw API or dataset: the `apify-google-flights-api` and `apify-flight-price-api` skills.
+- Destination discovery: https://apify.com/johnvc/google-travel-explore-api?fpr=9n7kx3&fp_sid=awesomeskills

--- a/skills/apify-plan-flights/references/actor-index.md
+++ b/skills/apify-plan-flights/references/actor-index.md
@@ -1,0 +1,23 @@
+# Actor index: plan flights
+
+The primary Actor for this skill, plus the travel-data Actors worth chaining. Read this after `SKILL.md` to pick the right Actor for a specific user intent.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| Google Flights | Price and compare flights for a route and dates | `johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search` | community | Pay per page plus a per-run setup fee. Supports one-way, round-trip, and multi-city (via `multi_city_json`). Returns `results.best_flights`, `results.other_flights`, and `price_insights`. Booking links only when `fetch_booking_options` is true (billed per option). |
+
+## Chain with other travel-data Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Lodging for the same trip | `johnvc/google-hotels-search-scraper` | Pair airfare with hotels for a total trip cost. See the `apify-plan-hotel-stays` skill. |
+| A whole event or destination trip with logistics | both Actors | See the `apify-plan-a-trip` skill; it reuses this flight workflow. |
+| Destination discovery and trip ideas | `johnvc/google-travel-explore-api` | Find where to fly before pricing a route. |
+
+## How to extend
+
+1. Search candidates: `apify actors search "google flights" --json --limit 20 2>/dev/null`
+2. Fetch the input schema: `apify actors info "johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-plan-flights/references/gotchas.md
+++ b/skills/apify-plan-flights/references/gotchas.md
@@ -1,0 +1,44 @@
+# Gotchas: plan flights (johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search)
+
+Cost guardrails, error recovery, input quirks, and the subagent parse routine. Read this on demand when building inputs, interpreting results, or when a run fails.
+
+## Cost guardrails
+
+Pricing model: pay per event. At the time of writing: about $0.02 per page of flight results processed (BRONZE tier), plus a $0.01 one-time setup fee per run, and a tiny per-result and per-start charge. Booking options are billed separately, about $0.02 per booking option returned, and only when `fetch_booking_options` is true. Confirm live prices with `apify actors info "johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search" --json 2>/dev/null` (look at pricing).
+
+Estimate before running: a normal route and date pair is one page, around $0.03. The expensive switch is `fetch_booking_options: true`, which adds a per-option charge across many options; leave it off unless the traveler wants booking links, and warn before enabling it on a broad search.
+
+Suggested confirmation thresholds:
+
+- Rough estimate over $5: warn the traveler.
+- Rough estimate over $20: get explicit confirmation before running.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Empty or thin results | Bad airport code, or no service on the route and date | Verify IATA codes; try nearby airports with the comma-separated form (for example "EWR,JFK,LGA"). |
+| Multi-city not working | Route and date fields set alongside `multi_city_json` | When you use `multi_city_json`, leave `departure_id`, `arrival_id`, and `outbound_date` empty; the JSON supplies each leg. |
+| Prices look off for the market | Currency defaulted from country | Set `currency` explicitly. |
+| No booking links in output | `fetch_booking_options` was false | Set it to true (and expect the per-option charge). |
+| Only a few options returned | Google returned a short list, or `max_pages` capped it | Raise `max_pages` if you need deeper coverage. |
+
+## Actor-specific notes
+
+- `max_price` is an integer in this schema (the hotels Actor uses strings). Pass 600, not "600".
+- From the dataset, the itinerary lives at the top level in `best_flights` (Google's curated shortlist), `other_flights` (the long tail), and a pre-flattened `all_flights` view; read `all_flights` for the quickest one-row-per-flight parse. A local `output_file` nests the same content under a `results` object.
+- Number of stops is the length of the `layovers` array on each flight option. `total_duration` and each leg `duration` are in minutes.
+- `type` is "Round trip" or "One way". For a round-trip the `flights` array holds all legs across both directions; group by direction when you display times.
+- `price_insights` is the advice layer: `lowest_price`, `price_level` (low, typical, high), `typical_price_range`, and a `price_history` series. Use it to say whether now is a good time to book.
+- The schema declares no required fields; requiredness is enforced in code (a one-way or round-trip search needs `departure_id`, `arrival_id`, and `outbound_date`).
+
+## Parse results in a subagent
+
+Large searches write minified JSON to a tool-results file rather than returning inline. To keep the main context clean, hand the saved file path to one subagent and ask it to:
+
+1. Prefer the pre-flattened `all_flights` array: one row per flight, already carrying `airlines`, `route`, `stops`, `stops_label`, `price`, `duration`, `departure_time`, and `arrival_time`. Fall back to `best_flights` and `other_flights` when you need per-leg detail.
+2. From `all_flights`, return one compact row per option: `airlines`, `route`, `stops_label`, `duration`, times, and `price`. From `best_flights` or `other_flights`, build the same by reading each leg's `airline`, counting `layovers` for stops, and converting `total_duration` minutes to hours and minutes.
+3. Also return the `price_insights` summary (lowest price, level, typical range).
+4. Verify every number against the data rather than estimating.
+
+Feed those rows to `scripts/render_price_table.py`.

--- a/skills/apify-plan-flights/scripts/render_price_table.py
+++ b/skills/apify-plan-flights/scripts/render_price_table.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Render a travel price comparison as an email-ready HTML table plus Markdown.
+
+Turns normalized rows (hotels, rentals, or flights) into two deliverables:
+a standalone HTML file that renders correctly when pasted into Gmail or Outlook,
+and a Markdown version for docs and chat. The HTML styling mirrors a working
+lodging price table (navy headers, zebra striping, right-aligned numbers,
+booking links), so the output is ready to send without extra formatting.
+
+Stdlib only. No third-party dependencies.
+
+Input JSON schema (pass a file with --in, or pipe on stdin):
+
+{
+  "title": "Trip lodging options",
+  "subtitles": ["Dates: Thu Oct 15 to Mon Oct 19, 2026", "Party: 3 travelers"],
+  "note": "Rates are per night for the party unless a column says total.",
+  "sections": [
+    {
+      "heading": "Denver options (near airport)",
+      "subheading": "Thursday, Oct 15 (arrival night)",   // optional H3
+      "note": "Entire homes, priced as a 2-night total.",  // optional
+      "columns": [
+        {"key": "name",  "label": "Hotel", "link_key": "link"},
+        {"key": "class", "label": "Class", "num": true},
+        {"key": "rating","label": "Rating","num": true},
+        {"key": "price", "label": "Per night", "num": true, "price": true}
+      ],
+      "rows": [
+        {"name": "Example Inn", "link": "https://example.com", "class": "3",
+         "rating": "4.1", "price": "$124"}
+      ]
+    }
+  ],
+  "footer": "Prices pulled from Google Hotels via johnvc/google-hotels-search-scraper. Verify before booking."
+}
+
+Usage:
+  python3 render_price_table.py --in table.json --out /path/to/basename
+    writes /path/to/basename.html and /path/to/basename.md
+  python3 render_price_table.py --in table.json --format html
+    prints HTML to stdout
+"""
+
+import argparse
+import html
+import json
+import sys
+
+CSS = """  body { font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; color: #1a1a1a; background: #ffffff; margin: 0; padding: 24px; line-height: 1.45; }
+  .wrap { max-width: 820px; margin: 0 auto; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 17px; margin: 30px 0 8px; padding-bottom: 5px; border-bottom: 2px solid #33526e; color: #33526e; }
+  h3 { font-size: 14px; margin: 18px 0 6px; color: #333; }
+  p.sub { margin: 0 0 6px; color: #444; }
+  p.note { font-size: 13px; color: #555; margin: 6px 0 0; }
+  table { border-collapse: collapse; width: 100%; margin: 8px 0 4px; font-size: 14px; }
+  th, td { border: 1px solid #cccccc; padding: 7px 9px; text-align: left; vertical-align: top; }
+  th { background: #33526e; color: #ffffff; font-weight: 600; }
+  tbody tr:nth-child(even) { background: #f4f6f8; }
+  td.num, th.num { text-align: right; white-space: nowrap; }
+  .price { font-weight: 700; white-space: nowrap; }
+  a { color: #1a5fb4; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .foot { font-size: 12px; color: #666; margin-top: 24px; border-top: 1px solid #ddd; padding-top: 10px; }"""
+
+
+def _cell_text(row, col):
+    val = row.get(col["key"], "")
+    if val is None:
+        val = ""
+    return str(val)
+
+
+def render_html(data):
+    out = []
+    out.append("<!DOCTYPE html>")
+    out.append('<html lang="en">')
+    out.append("<head>")
+    out.append('<meta charset="utf-8">')
+    out.append('<meta name="viewport" content="width=device-width, initial-scale=1">')
+    out.append("<title>%s</title>" % html.escape(data.get("title", "Price table")))
+    out.append("<style>")
+    out.append(CSS)
+    out.append("</style>")
+    out.append("</head>")
+    out.append("<body>")
+    out.append('<div class="wrap">')
+    out.append("")
+    out.append("  <h1>%s</h1>" % html.escape(data.get("title", "")))
+    for sub in data.get("subtitles", []):
+        out.append('  <p class="sub">%s</p>' % html.escape(sub))
+    if data.get("note"):
+        out.append('  <p class="note">%s</p>' % html.escape(data["note"]))
+
+    for section in data.get("sections", []):
+        out.append("")
+        out.append("  <h2>%s</h2>" % html.escape(section.get("heading", "")))
+        if section.get("subheading"):
+            out.append("  <h3>%s</h3>" % html.escape(section["subheading"]))
+        cols = section.get("columns", [])
+        out.append("  <table>")
+        head = "    <thead><tr>"
+        for col in cols:
+            cls = ' class="num"' if col.get("num") else ""
+            head += "<th%s>%s</th>" % (cls, html.escape(col.get("label", "")))
+        head += "</tr></thead>"
+        out.append(head)
+        out.append("    <tbody>")
+        for row in section.get("rows", []):
+            line = "      <tr>"
+            for col in cols:
+                classes = []
+                if col.get("num"):
+                    classes.append("num")
+                if col.get("price"):
+                    classes.append("price")
+                cls = ' class="%s"' % " ".join(classes) if classes else ""
+                text = html.escape(_cell_text(row, col))
+                link_key = col.get("link_key")
+                href = row.get(link_key) if link_key else None
+                if href:
+                    cell = '<a href="%s">%s</a>' % (html.escape(str(href)), text)
+                else:
+                    cell = text
+                line += "<td%s>%s</td>" % (cls, cell)
+            line += "</tr>"
+            out.append(line)
+        out.append("    </tbody>")
+        out.append("  </table>")
+        if section.get("note"):
+            out.append('  <p class="note">%s</p>' % html.escape(section["note"]))
+
+    if data.get("footer"):
+        out.append("")
+        out.append('  <p class="foot">%s</p>' % html.escape(data["footer"]))
+    out.append("")
+    out.append("</div>")
+    out.append("</body>")
+    out.append("</html>")
+    return "\n".join(out) + "\n"
+
+
+def render_markdown(data):
+    out = []
+    out.append("# %s" % data.get("title", ""))
+    out.append("")
+    for sub in data.get("subtitles", []):
+        out.append("**%s**  " % sub)
+    if data.get("note"):
+        out.append("")
+        out.append("_%s_" % data["note"])
+    for section in data.get("sections", []):
+        out.append("")
+        out.append("## %s" % section.get("heading", ""))
+        if section.get("subheading"):
+            out.append("")
+            out.append("### %s" % section["subheading"])
+        cols = section.get("columns", [])
+        out.append("")
+        out.append("| " + " | ".join(c.get("label", "") for c in cols) + " |")
+        out.append("| " + " | ".join("---:" if c.get("num") else "---" for c in cols) + " |")
+        for row in section.get("rows", []):
+            cells = []
+            for col in cols:
+                text = _cell_text(row, col).replace("|", "\\|")
+                link_key = col.get("link_key")
+                href = row.get(link_key) if link_key else None
+                if href:
+                    cells.append("[%s](%s)" % (text, href))
+                else:
+                    cells.append(text)
+            out.append("| " + " | ".join(cells) + " |")
+        if section.get("note"):
+            out.append("")
+            out.append("_%s_" % section["note"])
+    if data.get("footer"):
+        out.append("")
+        out.append("---")
+        out.append("")
+        out.append(data["footer"])
+    return "\n".join(out) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render a travel price table to HTML and Markdown.")
+    ap.add_argument("--in", dest="infile", help="Input JSON file (default: stdin)")
+    ap.add_argument("--out", dest="out", help="Output basename; writes .html and .md")
+    ap.add_argument("--format", choices=["html", "md", "both"], default="both",
+                    help="What to emit to stdout when --out is not given (default both)")
+    args = ap.parse_args()
+
+    raw = open(args.infile).read() if args.infile else sys.stdin.read()
+    data = json.loads(raw)
+
+    html_doc = render_html(data)
+    md_doc = render_markdown(data)
+
+    if args.out:
+        with open(args.out + ".html", "w") as f:
+            f.write(html_doc)
+        with open(args.out + ".md", "w") as f:
+            f.write(md_doc)
+        print("Wrote %s.html and %s.md" % (args.out, args.out))
+    else:
+        if args.format in ("html", "both"):
+            sys.stdout.write(html_doc)
+        if args.format == "both":
+            sys.stdout.write("\n")
+        if args.format in ("md", "both"):
+            sys.stdout.write(md_doc)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/apify-plan-flights/scripts/rewards.py
+++ b/skills/apify-plan-flights/scripts/rewards.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Map a loyalty or rewards program to concrete search filters.
+
+Neither the Google Hotels nor the Google Flights Actor filters by loyalty
+program directly, so this helper turns a program name into filters the Actors
+DO understand:
+
+  Flights: a list of airline codes for the program's own airline plus its
+           alliance partners, ready for the Actor's `airlines` input (CSV).
+  Hotels:  a list of brand-name substrings for the program's chain family,
+           used to keep or flag matching rows from a normal search (the Actor
+           has no loyalty filter, so match on each property's `name`).
+
+Honest limit: these Actors read public cash prices, not your loyalty account.
+They surface which chain or alliance properties exist at what cash rate; they
+do not show points or award pricing. Book award stays through your own program.
+
+Usage:
+  python3 rewards.py "Marriott Bonvoy"        # -> JSON with hotel brands
+  python3 rewards.py "United MileagePlus"      # -> JSON with airline codes
+  python3 rewards.py --list                    # list known programs
+"""
+
+import json
+import sys
+
+# Airline alliance member codes (IATA). Not exhaustive; the common carriers.
+STAR_ALLIANCE = ["UA", "AC", "LH", "NH", "SQ", "TK", "LX", "OS", "SN", "TP",
+                 "SK", "OZ", "TG", "CA", "ZH", "SA", "ET", "AV", "CM", "NZ",
+                 "MS", "BR", "AI", "LO", "A3", "JP"]
+ONEWORLD = ["AA", "BA", "QF", "CX", "JL", "IB", "AY", "QR", "MH", "RJ",
+            "UL", "AT", "AS", "WY", "S7", "FJ"]
+SKYTEAM = ["DL", "AF", "KL", "KE", "AZ", "SU", "MU", "CZ", "CI", "GA",
+           "SV", "ME", "KQ", "AR", "AM", "RO", "VN", "OK", "UX", "VS"]
+
+# Program -> filter definition. `aliases` are lowercase substrings for matching.
+PROGRAMS = {
+    # Airline programs (kind: air)
+    "United MileagePlus": {"kind": "air", "airlines": STAR_ALLIANCE,
+                           "aliases": ["united", "mileageplus", "mileage plus"]},
+    "Air Canada Aeroplan": {"kind": "air", "airlines": STAR_ALLIANCE,
+                            "aliases": ["aeroplan", "air canada"]},
+    "Lufthansa Miles & More": {"kind": "air", "airlines": STAR_ALLIANCE,
+                               "aliases": ["miles & more", "miles and more", "lufthansa"]},
+    "American AAdvantage": {"kind": "air", "airlines": ONEWORLD,
+                            "aliases": ["american", "aadvantage", "aa "]},
+    "British Airways Executive Club": {"kind": "air", "airlines": ONEWORLD,
+                                       "aliases": ["british airways", "executive club", "avios"]},
+    "Alaska Mileage Plan": {"kind": "air", "airlines": ONEWORLD,
+                            "aliases": ["alaska", "mileage plan"]},
+    "Delta SkyMiles": {"kind": "air", "airlines": SKYTEAM,
+                       "aliases": ["delta", "skymiles"]},
+    "Air France-KLM Flying Blue": {"kind": "air", "airlines": SKYTEAM,
+                                   "aliases": ["flying blue", "air france", "klm"]},
+    "Southwest Rapid Rewards": {"kind": "air", "airlines": ["WN"],
+                                "aliases": ["southwest", "rapid rewards"]},
+    "JetBlue TrueBlue": {"kind": "air", "airlines": ["B6"],
+                         "aliases": ["jetblue", "trueblue"]},
+
+    # Hotel programs (kind: hotel). Brand substrings match against property name.
+    "Marriott Bonvoy": {"kind": "hotel", "aliases": ["marriott", "bonvoy"],
+                        "hotel_brands": ["Marriott", "Courtyard", "Fairfield", "SpringHill",
+                                         "Residence Inn", "TownePlace", "Ritz-Carlton", "Westin",
+                                         "Sheraton", "W Hotels", "Aloft", "Element", "Four Points",
+                                         "Le Meridien", "St. Regis", "Autograph", "Moxy", "AC Hotels",
+                                         "Delta Hotels", "Gaylord", "Renaissance", "Tribute",
+                                         "JW Marriott"]},
+    "Hilton Honors": {"kind": "hotel", "aliases": ["hilton", "honors"],
+                      "hotel_brands": ["Hilton", "Hampton", "Home2", "Homewood", "Garden Inn",
+                                       "Embassy Suites", "DoubleTree", "Waldorf Astoria", "Conrad",
+                                       "Canopy", "Curio", "Tapestry", "Tru", "Motto", "LXR",
+                                       "Signia", "Tempo", "Spark"]},
+    "IHG One Rewards": {"kind": "hotel", "aliases": ["ihg", "one rewards"],
+                        "hotel_brands": ["Holiday Inn", "avid", "Garner", "Candlewood", "Staybridge",
+                                         "Crowne Plaza", "InterContinental", "Kimpton", "Hotel Indigo",
+                                         "EVEN", "Regent", "Six Senses", "voco", "Atwell", "Iberostar"]},
+    "World of Hyatt": {"kind": "hotel", "aliases": ["hyatt"],
+                       "hotel_brands": ["Hyatt", "Andaz", "Thompson", "Caption", "Alila", "Miraval",
+                                        "Grand Hyatt", "Park Hyatt", "Hyatt Regency", "Hyatt Place",
+                                        "Hyatt House", "Destination", "Dream", "The Unbound"]},
+    "Wyndham Rewards": {"kind": "hotel", "aliases": ["wyndham"],
+                        "hotel_brands": ["Wyndham", "Days Inn", "Super 8", "La Quinta", "Baymont",
+                                         "Ramada", "Howard Johnson", "Microtel", "Travelodge",
+                                         "Wingate", "AmericInn", "Dolce", "Dazzler", "Esplendor"]},
+    "Choice Privileges": {"kind": "hotel", "aliases": ["choice", "privileges"],
+                          "hotel_brands": ["Comfort", "Quality Inn", "Sleep Inn", "Clarion", "Cambria",
+                                           "Ascend", "Econo Lodge", "Rodeway", "MainStay", "WoodSpring",
+                                           "Suburban", "Everhome"]},
+    "Best Western Rewards": {"kind": "hotel", "aliases": ["best western"],
+                             "hotel_brands": ["Best Western", "SureStay", "Aiden", "Sadie", "Glo",
+                                              "Vib", "Executive Residency"]},
+    "Accor Live Limitless": {"kind": "hotel", "aliases": ["accor", "all ", "live limitless"],
+                             "hotel_brands": ["Sofitel", "Novotel", "Mercure", "ibis", "Pullman",
+                                              "Fairmont", "Raffles", "Swissotel", "Movenpick",
+                                              "MGallery", "Grand Mercure", "Adagio"]},
+}
+
+
+def lookup(name):
+    """Return the program definition best matching a free-text name, or None."""
+    if not name:
+        return None
+    q = name.strip().lower()
+    # Exact key match first.
+    for key, val in PROGRAMS.items():
+        if key.lower() == q:
+            return dict(val, program=key)
+    # Alias substring match.
+    for key, val in PROGRAMS.items():
+        for alias in val.get("aliases", []):
+            if alias in q:
+                return dict(val, program=key)
+    return None
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__)
+        return
+    if args[0] == "--list":
+        for key, val in sorted(PROGRAMS.items()):
+            print("%-32s %s" % (key, val["kind"]))
+        return
+    name = " ".join(args)
+    result = lookup(name)
+    if result is None:
+        print(json.dumps({"query": name, "match": None,
+                          "note": "No known program matched. Run with --list to see known programs, "
+                                  "or brand-bias the search query by hand."}, indent=2))
+        return
+    print(json.dumps({"query": name, **result}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## apify-plan-flights

A consumer trip-planning agent skill built on the Apify Google Flights Data Scraper (johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search). One skill per PR: touches only `skills/apify-plan-flights/`. Telemetry flags present on every apify CLI call; validated locally with lint_telemetry.sh and generate_agents.py. Catalog files (marketplace.json, AGENTS.md, README) left for post-merge regeneration.

Canonical repo: https://github.com/johnisanerd/claude-skill-plan-flights