### PR TITLE
Add apify-plan-a-trip skill

### DIFF
--- a/skills/apify-plan-a-trip/SKILL.md
+++ b/skills/apify-plan-a-trip/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: apify-plan-a-trip
+description: Plan an entire trip end to end, flights and hotels and logistics. Given an origin, a destination or a fixed anchor event, rough dates, party size, budget, and optional airline and hotel rewards programs, verify the anchor date live, price flights, price lodging at each overnight stop, reason about drive times and whether a leg is a day trip or an overnight, detect sold-out towns and re-base to a larger nearby city, and produce an itinerary plus a total-cost price table. Built on the Apify Google Flights Data Scraper and Google Hotels Search Scraper (johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search and johnvc/google-hotels-search-scraper), and reuses the plan-flights and plan-hotel-stays workflows. Use whenever someone says "plan a trip to", "help me plan an event trip", "flights and hotels for", "itinerary and budget for these dates", or describes a trip anchored to a game, festival, wedding, conference, or open house.
+author: John Cole
+author_url: https://github.com/johnisanerd
+license: MIT
+metadata:
+  version: "1.0"
+  keywords: "plan a trip, trip planner, flights and hotels, itinerary, event trip, travel budget, drive time planning, trip planning, google flights, google hotels, apify"
+---
+
+# Plan a Trip: flights, hotels, and logistics into one itinerary
+
+Take a trip from a rough idea to a bookable plan. This skill anchors on the fixed thing (an event, or a destination and dates), verifies it against today's facts, prices the flights, works out the driving and where to sleep each night, prices lodging at each stop, catches towns that sell out and re-bases them, and produces an itinerary with a per-person and total cost table.
+
+It reuses two sibling skills: `apify-plan-flights` for airfare and `apify-plan-hotel-stays` for lodging. Read those for the depth on each Actor; this skill is the orchestration and the trip judgment.
+
+## When to use this skill
+
+- The traveler says "plan a trip to", "help me plan a trip for this event", or "flights and hotels for these dates".
+- The trip is anchored to a fixed date or place: a game, a festival, a wedding, a conference, an open house.
+- They want an itinerary and a budget, not just one flight search or one hotel search.
+- The plan involves flying in and driving, or more than one place to sleep.
+
+Not for: a single hotel comparison (use `apify-plan-hotel-stays`) or a single flight search (use `apify-plan-flights`).
+
+## Gather the trip parameters first
+
+Ask for what is missing before you search. Everything downstream maps to these:
+
+- Origin airport (or home city).
+- Anchor: a fixed event (with its expected date) or a destination and rough dates.
+- Party size and rooms.
+- Budget range for the whole trip, or per night and per ticket.
+- Preferences: airport vs city-center lodging, nonstop vs cheapest flights, one base vs splitting nights.
+- Rewards programs: an airline or miles program for flights, a hotel program for lodging. Pass both to `scripts/rewards.py`.
+
+## Workflow
+
+1. Anchor first, and verify it live. The whole plan hinges on the fixed date being right. Event dates and venue details are present-day facts, so confirm them with a web search rather than trusting memory. Example: a Trinity Site open house is a specific Saturday each October; verify the exact date and the gate location before building around it.
+
+2. Price the flights. Follow `apify-plan-flights`: resolve airports, run the search for the party and dates, read `price_insights` to judge the fare, and note the arrival and departure days. Those days set the first and last nights of lodging. Apply the airline or miles program via the `airlines` filter.
+
+3. Work out the driving and the shape of each day. Look up or compute the drive legs between the arrival airport, the anchor, and each candidate base. Reason about whether a leg is a day trip or needs an overnight. Distance decides lodging shape: if the anchor is far from the arrival city, base near the anchor for that night; if it is close, a day trip from one base is cheaper and simpler. Example: Denver to the Albuquerque area is about 6.5 to 7.5 hours of driving, and the Trinity gate is about an hour from one base but nearly two from another, which is what makes the middle nights an overnight near the site rather than a daily round trip.
+
+4. Price lodging at each overnight stop. Follow `apify-plan-hotel-stays` for each base and date: run the search, apply the hotel rewards brand filter, and normalize per-night versus total. Run the arrival-night and departure-night lodging near the airport, and the anchor nights near the anchor.
+
+5. Detect sellouts and re-base automatically. Apply the availability guard: if a small town near the anchor comes back largely with no rates for the anchor night, it is selling out. Say so and widen to a larger nearby city, then re-price. Example: Socorro sold out for the open-house night, so the base moved to Albuquerque about an hour north.
+
+6. Assemble the itinerary and the cost. Lay out the days (fly in, drive, anchor day, drive back, fly home), then total the cost: flights for the party, lodging per night summed across stops, and a note on rental cars or fuel if relevant. Show per-person and total. Label every lodging basis (per night for a room, or a full multi-night total with fees for a rental).
+
+7. Render the deliverables. Use `scripts/render_price_table.py` for an email-ready HTML table and a Markdown version: a flights section, a lodging section per stop, and a cost summary, each with booking links and a "verify before booking" note.
+
+## The Actors
+
+- Flights: https://apify.com/johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search?fpr=9n7kx3&fp_sid=awesomeskills (Actor ID `johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search`)
+- Hotels: https://apify.com/johnvc/google-hotels-search-scraper?fpr=9n7kx3&fp_sid=awesomeskills (Actor ID `johnvc/google-hotels-search-scraper`)
+- Both are pay per event; estimate before big runs (see `references/gotchas.md`).
+
+## Prerequisites
+
+- Apify account (sign up at https://apify.com?fpr=9n7kx3&fp_sid=awesomeskills); `apify login` or an `APIFY_TOKEN`.
+- Web search, to verify the anchor date and drive times.
+- Optional: Chrome MCP, only to price specific Airbnb listings.
+
+## Run it with the Apify CLI
+
+Flights leg:
+
+```bash
+apify actors call "johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search" -i '{"departure_id":"IAD","arrival_id":"DEN","outbound_date":"2026-10-15","return_date":"2026-10-19","adults":3,"currency":"USD"}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-a-trip \
+  2>/dev/null
+```
+
+Lodging leg (arrival night near the airport):
+
+```bash
+apify actors call "johnvc/google-hotels-search-scraper" -i '{"search_type":"search","q":"hotels near Denver International Airport","check_in_date":"2026-10-15","check_out_date":"2026-10-16","adults":3,"currency":"USD","max_pages":1}' \
+  --json \
+  --user-agent apify-awesome-skills/apify-plan-a-trip \
+  2>/dev/null
+```
+
+Every call carries the three flags this repo expects: `--json`, `--user-agent apify-awesome-skills/apify-plan-a-trip`, and `2>/dev/null`.
+
+## Run it from Claude or another AI agent (MCP)
+
+Both Actors are MCP-ready:
+
+`https://mcp.apify.com/?tools=actors,docs,johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search,johnvc/google-hotels-search-scraper`
+
+Then ask, for example: "Plan a 4-night trip: fly IAD to DEN Oct 15 to 19 for 3 adults, we are driving to the Trinity Site open house on Oct 17, base us sensibly, and give me an itinerary and total cost."
+
+## Cost guardrails
+
+Each Actor is pay per event; a normal trip runs a handful of pages across flights and a few lodging searches, usually well under a dollar. `max_pages` is the cost cap on hotels; leave `fetch_booking_options` off on flights unless links are needed. See `references/gotchas.md` and the two sibling skills.
+
+## Honest limits
+
+- Read-only. This plans and prices; it does not book anything.
+- Cash prices only, not points or award pricing.
+- Drive times and event dates are looked up, not guaranteed; the traveler should verify before booking.
+- Airbnb is priced separately from Google Hotels (see the hotels skill references).
+
+## Troubleshooting and depth
+
+- Flight depth, price insights, and the flights parse routine: the `apify-plan-flights` skill and its `references/gotchas.md`.
+- Lodging depth, the availability guard, and the Airbnb and subagent-parse routines: the `apify-plan-hotel-stays` skill and its references.
+- Trip judgment encoded as lessons: `references/trip-planning-lessons.md`.
+- Actor routing table: `references/actor-index.md`.
+
+## Bundled scripts
+
+- `scripts/render_price_table.py`: rows in, a Markdown table and an email-ready HTML table out.
+- `scripts/rewards.py`: a rewards program name in, airline codes or hotel brand families out.
+
+## Related travel skills
+
+- `apify-plan-flights`: airfare only.
+- `apify-plan-hotel-stays`: lodging only.
+- `apify-scrape-hotel-prices`, `apify-google-flights-api`: the raw-data (API and dataset) versions.

--- a/skills/apify-plan-a-trip/references/actor-index.md
+++ b/skills/apify-plan-a-trip/references/actor-index.md
@@ -1,0 +1,24 @@
+# Actor index: plan a trip
+
+This skill orchestrates two Actors plus web search. Read this after `SKILL.md` to route a specific need to the right Actor.
+
+| Platform | User intent | Actor ID | Tier | Notes |
+|----------|-------------|----------|------|-------|
+| Google Flights | Price flights for each leg of the trip | `johnvc/Google-Flights-Data-Scraper-Flight-and-Price-Search` | community | One-way, round-trip, multi-city. Returns `results.best_flights`, `results.other_flights`, `price_insights`. See the `apify-plan-flights` skill for depth. |
+| Google Hotels | Price lodging at each overnight stop | `johnvc/google-hotels-search-scraper` | community | Pay per page; one page object per dataset item. Apply the availability guard and rewards brand filter. See the `apify-plan-hotel-stays` skill for depth. |
+| Web search | Verify the anchor event date and look up drive times | (built-in) | n/a | Event dates and distances are present-day facts; verify them live, do not assume. |
+
+## Chain with other travel-data Actors
+
+| User intent | Actor ID | Notes |
+|-------------|----------|-------|
+| Destination discovery before dates are fixed | `johnvc/google-travel-explore-api` | Find where to go, then anchor and plan. |
+| Restaurants and attractions at a stop | `johnvc/google-local-api` | Feed a base city or a property's coordinates into local search. |
+
+## How to extend
+
+1. Search candidates: `apify actors search "travel" --json --limit 20 2>/dev/null`
+2. Fetch a schema: `apify actors info "johnvc/google-hotels-search-scraper" --input --json 2>/dev/null`
+3. Add a row above with the user intent that should trigger it.
+
+Note: `Tier` here is `community` because these are third-party Actors published by John Cole on the Apify Store, not Apify-maintained Actors.

--- a/skills/apify-plan-a-trip/references/gotchas.md
+++ b/skills/apify-plan-a-trip/references/gotchas.md
@@ -1,0 +1,31 @@
+# Gotchas: plan a trip (both Actors)
+
+Cost, sequencing, and where to look for depth. This skill orchestrates the flights and hotels Actors, so most Actor-specific quirks live in the two sibling skills' references. This file covers what is specific to running them together.
+
+## Cost guardrails (combined)
+
+A whole trip is a handful of runs: one or two flight searches plus a lodging search per overnight stop. Each is pay per event.
+
+- Flights: about $0.02 per page plus a $0.01 setup fee per run. Leave `fetch_booking_options` off unless the traveler wants booking links, because it bills per option.
+- Hotels: about $0.018 per page plus a $0.02 setup fee per run. `max_pages: 1` per city and date is usually enough; never run `max_pages: 0` on a broad city query.
+
+A typical 4-night, one-anchor trip (one round-trip flight search, three or four lodging searches) lands well under a dollar. Estimate and confirm before enabling booking options or running many pages.
+
+## Sequencing
+
+- Verify the anchor date before anything else; a wrong date invalidates every downstream search.
+- Price flights before lodging: the arrival and departure days set the first and last lodging nights.
+- Work out the driving before pricing the anchor-night lodging: the drive decides which city to search.
+- Re-base and re-price if the availability guard trips (a small town selling out for the anchor night).
+
+## Where to look for depth
+
+- Flights inputs, `price_insights`, the parse routine, the booking-options cost: the `apify-plan-flights` skill and its `references/gotchas.md`.
+- Hotels inputs, the availability guard, the string-versus-number quirks, the Airbnb routine, the subagent parse: the `apify-plan-hotel-stays` skill and its `references/gotchas.md` and `references/airbnb-and-parsing.md`.
+- Trip judgment (anchoring, drive-time reasoning, sellouts, normalization, delivery): `references/trip-planning-lessons.md`.
+
+## Schema quirks to remember when calling both
+
+- Hotels `min_price`, `max_price`, and `guest_rating` are strings; flights `max_price` is an integer.
+- Neither schema declares required fields; requiredness is enforced in code. Flights need `departure_id`, `arrival_id`, `outbound_date` (or `multi_city_json`); a hotels query search needs `q` and `check_in_date`.
+- Flight durations are in minutes; hotel rates are per room for the party.

--- a/skills/apify-plan-a-trip/references/trip-planning-lessons.md
+++ b/skills/apify-plan-a-trip/references/trip-planning-lessons.md
@@ -1,0 +1,30 @@
+# Trip-planning lessons (the judgment worth encoding)
+
+These are the decisions that made a real event trip work (a fly-to-Denver, drive-to-New-Mexico trip anchored on a Trinity Site open house). They are the difference between a data dump and a plan. Read this when a trip involves an anchor event, driving, or multiple places to sleep.
+
+## Anchoring and verification
+
+1. Anchor on the fixed thing first. The plan hangs off the immovable date or place (the event, the wedding, the conference). Build outward from it: flights to arrive before it, lodging for the nights around it.
+2. Verify the anchor live. Event dates and venue details are present-day facts and they change. Confirm the date and location with a web search before building the plan, and tell the traveler to reconfirm before booking.
+
+## Driving and the shape of the trip
+
+3. Drive time decides lodging shape. Compute or look up the legs between the arrival airport, the anchor, and each candidate base. A long leg turns a visit into an overnight; a short one keeps it a day trip from a single base. This is the call that sets where to sleep.
+4. Base near the anchor for the anchor night when the drive is long, and near the airport for the arrival and departure nights. Splitting the trip into an airport base and an anchor base is often cheaper and less tiring than one central base with long daily drives.
+
+## Lodging judgment
+
+5. No rate means no availability, not a price of zero. Separate priced from unpriced properties when you flatten results.
+6. Small towns sell out around events. When the well-rated properties in a small town near the anchor come back without rates for the anchor night, treat it as a sellout, say so, and widen the search to a larger nearby city, then re-price.
+7. Normalize before comparing. Hotel rates are per room for the party; whole-home rental totals fold in cleaning and service fees, which make a one-night rental look expensive per night. Label the basis (per night for a room, or a full multi-night total with fees) so the comparison is fair.
+8. Rank on rating, review count, and price, not on star class. Star class is occasionally wrong; show it as a label only.
+
+## Cost and delivery
+
+9. Total the trip, not just the pieces. Sum flights for the party, lodging per night across every stop, and note rental car or fuel where it matters. Show per-person and total, because that is the number the traveler actually decides on.
+10. Deliver something shareable. A full comparison document (Markdown) and an email-ready HTML price table are what people forward and act on. Include booking links, label per-night versus total clearly, flag availability and cancellation windows, and add a "verify before booking" note. Use `scripts/render_price_table.py`.
+
+## Data handling (so the plan stays accurate and the context stays clean)
+
+11. Parse big result files in a subagent. Each search returns tens of KB of minified JSON in a tool-results file; hand the file paths to one subagent that returns compact, verified rows rather than pulling raw JSON into the main context.
+12. Compute on the numeric fields, not the display strings, and dedupe hotels on `property_token`. See the two sibling skills' references for the exact field maps and the Airbnb routine.

--- a/skills/apify-plan-a-trip/scripts/render_price_table.py
+++ b/skills/apify-plan-a-trip/scripts/render_price_table.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Render a travel price comparison as an email-ready HTML table plus Markdown.
+
+Turns normalized rows (hotels, rentals, or flights) into two deliverables:
+a standalone HTML file that renders correctly when pasted into Gmail or Outlook,
+and a Markdown version for docs and chat. The HTML styling mirrors a working
+lodging price table (navy headers, zebra striping, right-aligned numbers,
+booking links), so the output is ready to send without extra formatting.
+
+Stdlib only. No third-party dependencies.
+
+Input JSON schema (pass a file with --in, or pipe on stdin):
+
+{
+  "title": "Trip lodging options",
+  "subtitles": ["Dates: Thu Oct 15 to Mon Oct 19, 2026", "Party: 3 travelers"],
+  "note": "Rates are per night for the party unless a column says total.",
+  "sections": [
+    {
+      "heading": "Denver options (near airport)",
+      "subheading": "Thursday, Oct 15 (arrival night)",   // optional H3
+      "note": "Entire homes, priced as a 2-night total.",  // optional
+      "columns": [
+        {"key": "name",  "label": "Hotel", "link_key": "link"},
+        {"key": "class", "label": "Class", "num": true},
+        {"key": "rating","label": "Rating","num": true},
+        {"key": "price", "label": "Per night", "num": true, "price": true}
+      ],
+      "rows": [
+        {"name": "Example Inn", "link": "https://example.com", "class": "3",
+         "rating": "4.1", "price": "$124"}
+      ]
+    }
+  ],
+  "footer": "Prices pulled from Google Hotels via johnvc/google-hotels-search-scraper. Verify before booking."
+}
+
+Usage:
+  python3 render_price_table.py --in table.json --out /path/to/basename
+    writes /path/to/basename.html and /path/to/basename.md
+  python3 render_price_table.py --in table.json --format html
+    prints HTML to stdout
+"""
+
+import argparse
+import html
+import json
+import sys
+
+CSS = """  body { font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; color: #1a1a1a; background: #ffffff; margin: 0; padding: 24px; line-height: 1.45; }
+  .wrap { max-width: 820px; margin: 0 auto; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 17px; margin: 30px 0 8px; padding-bottom: 5px; border-bottom: 2px solid #33526e; color: #33526e; }
+  h3 { font-size: 14px; margin: 18px 0 6px; color: #333; }
+  p.sub { margin: 0 0 6px; color: #444; }
+  p.note { font-size: 13px; color: #555; margin: 6px 0 0; }
+  table { border-collapse: collapse; width: 100%; margin: 8px 0 4px; font-size: 14px; }
+  th, td { border: 1px solid #cccccc; padding: 7px 9px; text-align: left; vertical-align: top; }
+  th { background: #33526e; color: #ffffff; font-weight: 600; }
+  tbody tr:nth-child(even) { background: #f4f6f8; }
+  td.num, th.num { text-align: right; white-space: nowrap; }
+  .price { font-weight: 700; white-space: nowrap; }
+  a { color: #1a5fb4; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .foot { font-size: 12px; color: #666; margin-top: 24px; border-top: 1px solid #ddd; padding-top: 10px; }"""
+
+
+def _cell_text(row, col):
+    val = row.get(col["key"], "")
+    if val is None:
+        val = ""
+    return str(val)
+
+
+def render_html(data):
+    out = []
+    out.append("<!DOCTYPE html>")
+    out.append('<html lang="en">')
+    out.append("<head>")
+    out.append('<meta charset="utf-8">')
+    out.append('<meta name="viewport" content="width=device-width, initial-scale=1">')
+    out.append("<title>%s</title>" % html.escape(data.get("title", "Price table")))
+    out.append("<style>")
+    out.append(CSS)
+    out.append("</style>")
+    out.append("</head>")
+    out.append("<body>")
+    out.append('<div class="wrap">')
+    out.append("")
+    out.append("  <h1>%s</h1>" % html.escape(data.get("title", "")))
+    for sub in data.get("subtitles", []):
+        out.append('  <p class="sub">%s</p>' % html.escape(sub))
+    if data.get("note"):
+        out.append('  <p class="note">%s</p>' % html.escape(data["note"]))
+
+    for section in data.get("sections", []):
+        out.append("")
+        out.append("  <h2>%s</h2>" % html.escape(section.get("heading", "")))
+        if section.get("subheading"):
+            out.append("  <h3>%s</h3>" % html.escape(section["subheading"]))
+        cols = section.get("columns", [])
+        out.append("  <table>")
+        head = "    <thead><tr>"
+        for col in cols:
+            cls = ' class="num"' if col.get("num") else ""
+            head += "<th%s>%s</th>" % (cls, html.escape(col.get("label", "")))
+        head += "</tr></thead>"
+        out.append(head)
+        out.append("    <tbody>")
+        for row in section.get("rows", []):
+            line = "      <tr>"
+            for col in cols:
+                classes = []
+                if col.get("num"):
+                    classes.append("num")
+                if col.get("price"):
+                    classes.append("price")
+                cls = ' class="%s"' % " ".join(classes) if classes else ""
+                text = html.escape(_cell_text(row, col))
+                link_key = col.get("link_key")
+                href = row.get(link_key) if link_key else None
+                if href:
+                    cell = '<a href="%s">%s</a>' % (html.escape(str(href)), text)
+                else:
+                    cell = text
+                line += "<td%s>%s</td>" % (cls, cell)
+            line += "</tr>"
+            out.append(line)
+        out.append("    </tbody>")
+        out.append("  </table>")
+        if section.get("note"):
+            out.append('  <p class="note">%s</p>' % html.escape(section["note"]))
+
+    if data.get("footer"):
+        out.append("")
+        out.append('  <p class="foot">%s</p>' % html.escape(data["footer"]))
+    out.append("")
+    out.append("</div>")
+    out.append("</body>")
+    out.append("</html>")
+    return "\n".join(out) + "\n"
+
+
+def render_markdown(data):
+    out = []
+    out.append("# %s" % data.get("title", ""))
+    out.append("")
+    for sub in data.get("subtitles", []):
+        out.append("**%s**  " % sub)
+    if data.get("note"):
+        out.append("")
+        out.append("_%s_" % data["note"])
+    for section in data.get("sections", []):
+        out.append("")
+        out.append("## %s" % section.get("heading", ""))
+        if section.get("subheading"):
+            out.append("")
+            out.append("### %s" % section["subheading"])
+        cols = section.get("columns", [])
+        out.append("")
+        out.append("| " + " | ".join(c.get("label", "") for c in cols) + " |")
+        out.append("| " + " | ".join("---:" if c.get("num") else "---" for c in cols) + " |")
+        for row in section.get("rows", []):
+            cells = []
+            for col in cols:
+                text = _cell_text(row, col).replace("|", "\\|")
+                link_key = col.get("link_key")
+                href = row.get(link_key) if link_key else None
+                if href:
+                    cells.append("[%s](%s)" % (text, href))
+                else:
+                    cells.append(text)
+            out.append("| " + " | ".join(cells) + " |")
+        if section.get("note"):
+            out.append("")
+            out.append("_%s_" % section["note"])
+    if data.get("footer"):
+        out.append("")
+        out.append("---")
+        out.append("")
+        out.append(data["footer"])
+    return "\n".join(out) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render a travel price table to HTML and Markdown.")
+    ap.add_argument("--in", dest="infile", help="Input JSON file (default: stdin)")
+    ap.add_argument("--out", dest="out", help="Output basename; writes .html and .md")
+    ap.add_argument("--format", choices=["html", "md", "both"], default="both",
+                    help="What to emit to stdout when --out is not given (default both)")
+    args = ap.parse_args()
+
+    raw = open(args.infile).read() if args.infile else sys.stdin.read()
+    data = json.loads(raw)
+
+    html_doc = render_html(data)
+    md_doc = render_markdown(data)
+
+    if args.out:
+        with open(args.out + ".html", "w") as f:
+            f.write(html_doc)
+        with open(args.out + ".md", "w") as f:
+            f.write(md_doc)
+        print("Wrote %s.html and %s.md" % (args.out, args.out))
+    else:
+        if args.format in ("html", "both"):
+            sys.stdout.write(html_doc)
+        if args.format == "both":
+            sys.stdout.write("\n")
+        if args.format in ("md", "both"):
+            sys.stdout.write(md_doc)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/apify-plan-a-trip/scripts/rewards.py
+++ b/skills/apify-plan-a-trip/scripts/rewards.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Map a loyalty or rewards program to concrete search filters.
+
+Neither the Google Hotels nor the Google Flights Actor filters by loyalty
+program directly, so this helper turns a program name into filters the Actors
+DO understand:
+
+  Flights: a list of airline codes for the program's own airline plus its
+           alliance partners, ready for the Actor's `airlines` input (CSV).
+  Hotels:  a list of brand-name substrings for the program's chain family,
+           used to keep or flag matching rows from a normal search (the Actor
+           has no loyalty filter, so match on each property's `name`).
+
+Honest limit: these Actors read public cash prices, not your loyalty account.
+They surface which chain or alliance properties exist at what cash rate; they
+do not show points or award pricing. Book award stays through your own program.
+
+Usage:
+  python3 rewards.py "Marriott Bonvoy"        # -> JSON with hotel brands
+  python3 rewards.py "United MileagePlus"      # -> JSON with airline codes
+  python3 rewards.py --list                    # list known programs
+"""
+
+import json
+import sys
+
+# Airline alliance member codes (IATA). Not exhaustive; the common carriers.
+STAR_ALLIANCE = ["UA", "AC", "LH", "NH", "SQ", "TK", "LX", "OS", "SN", "TP",
+                 "SK", "OZ", "TG", "CA", "ZH", "SA", "ET", "AV", "CM", "NZ",
+                 "MS", "BR", "AI", "LO", "A3", "JP"]
+ONEWORLD = ["AA", "BA", "QF", "CX", "JL", "IB", "AY", "QR", "MH", "RJ",
+            "UL", "AT", "AS", "WY", "S7", "FJ"]
+SKYTEAM = ["DL", "AF", "KL", "KE", "AZ", "SU", "MU", "CZ", "CI", "GA",
+           "SV", "ME", "KQ", "AR", "AM", "RO", "VN", "OK", "UX", "VS"]
+
+# Program -> filter definition. `aliases` are lowercase substrings for matching.
+PROGRAMS = {
+    # Airline programs (kind: air)
+    "United MileagePlus": {"kind": "air", "airlines": STAR_ALLIANCE,
+                           "aliases": ["united", "mileageplus", "mileage plus"]},
+    "Air Canada Aeroplan": {"kind": "air", "airlines": STAR_ALLIANCE,
+                            "aliases": ["aeroplan", "air canada"]},
+    "Lufthansa Miles & More": {"kind": "air", "airlines": STAR_ALLIANCE,
+                               "aliases": ["miles & more", "miles and more", "lufthansa"]},
+    "American AAdvantage": {"kind": "air", "airlines": ONEWORLD,
+                            "aliases": ["american", "aadvantage", "aa "]},
+    "British Airways Executive Club": {"kind": "air", "airlines": ONEWORLD,
+                                       "aliases": ["british airways", "executive club", "avios"]},
+    "Alaska Mileage Plan": {"kind": "air", "airlines": ONEWORLD,
+                            "aliases": ["alaska", "mileage plan"]},
+    "Delta SkyMiles": {"kind": "air", "airlines": SKYTEAM,
+                       "aliases": ["delta", "skymiles"]},
+    "Air France-KLM Flying Blue": {"kind": "air", "airlines": SKYTEAM,
+                                   "aliases": ["flying blue", "air france", "klm"]},
+    "Southwest Rapid Rewards": {"kind": "air", "airlines": ["WN"],
+                                "aliases": ["southwest", "rapid rewards"]},
+    "JetBlue TrueBlue": {"kind": "air", "airlines": ["B6"],
+                         "aliases": ["jetblue", "trueblue"]},
+
+    # Hotel programs (kind: hotel). Brand substrings match against property name.
+    "Marriott Bonvoy": {"kind": "hotel", "aliases": ["marriott", "bonvoy"],
+                        "hotel_brands": ["Marriott", "Courtyard", "Fairfield", "SpringHill",
+                                         "Residence Inn", "TownePlace", "Ritz-Carlton", "Westin",
+                                         "Sheraton", "W Hotels", "Aloft", "Element", "Four Points",
+                                         "Le Meridien", "St. Regis", "Autograph", "Moxy", "AC Hotels",
+                                         "Delta Hotels", "Gaylord", "Renaissance", "Tribute",
+                                         "JW Marriott"]},
+    "Hilton Honors": {"kind": "hotel", "aliases": ["hilton", "honors"],
+                      "hotel_brands": ["Hilton", "Hampton", "Home2", "Homewood", "Garden Inn",
+                                       "Embassy Suites", "DoubleTree", "Waldorf Astoria", "Conrad",
+                                       "Canopy", "Curio", "Tapestry", "Tru", "Motto", "LXR",
+                                       "Signia", "Tempo", "Spark"]},
+    "IHG One Rewards": {"kind": "hotel", "aliases": ["ihg", "one rewards"],
+                        "hotel_brands": ["Holiday Inn", "avid", "Garner", "Candlewood", "Staybridge",
+                                         "Crowne Plaza", "InterContinental", "Kimpton", "Hotel Indigo",
+                                         "EVEN", "Regent", "Six Senses", "voco", "Atwell", "Iberostar"]},
+    "World of Hyatt": {"kind": "hotel", "aliases": ["hyatt"],
+                       "hotel_brands": ["Hyatt", "Andaz", "Thompson", "Caption", "Alila", "Miraval",
+                                        "Grand Hyatt", "Park Hyatt", "Hyatt Regency", "Hyatt Place",
+                                        "Hyatt House", "Destination", "Dream", "The Unbound"]},
+    "Wyndham Rewards": {"kind": "hotel", "aliases": ["wyndham"],
+                        "hotel_brands": ["Wyndham", "Days Inn", "Super 8", "La Quinta", "Baymont",
+                                         "Ramada", "Howard Johnson", "Microtel", "Travelodge",
+                                         "Wingate", "AmericInn", "Dolce", "Dazzler", "Esplendor"]},
+    "Choice Privileges": {"kind": "hotel", "aliases": ["choice", "privileges"],
+                          "hotel_brands": ["Comfort", "Quality Inn", "Sleep Inn", "Clarion", "Cambria",
+                                           "Ascend", "Econo Lodge", "Rodeway", "MainStay", "WoodSpring",
+                                           "Suburban", "Everhome"]},
+    "Best Western Rewards": {"kind": "hotel", "aliases": ["best western"],
+                             "hotel_brands": ["Best Western", "SureStay", "Aiden", "Sadie", "Glo",
+                                              "Vib", "Executive Residency"]},
+    "Accor Live Limitless": {"kind": "hotel", "aliases": ["accor", "all ", "live limitless"],
+                             "hotel_brands": ["Sofitel", "Novotel", "Mercure", "ibis", "Pullman",
+                                              "Fairmont", "Raffles", "Swissotel", "Movenpick",
+                                              "MGallery", "Grand Mercure", "Adagio"]},
+}
+
+
+def lookup(name):
+    """Return the program definition best matching a free-text name, or None."""
+    if not name:
+        return None
+    q = name.strip().lower()
+    # Exact key match first.
+    for key, val in PROGRAMS.items():
+        if key.lower() == q:
+            return dict(val, program=key)
+    # Alias substring match.
+    for key, val in PROGRAMS.items():
+        for alias in val.get("aliases", []):
+            if alias in q:
+                return dict(val, program=key)
+    return None
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__)
+        return
+    if args[0] == "--list":
+        for key, val in sorted(PROGRAMS.items()):
+            print("%-32s %s" % (key, val["kind"]))
+        return
+    name = " ".join(args)
+    result = lookup(name)
+    if result is None:
+        print(json.dumps({"query": name, "match": None,
+                          "note": "No known program matched. Run with --list to see known programs, "
+                                  "or brand-bias the search query by hand."}, indent=2))
+        return
+    print(json.dumps({"query": name, **result}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## apify-plan-a-trip

A consumer trip-planning agent skill built on the Apify Google Flights and Google Hotels Actors. One skill per PR: touches only `skills/apify-plan-a-trip/`. Telemetry flags present on every apify CLI call; validated locally with lint_telemetry.sh and generate_agents.py. Catalog files (marketplace.json, AGENTS.md, README) left for post-merge regeneration.

Canonical repo: https://github.com/johnisanerd/claude-skill-plan-a-trip